### PR TITLE
fix(lifecycle): release active input before state teardown

### DIFF
--- a/assets/lua/main.fnl
+++ b/assets/lua/main.fnl
@@ -2017,6 +2017,7 @@
 (fn app.drop []
   (set (. package.loaded "renderers") nil)
   (drop-agent-runtime!)
+  (InputState.release-active-input)
   (AppBootstrap.drop-states)
   (when (and app.update-handler app.engine.events app.engine.events.updated)
     (app.engine.events.updated:disconnect app.update-handler true)

--- a/assets/lua/tests/test-main-events.fnl
+++ b/assets/lua/tests/test-main-events.fnl
@@ -1196,6 +1196,16 @@
   ;; whose drop/disconnect calls require the states host, which is already nil.
   (reset-state)
   (ensure-renderers)
+  ;; Save global app systems that Main.drop destroys, so subsequent test
+  ;; modules are not affected by the teardown in this test.
+  (local saved-intersectables app.intersectables)
+  (local saved-clickables app.clickables)
+  (local saved-hoverables app.hoverables)
+  (local saved-movables app.movables)
+  (local saved-resizables app.resizables)
+  (local saved-system-cursors app.system-cursors)
+  (local saved-renderers app.renderers)
+  (local saved-states app.states)
   (var last-state nil)
   (local states-host
     {:active-name (fn [_self] "normal")
@@ -1224,8 +1234,24 @@
   (Main.drop)
   (assert disconnected? "Input should have been disconnected during drop")
   (assert (not (InputState.active-input)) "No input should be active after drop")
+  ;; Restore global app systems destroyed by Main.drop so subsequent
+  ;; modules (test-states, etc.) are not affected.
+  (when (not app.intersectables)
+    (set app.intersectables saved-intersectables))
+  (when (not app.clickables)
+    (set app.clickables saved-clickables))
+  (when (not app.hoverables)
+    (set app.hoverables saved-hoverables))
+  (when (not app.movables)
+    (set app.movables saved-movables))
+  (when (not app.resizables)
+    (set app.resizables saved-resizables))
+  (when (not app.system-cursors)
+    (set app.system-cursors saved-system-cursors))
+  (set app.renderers saved-renderers)
+  (set app.states saved-states)
   (InputState.reset)
-  (StateSystemBindings.bind-states-host nil))
+  (StateSystemBindings.bind-states-host saved-states))
 (table.insert tests {:name "app.drop releases active input before state teardown" :fn app-drop-releases-active-input-before-state-teardown})
 
 (local main

--- a/assets/lua/tests/test-main-events.fnl
+++ b/assets/lua/tests/test-main-events.fnl
@@ -6,6 +6,10 @@
 (local Hoverables (require :hoverables))
 (local AppViewport (require :app-viewport))
 (local AppProjection (require :app-projection))
+(local InputState (require :input-state-router))
+(local StateSystemBindings (require :state-system-bindings))
+(local Units (require :units))
+(local UnitManager (require :unit-manager))
 (local reset-engine-events
   (fn []
     (when _G.reset-engine-events
@@ -1184,7 +1188,45 @@
 (table.insert tests {:name "bind-active-world-runtime emits shell once for surface sync"
                      :fn bind-active-world-runtime-emits-shell-once-for-surface-sync})
 (table.insert tests {:name "bind-active-world-runtime respects shell suppression"
-                     :fn bind-active-world-runtime-respects-shell-suppression})
+                      :fn bind-active-world-runtime-respects-shell-suppression})
+
+(fn app-drop-releases-active-input-before-state-teardown []
+  ;; Regression test: app.drop must release active input before unbinding the
+  ;; states host.  Without this ordering, unit-manager:clear unloads units
+  ;; whose drop/disconnect calls require the states host, which is already nil.
+  (reset-state)
+  (ensure-renderers)
+  (var last-state nil)
+  (local states-host
+    {:active-name (fn [_self] "normal")
+     :set-state (fn [_self name] (set last-state name))
+     :drop (fn [_self] nil)})
+  (StateSystemBindings.bind-states-host states-host)
+  (set app.states states-host)
+  (var disconnected? false)
+  (local input
+    {:on-state-connected (fn [_self _payload] true)
+     :on-state-disconnected (fn [_self _payload] (set disconnected? true))
+     :on-key-down (fn [_self _payload] false)})
+  (InputState.connect-input input)
+  (assert (= (InputState.active-input) input)
+          "Input should be active before drop")
+  (local unit (Units.Unit
+                {:id "test-drop-unit"
+                 :load (fn [_ctx] nil)
+                 :unload (fn [_ctx]
+                           (InputState.disconnect-input input))}))
+  (set app.unit-manager (or app.unit-manager (UnitManager)))
+  (app.unit-manager:register unit)
+  (unit:load {})
+  (assert (= (InputState.active-input) input)
+          "Input must remain active after unit load")
+  (Main.drop)
+  (assert disconnected? "Input should have been disconnected during drop")
+  (assert (not (InputState.active-input)) "No input should be active after drop")
+  (InputState.reset)
+  (StateSystemBindings.bind-states-host nil))
+(table.insert tests {:name "app.drop releases active input before state teardown" :fn app-drop-releases-active-input-before-state-teardown})
 
 (local main
   (fn []


### PR DESCRIPTION
## Summary\n- release active input at the start of app.drop before unbinding the states host\n- add regression coverage for unit teardown disconnecting an active input after state teardown\n- restore app globals in the regression test to keep the fast suite isolated\n\n## Validation\n- SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="/home/ubuntu/space/monkfish/assets" FENNEL_PATH="/home/ubuntu/space/monkfish/assets/lua/?.fnl;/home/ubuntu/space/monkfish/assets/lua/?/init.fnl" FENNEL_MACRO_PATH="/home/ubuntu/space/monkfish/assets/lua/?.fnl;/home/ubuntu/space/monkfish/assets/lua/?/init.fnl" ./build/space -m tests.test-main-events:main\n- SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="/home/ubuntu/space/monkfish/assets" make test