### PR TITLE
fix(lua): wrap user-code unit load in pcall to survive bad modules

### DIFF
--- a/assets/lua/main.fnl
+++ b/assets/lua/main.fnl
@@ -1338,7 +1338,10 @@
                              :module-paths unit-module-paths
                              :owned-paths candidate.owned-paths}))
         (app.unit-manager:register unit)
-        (unit:load))))
+        (local (load-ok load-err) (pcall #(unit:load)))
+        (when (not load-ok)
+          (app.unit-manager:unregister unit.id)
+          (print (.. "Failed to load user-code unit \"" candidate.name "\": " (tostring load-err)))))))
   true)
 
 (local installable-reset-projection app.reset-projection)

--- a/assets/lua/tests/test-unit-manager.fnl
+++ b/assets/lua/tests/test-unit-manager.fnl
@@ -434,6 +434,42 @@
 (table.insert tests {:name "scanner prefers directory init when flat collides"
                      :fn scanner-prefers-directory-init-when-flat-collides})
 
+(fn ensure-user-code-units-survives-bad-module []
+  (with-temp-dir
+    (fn [dir]
+      (local old-fennel-path (. (require :fennel) :path))
+      (fs.write-file (fs.join-path dir "bad-unit.fnl")
+                     (.. "(fn init [] (require :nonexistent-module) true)\n"
+                         "(fn drop [] true)\n"
+                         "{:init init :drop drop}"))
+      (fs.write-file (fs.join-path dir "good-unit.fnl")
+                     (.. "(fn init [] (set app.__good-loaded true) true)\n"
+                         "(fn drop [] (set app.__good-loaded false) true)\n"
+                         "{:init init :drop drop}"))
+      (set app.__good-loaded nil)
+      (local (ok err)
+        (pcall
+          (fn []
+            (set app.unit-manager (or app.unit-manager (UnitManager {})))
+            (local original-code-dir app.code-dir)
+            (set app.code-dir dir)
+            (Main.ensure-user-code-units!)
+            (set app.code-dir original-code-dir)
+            (assert app.__good-loaded "good unit should be loaded even when bad unit fails")
+            (assert (= (app.unit-manager:count) 1)
+                    "only good unit should be registered, bad one unregistered")
+            (app.unit-manager:clear)
+            (assert (not app.__good-loaded) "good unit should be unloaded on clear")
+            (assert (= (app.unit-manager:count) 0) "manager should be empty after clear")
+            (app.unit-manager:clear))))
+      (tset (require :fennel) :path old-fennel-path)
+      (set app.__good-loaded nil)
+      (when (not ok)
+        (error err)))))
+
+(table.insert tests {:name "ensure-user-code-units survives bad module"
+                     :fn ensure-user-code-units-survives-bad-module})
+
 (local main
   (fn []
     (local runner (require :tests/runner))


### PR DESCRIPTION
## Problem

Stale user-code units in `~/.local/share/space/code/` that reference deleted modules crash the entire app at startup. This happened after the canvas-modes \u2192 activities migration (commit 6f2b87d6) deleted `canvas-modes.fnl`, but AI-created user units (bob.fnl, bubbles/init.fnl) still require it.

A single bad user unit should not brick the app.

## Fix

`ensure-user-code-units!` in `assets/lua/main.fnl` now wraps `unit:load` in `pcall`:
- On failure: unregisters the unit, prints the error, continues with remaining units
- On success: unit stays registered and loaded

Added test in `test-unit-manager.fnl` with a bad unit (requires nonexistent module) + a good unit, verifying the good unit loads and only it remains registered.

## Testing

- 12/12 CTest pass
- App starts cleanly with stale user-code units present (no crash)