### PR TITLE
Fix graph map sidebar actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ Clean design is important, refactor when reasonable.
 
 The default base branch for pull requests and merges is `main`.
 
+After implementation is complete — reviewed, committed, tests passing, tree
+clean — the default integration action is to push the current branch and create a
+pull request targeting `main`. Do this automatically; do not present an
+integration menu or ask the user which action to take. Only deviate when the user
+explicitly requests a different integration action or when the branch state is
+unsafe (uncommitted changes, failing tests, unresolved merge conflicts with
+`main`).
+
 ## Project Structure & Modules
 - `src/` holds the C++17 engine modules (rendering, physics, audio, bindings). Add new systems as matching `.cpp`/`.h` pairs. Engine Lua bindings live in `src/lua_engine.cpp`.
 - `apps/space/main.cpp` is the executable entry point; bootstrap other front ends here.

--- a/assets/lua/graph/map-manager.fnl
+++ b/assets/lua/graph/map-manager.fnl
@@ -554,13 +554,13 @@
         (when (. entries id)
             (error (.. "GraphMapManager.create-map! duplicate id: " id)))
          (set (. entries id) {:id id
-                              :name resolved-name
-                              :nodes []
-                              :edges []
-                              :selected_node_keys []
-                              :focused_node_key nil
-                              :restored-from-state? true
-                              :map nil})
+                               :name resolved-name
+                               :nodes []
+                               :edges []
+                               :selected_node_keys []
+                               :focused_node_key nil
+                               :restored-from-state? false
+                               :map nil})
         (set next-id (+ next-id 1))
         (set self.next-map-id next-id)
         (maps-changed:emit {:created-id id :active-id active-id})

--- a/assets/lua/graph/map-sidebar.fnl
+++ b/assets/lua/graph/map-sidebar.fnl
@@ -167,7 +167,7 @@
                                                     :children
                                                     [(FlexChild (build-action-button "New"
                                                                                       (fn [_ _]
-                                                                                          (local sid (.. "map-" (tostring (manager.next-map-id))))
+                                                                                           (local sid (.. "map-" (tostring manager.next-map-id)))
                                                                                           (manager:create-map! sid sid)
                                                                                           (manager:switch-map! sid))
                                                                                       true)
@@ -193,17 +193,20 @@
                                             ic2))})
                      ic)))
 
-            (local children
-                [(fn [ic] ((Rectangle {:color (panel-bg)}) ic))
-                 (build-title)
-                 (build-switch-title)])
+            (local content-children
+                [(FlexChild (build-title) 0)
+                 (FlexChild (build-actions) 0)
+                 (FlexChild (build-switch-title) 0)])
             (each [_ entry (ipairs maps)]
-                (table.insert children (build-map-row entry)))
-            (table.insert children (build-selected-count))
-            (table.insert children (build-separator))
-            (table.insert children (build-actions))
+                (table.insert content-children (FlexChild (build-map-row entry) 0)))
+            (table.insert content-children (FlexChild (build-separator) 0))
+            (table.insert content-children (FlexChild (build-selected-count) 0))
             (root-layout:clear-children)
-            (set content-entity ((Stack {:children children}) ctx))
+            (set content-entity
+                 ((Stack {:children
+                          [(fn [ic] ((Rectangle {:color (panel-bg)}) ic))
+                           (fn [ic] ((Flex {:axis 2 :spacing 0.0 :children content-children}) ic))]})
+                  ctx))
             (when content-entity
                 (root-layout:add-child content-entity.layout)))
 

--- a/assets/lua/tests/test-graph-map-manager.fnl
+++ b/assets/lua/tests/test-graph-map-manager.fnl
@@ -1158,6 +1158,24 @@
 (table.insert tests {:name "GraphMapManager selection survives switch" :fn manager-selection-survives-switch})
 (table.insert tests {:name "GraphMapManager selection survives capture roundtrip" :fn manager-selection-survives-capture-roundtrip})
 
+(fn manager-newly-created-map-seeds-start-after-switch []
+    (local graph (Graph {:with-start false}))
+    (graph:register-key-loader "start"
+        (fn [_key]
+            (Graph.GraphNode {:key "start"})))
+    (local manager (GraphMapManager.GraphMapManager {:graph graph}))
+    ;; Create a second map and switch to it
+    (manager:create-map! "second" "Second")
+    (manager:switch-map! "second")
+    (local active (manager:get-active-map))
+    (assert (>= (active:node-count) 1)
+            "Newly created map should seed start node after switch")
+    (manager:switch-map! "main")
+    (manager:drop)
+    (graph:drop))
+
+(table.insert tests {:name "GraphMapManager newly created map seeds start after switch" :fn manager-newly-created-map-seeds-start-after-switch})
+
 (fn manager-switch-emits-will-change-before-drop []
     (local graph (Graph {:with-start false}))
     (graph:register-key-loader "test"

--- a/assets/lua/tests/test-graph-map-sidebar.fnl
+++ b/assets/lua/tests/test-graph-map-sidebar.fnl
@@ -1,3 +1,4 @@
+(local glm (require :glm))
 (local Graph (require :graph/init))
 (local GraphMapManager (require :graph/map-manager))
 (local GraphMapSidebar (require :graph/map-sidebar))
@@ -186,7 +187,7 @@
             (Graph.GraphNode {:key key})))
     (local manager (GraphMapManager.GraphMapManager {:graph graph}))
     (local ctx (BuildContext {:clickables (assert app.clickables "test requires app.clickables")
-                              :hoverables (make-hoverables-stub)}))
+                               :hoverables (make-hoverables-stub)}))
     (local builder (GraphMapSidebar.GraphMapSidebar {:manager manager}))
     (local entity (builder ctx))
     (local active (manager:get-active-map))
@@ -208,6 +209,73 @@
     (manager:drop)
     (graph:drop))
 
+(local text-utils (require :text-utils))
+
+(fn button-label [btn]
+    ;; Convert codepoints back to a string for comparison
+    (when (and btn.text btn.text.get-codepoints)
+        (local cps (btn.text:get-codepoints))
+        (var s "")
+        (each [_ cp (ipairs cps)]
+            (set s (.. s (string.char cp))))
+        s))
+
+(fn find-clickable-by-label [target-text]
+    (var found nil)
+    (each [_ obj (ipairs app.clickables.left-click-objects)]
+        (when (and (not found) obj.on-click)
+            (local label (button-label obj))
+            (when (= label target-text)
+                (set found obj))))
+    found)
+
+(fn sidebar-new-button-creates-map-without-crashing []
+    (local graph (Graph {:with-start false}))
+    (local manager (GraphMapManager.GraphMapManager {:graph graph}))
+    (local ctx (BuildContext {:clickables (assert app.clickables "test requires app.clickables")
+                               :hoverables (make-hoverables-stub)}))
+    (local builder (GraphMapSidebar.GraphMapSidebar {:manager manager}))
+    (local entity (builder ctx))
+    (entity:update)
+    (local new-button (find-clickable-by-label "New"))
+    (assert new-button "Sidebar should render a New button")
+    (local initial-map-count (length (manager:list-maps)))
+    (local (ok err) (pcall (fn [] (new-button:on-click {}))))
+    (assert ok (.. "New button click should not crash: " (tostring err)))
+    (entity:drop)
+    (manager:drop)
+    (graph:drop))
+
+(fn sidebar-map-rows-do-not-stretch-to-full-panel-height []
+    (local graph (Graph {:with-start false}))
+    (local manager (GraphMapManager.GraphMapManager {:graph graph}))
+    (local ctx (BuildContext {:clickables (assert app.clickables "test requires app.clickables")
+                               :hoverables (make-hoverables-stub)}))
+    (local builder (GraphMapSidebar.GraphMapSidebar {:manager manager}))
+    (local entity (builder ctx))
+    (entity:update)
+    (local panel-height 10.0)
+    (set entity.layout.size (glm.vec3 3 panel-height 0))
+    (entity.layout:measurer)
+    (entity.layout:layouter)
+    ;; After layout, root-layout.children[1] is the Stack layout.
+    ;; Stack layout.children[1] = background, [2] = content Flex.
+    (local root-children entity.layout.children)
+    (assert (= (length root-children) 1) "Root layout should have 1 child: the Stack")
+    (local stack-layout (. root-children 1))
+    (local stack-children stack-layout.children)
+    (assert (= (length stack-children) 2) "Stack should have 2 children: background + content Flex")
+    (local flex-layout (. stack-children 2))
+    (local flex-children flex-layout.children)
+    ;; flex-children[1]=title, [2]=actions, [3]=switch-title, [4]=map row, [5]=separator, [6]=selected-count
+    (assert (>= (length flex-children) 4) "Flex should have at least 4 content rows with 1 map")
+    (local map-row-layout (. flex-children 4))
+    (assert (< map-row-layout.size.y panel-height)
+            "Map row should not stretch to full panel height")
+    (entity:drop)
+    (manager:drop)
+    (graph:drop))
+
 (table.insert tests {:name "GraphMapManager active-map-id updates after switch" :fn manager-active-map-id-updates-after-switch})
 (table.insert tests {:name "GraphMapManager rename updates active-map-name" :fn manager-rename-updates-active-map-name})
 (table.insert tests {:name "GraphMapManager active-map-status returns correct values" :fn manager-active-map-status-returns-correct-values})
@@ -221,6 +289,8 @@
 (table.insert tests {:name "GraphMap sidebar rebuilds on maps-changed" :fn sidebar-rebuilds-on-maps-changed})
 (table.insert tests {:name "GraphMap sidebar labels map actions and selected count" :fn sidebar-exposes-map-labels-and-selected-count})
 (table.insert tests {:name "GraphMap sidebar refreshes active map counts after map mutations" :fn sidebar-refreshes-active-map_counts_after_map_mutations})
+(table.insert tests {:name "GraphMap sidebar New button creates map without crashing" :fn sidebar-new-button-creates-map-without-crashing})
+(table.insert tests {:name "GraphMap sidebar map rows do not stretch to full panel height" :fn sidebar-map-rows-do-not-stretch-to-full-panel-height})
 
 (local main
     (fn []


### PR DESCRIPTION
## Summary
- Move graph map sidebar actions to the top and keep map rows natural-height.
- Fix the New graph map crash caused by calling next-map-id as a function.
- Seed the start node when switching to newly created graph maps.
- Document the repo default to open PRs to main after reviewed, committed, tested, clean work.

## Testing
- SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets make test — passed