### PR TITLE
feat(lua): add external unit MCP surface

### DIFF
--- a/assets/lua/llm/external-unit-mcp/bridge.fnl
+++ b/assets/lua/llm/external-unit-mcp/bridge.fnl
@@ -1,0 +1,120 @@
+;; External Unit MCP bridge — owns the loopback MCP HTTP server and isolated
+;; OpenCode config for external unit development sessions.  This is a separate
+;; bridge from `llm/agent/opencode-mcp-bridge.fnl` and must not import or
+;; mutate the internal agent bridge.
+
+(local fs (require :fs))
+(local JsonUtils (require :json-utils))
+
+(fn ensure-dir! [path]
+  (when (not (fs.exists path))
+    (fs.create-dirs path)))
+
+(fn remote-url [host port]
+  (.. "http://" host ":" (tostring port) "/mcp"))
+
+(fn config-path [config-root]
+  (fs.join-path (fs.join-path config-root "opencode") "opencode.json"))
+
+(local native-tool-permissions
+  {:invalid "deny"
+   :read "deny"
+   :write "deny"
+   :edit "deny"
+   :grep "deny"
+   :glob "deny"
+   :list "deny"
+   :bash "deny"
+   :task "deny"
+   :external_directory "deny"
+   :todowrite "deny"
+   :webfetch "deny"
+   :websearch "deny"
+   :lsp "deny"
+   :skill "deny"
+   :question "deny"})
+
+(fn write-opencode-config! [config-root url]
+  (local opencode-dir (fs.join-path config-root "opencode"))
+  (ensure-dir! opencode-dir)
+  (JsonUtils.write-json!
+    (config-path config-root)
+    {:permission native-tool-permissions
+     :mcp {:space-unit-dev {:type "remote"
+                            :url url
+                            :enabled true}}}))
+
+(fn ExternalUnitMcpBridge [opts]
+  (local tools (or opts.tools (error "ExternalUnitMcpBridge requires :tools")))
+  (local data-dir (or opts.data-dir (error "ExternalUnitMcpBridge requires :data-dir")))
+  (local host (or opts.host "127.0.0.1"))
+  (local http-server-factory (or opts.http-server-factory
+                                 (fn []
+                                   (local http-server-mod (require :http_server))
+                                   (http-server-mod.HttpServer))))
+  (local mcp-server-factory (or opts.mcp-server-factory
+                                (fn [http-server]
+                                  (local MCPHTTPServer (require :mcp/server-http))
+                                  (MCPHTTPServer {:http-server http-server
+                                                  :tools tools
+                                                  :force-sse true}))))
+
+  (var server nil)
+  (var config-root nil)
+  (var port nil)
+  (var url nil)
+  (var started? false)
+
+  (fn start [self]
+    (when started?
+      (error "ExternalUnitMcpBridge already started"))
+    (ensure-dir! data-dir)
+    (set config-root (fs.join-path data-dir "external-unit-opencode-config"))
+    (ensure-dir! config-root)
+    (set server (mcp-server-factory (http-server-factory)))
+    (local (ok result) (pcall (fn []
+                                (set port (server:start host 0))
+                                (when (not (> port 0))
+                                  (error (.. "ExternalUnitMcpBridge got invalid MCP port: "
+                                             (tostring port))))
+                                (set url (remote-url host port))
+                                (write-opencode-config! config-root url))))
+    (when (not ok)
+      (when server
+        (pcall (fn [] (server:stop))))
+      (set server nil)
+      (set port nil)
+      (set url nil)
+      (set config-root nil)
+      (error result))
+    (set started? true)
+    self)
+
+  (fn stop [self]
+    (when server
+      (server:stop))
+    (set server nil)
+    (set port nil)
+    (set url nil)
+    (set started? false)
+    self)
+
+  (fn opencode-env [self]
+    (when (not started?)
+      (error "ExternalUnitMcpBridge must be started before building OpenCode env"))
+    {:XDG_CONFIG_HOME config-root})
+
+  (fn status [self]
+    {:started? started?
+     :host host
+     :port port
+     :url url
+     :config-root config-root
+     :config-path (and config-root (config-path config-root))})
+
+  {:start start
+   :stop stop
+   :opencode-env opencode-env
+   :status status})
+
+{:ExternalUnitMcpBridge ExternalUnitMcpBridge}

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -1,6 +1,5 @@
-;; External Unit MCP Service — loader-neutral unit discovery, handles, inspect, and resolve.
-;; This is a read-only facade over the UnitManager that presents units in a loader-neutral
-;; interface. It does not mutate units or expose raw filesystem paths directly.
+;; External Unit MCP Service — loader-neutral unit discovery, handles, inspect, resolve,
+;; source read, patch, create, and reload operations.
 
 (local fs (require :fs))
 (local Sha256 (require :repo/sha256))
@@ -77,6 +76,86 @@
 
 (fn build-commit-capability [_loader]
   "none")
+
+;; ── Task 2: Source resolution and mutation helpers ──
+
+(fn hash-file [path]
+  (.. "sha256:" (Sha256.hash-file path)))
+
+(fn validate-source-id [source-id operation]
+  (assert (= (type source-id) "string")
+          (.. operation " requires a string :source_id"))
+  (assert (> (# source-id) 0)
+          (.. operation " :source_id must not be empty"))
+  (assert (not (string.find source-id "\0" 1 true))
+          (.. operation " :source_id contains a NUL byte"))
+  (assert (not (or (string.match source-id "^/")
+                   (string.match source-id "^%a:[\\/]")))
+          (.. operation " :source_id must be relative, not absolute"))
+  (assert (not (or (string.match source-id "%f[^/]%.%./")
+                   (string.match source-id "%.%.$")
+                   (= source-id "..")))
+          (.. operation " :source_id must not contain .. segments")))
+
+(fn get-unit-root-dir [unit]
+  ;; Find the unit root directory from owned-paths (first directory entry).
+  (local paths (or unit.owned-paths []))
+  (var root nil)
+  (each [_ path (ipairs paths) &until root]
+    (when (and path (fs.exists path))
+      (local st (fs.stat path))
+      (when (and st st.is-dir)
+        (set root path))))
+  root)
+
+(fn is-directory-unit? [unit]
+  (not= (get-unit-root-dir unit) nil))
+
+(fn get-primary-source-path [unit]
+  ;; Find the first .fnl file in owned-paths.
+  (local paths (or unit.owned-paths []))
+  (var primary nil)
+  (each [_ path (ipairs paths) &until primary]
+    (when (and path (path-has-fnl-extension? path))
+      (set primary path)))
+  primary)
+
+(fn get-primary-source-basename [unit]
+  (local primary-path (get-primary-source-path unit))
+  (when primary-path
+    (path-basename primary-path)))
+
+(fn assert-filesystem-unit [unit operation]
+  (assert (not (= unit.source :builtin))
+          (.. operation ": cannot modify built-in unit " unit.id))
+  (assert (= (classify-loader unit) "filesystem")
+          (.. operation ": unit " unit.id " loader does not support write operations")))
+
+(fn assert-directory-unit [unit operation]
+  (assert-filesystem-unit unit operation)
+  (assert (is-directory-unit? unit)
+          (.. operation ": unit " unit.id " is a flat unit and cannot create new source artifacts")))
+
+(fn resolve-source-path [unit source-id operation]
+  ;; Resolve a source_id to an absolute file path for a filesystem unit.
+  ;; Rejects invalid source_ids and validates against unit structure.
+  (validate-source-id source-id operation)
+  (if (is-directory-unit? unit)
+      (let [root (get-unit-root-dir unit)]
+        (fs.join-path root source-id))
+      (let [primary-basename (get-primary-source-basename unit)]
+        (assert primary-basename
+                (.. operation ": unit " unit.id " has no primary source file"))
+        (assert (= source-id primary-basename)
+                (.. operation ": flat unit " unit.id " only accepts source_id " primary-basename))
+        (get-primary-source-path unit))))
+
+(fn validate-fnl-source [path source]
+  (when (path-has-fnl-extension? path)
+    (local fennel (require :fennel))
+    (local (compile-ok compile-err) (pcall fennel.compile-string source
+                                           {:filename path}))
+    (assert compile-ok (.. "source does not compile: " (tostring compile-err)))))
 
 ;; ── Handle construction ──
 
@@ -197,10 +276,170 @@
         (table.remove candidates)))
     {:candidates candidates})
 
+  ;; ── Task 2: Source read, patch, create, and reload ──
+
+  (fn read-source [_ args]
+    (local unit-id (or args.unit_id (error "read-source requires :unit_id")))
+    (local source-id (or args.source_id (error "read-source requires :source_id")))
+    (local unit (mgr:get unit-id))
+    (assert unit (.. "unit not found: " unit-id))
+    (local target-path (resolve-source-path unit source-id "read-source"))
+    (assert (fs.exists target-path)
+            (.. "read-source: source file not found: " source-id))
+    (local content (fs.read-file target-path))
+    {:unit-id unit.id
+     :source-id source-id
+     :content content
+     :hash (hash-file target-path)})
+
+  (fn apply-patch [_ args]
+    (local unit-id (or args.unit_id (error "apply-patch requires :unit_id")))
+    (local source-id (or args.source_id (error "apply-patch requires :source_id")))
+    (local unit (mgr:get unit-id))
+    (assert unit (.. "unit not found: " unit-id))
+    (assert-filesystem-unit unit "apply-patch")
+    (local target-path (resolve-source-path unit source-id "apply-patch"))
+    (assert (fs.exists target-path)
+            (.. "apply-patch: source file not found: " source-id))
+
+    ;; Stale-content protection via expected_hash
+    (when args.expected_hash
+      (local current-hash (hash-file target-path))
+      (assert (= current-hash args.expected_hash)
+              (.. "apply-patch rejected: expected hash " args.expected_hash
+                  " but current hash is " current-hash)))
+
+    ;; Save original content for rollback
+    (local old-source (fs.read-file target-path))
+
+    ;; Determine patch mode: unified diff or exact replacement
+    (local has-patch (not= args.patch nil))
+    (local has-old (not= args.old nil))
+    (local has-new (not= args.new nil))
+    (assert (not (and has-patch (or has-old has-new)))
+            "apply-patch: provide either :patch or :old/:new, not both")
+    (assert (or has-patch (and has-old has-new))
+            "apply-patch: provide either :patch or both :old and :new")
+    (assert (or has-patch (= has-old has-new))
+            "apply-patch: both :old and :new are required for exact replacement")
+
+    (if has-patch
+        ;; Unified diff patch mode
+        (do
+          (assert (= (type args.patch) "string") "apply-patch :patch must be a string")
+          (local ApplyPatch (require :llm/tools/apply-patch))
+          (local root (or (get-unit-root-dir unit) (fs.parent target-path)))
+          (local (patch-ok patch-err)
+            (pcall ApplyPatch.call
+                   {:path source-id :patch args.patch :allow_create false}
+                   {:cwd root}))
+          (when (not patch-ok)
+            ;; Restore original source on patch failure
+            (pcall fs.write-file target-path old-source)
+            (error (.. "apply-patch failed, source restored: " (tostring patch-err))))
+          ;; Validate the result and reload; restore on failure
+          (local (validate-ok validate-err)
+            (pcall (fn []
+                     (local current-source (fs.read-file target-path))
+                     (validate-fnl-source target-path current-source)
+                     (mgr:reload-unit unit-id {}))))
+          (if validate-ok
+              {:unit-id unit.id
+               :source-id source-id
+               :reloaded true
+               :hash (hash-file target-path)}
+              (do
+                ;; Rollback: restore old source
+                (pcall fs.write-file target-path old-source)
+                ;; Attempt recovery reload with old source
+                (pcall #(mgr:reload-unit unit-id {}))
+                (error (.. "apply-patch reload failed, source restored: " (tostring validate-err))))))
+        ;; Exact replacement mode
+        (do
+          (assert (= (type args.old) "string") "apply-patch :old must be a string")
+          (assert (= (type args.new) "string") "apply-patch :new must be a string")
+          (assert (> (# args.old) 0) "apply-patch :old must not be empty")
+          (local (start-pos end-pos) (string.find old-source args.old 1 true))
+          (assert start-pos "apply-patch: :old text was not found in source")
+          (local (next-pos) (string.find old-source args.old (+ end-pos 1) true))
+          (assert (not next-pos) "apply-patch: :old text matched more than once")
+          (local new-source (.. (string.sub old-source 1 (- start-pos 1))
+                                args.new
+                                (string.sub old-source (+ end-pos 1))))
+          ;; Validate Fennel source before writing
+          (validate-fnl-source target-path new-source)
+          ;; Write the new source
+          (local (write-ok write-err) (pcall fs.write-file target-path new-source))
+          (when (not write-ok)
+            (error (.. "apply-patch failed to write: " (tostring write-err))))
+          ;; Reload the unit; on failure, restore old source and re-raise
+          (local (reload-ok reload-err) (pcall #(mgr:reload-unit unit-id {})))
+          (if reload-ok
+              {:unit-id unit.id
+               :source-id source-id
+               :reloaded true
+               :hash (hash-file target-path)}
+              (do
+                ;; Rollback: restore old source
+                (pcall fs.write-file target-path old-source)
+                ;; Attempt recovery reload with old source
+                (pcall #(mgr:reload-unit unit-id {}))
+                (error (.. "apply-patch reload failed, source restored: " (tostring reload-err))))))))
+
+  (fn create-source [_ args]
+    (local unit-id (or args.unit_id (error "create-source requires :unit_id")))
+    (local source-id (or args.source_id (error "create-source requires :source_id")))
+    (local source (or args.source (error "create-source requires :source")))
+    (assert (= (type source) "string") "create-source :source must be a string")
+    (local unit (mgr:get unit-id))
+    (assert unit (.. "unit not found: " unit-id))
+    (assert-directory-unit unit "create-source")
+    (validate-source-id source-id "create-source")
+    (local root (get-unit-root-dir unit))
+    (local target-path (fs.join-path root source-id))
+    ;; Check file does not already exist if expected_absent is true
+    (when args.expected_absent
+      (assert (not (fs.exists target-path))
+              (.. "create-source: file already exists: " source-id)))
+    ;; Validate Fennel source before creating
+    (validate-fnl-source target-path source)
+    ;; Create parent directories if needed
+    (local parent-dir (fs.parent target-path))
+    (when (and parent-dir (not (fs.exists parent-dir)))
+      (fs.create-dirs parent-dir))
+    ;; Write the new file
+    (local (write-ok write-err) (pcall fs.write-file target-path source))
+    (when (not write-ok)
+      (error (.. "create-source failed to write: " (tostring write-err))))
+    ;; Reload the unit; on failure, remove new file and re-raise
+    (local (reload-ok reload-err) (pcall #(mgr:reload-unit unit-id {})))
+    (if reload-ok
+        {:unit-id unit.id
+         :source-id source-id
+         :created true
+         :reloaded true
+         :hash (hash-file target-path)}
+        (do
+          ;; Rollback: remove the newly created file
+          (pcall fs.remove-all target-path)
+          (error (.. "create-source reload failed, new file removed: " (tostring reload-err))))))
+
+  (fn reload [_ args]
+    (local unit-id (or args.unit_id (error "reload requires :unit_id")))
+    (local unit (mgr:get unit-id))
+    (assert unit (.. "unit not found: " unit-id))
+    (mgr:reload-unit unit-id {})
+    {:unit-id unit.id
+     :reloaded true})
+
   (set self.unit-handle unit-handle)
   (set self.list list)
   (set self.inspect inspect)
   (set self.resolve resolve)
+  (set self.read-source read-source)
+  (set self.apply-patch apply-patch)
+  (set self.create-source create-source)
+  (set self.reload reload)
 
   self)
 

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -460,6 +460,123 @@
     {:unit-id unit.id
      :reloaded true})
 
+  ;; ── Task 3: External Unit Test, Log, and Snapshot Operations ──
+
+  (fn get-unit-fennel-root [unit]
+    ;; Return the directory that serves as the Fennel path base for this unit.
+    ;; For directory units, this is the unit directory itself.
+    ;; For flat units, this is the parent directory of the primary source file.
+    (local paths (or unit.owned-paths []))
+    (var root nil)
+    (each [_ path (ipairs paths) &until root]
+      (when (and path (fs.exists path))
+        (local st (fs.stat path))
+        (if (and st st.is-dir)
+            (set root path)
+            (set root (fs.parent path)))))
+    root)
+
+  (fn run-tests [self args]
+    (local unit-id (or args.unit_id (error "run-tests requires :unit_id")))
+    (local unit (mgr:get unit-id))
+    (assert unit (.. "unit not found: " unit-id))
+    (assert (not (= unit.source :builtin))
+            "run-tests: cannot run tests for built-in unit")
+    (local test-name (or args.test_name "init"))
+    (local name (or unit.module-name unit.id))
+    (local test-module (.. name ".test-" test-name))
+    (local Process (require :process))
+    (local runtime (require :runtime))
+    (local fs (require :fs))
+    (local assets-path (or (os.getenv "SPACE_ASSETS_PATH") runtime.assets-path))
+    ;; Resolve the space binary
+    (local space-bin
+      (if (os.getenv "SPACE_BIN")
+          (os.getenv "SPACE_BIN")
+          (let [cwd (fs.cwd)
+                base-candidates [(fs.join-path cwd "build" "space")
+                                 (fs.join-path cwd "build" "dist" "windows" "space")
+                                 (fs.join-path cwd "space")
+                                 (fs.join-path cwd ".." "build" "space")]]
+            (var resolved nil)
+            (each [_ candidate (ipairs base-candidates) &until resolved]
+              (when (fs.exists candidate)
+                (set resolved candidate))
+              (when (and (not resolved) (fs.exists (.. candidate ".exe")))
+                (set resolved (.. candidate ".exe"))))
+            (assert resolved
+                    (.. "run-tests: could not locate space binary from cwd " cwd))
+            resolved)))
+    ;; Build Fennel paths from the unit's directory, falling back to app.code-dir
+    (local unit-root (or (get-unit-fennel-root unit)
+                         (and app app.code-dir)))
+    (local unit-fennel-path
+      (if unit-root
+          (.. (fs.join-path unit-root "?" "init.fnl")
+              ";" (fs.join-path unit-root "?.fnl"))
+          ""))
+    (local fennel-path
+      (if (> (# unit-fennel-path) 0)
+          (.. unit-fennel-path ";" runtime.fennel-path)
+          runtime.fennel-path))
+    (local result (Process.run
+                    {:args [space-bin "-m" (.. test-module ":main")]
+                     :env {:FENNEL_PATH fennel-path
+                           :FENNEL_MACRO_PATH fennel-path
+                           :SPACE_ASSETS_PATH assets-path
+                           :SPACE_DISABLE_AUDIO "1"}
+                     :timeout 30}))
+    {:passed (= result.exit-code 0)
+     :exit-code result.exit-code
+     :stdout (or result.stdout "")
+     :stderr result.stderr})
+
+  (fn read-log [self args]
+    (local logging (require :logging))
+    (local log-path (logging.get-output-path))
+    (local fs (require :fs))
+    (when (not (fs.exists log-path))
+      (error (.. "read-log: log file not found: " log-path)))
+    (var content (fs.read-file log-path))
+    (when (or (not content) (= content ""))
+      (error "read-log: log file is empty"))
+    (local all-lines [])
+    (each [line (_G.string.gmatch content "([^\n]*)\n?")]
+      (table.insert all-lines line))
+    (local total-count (# all-lines))
+    (when (= total-count 0)
+      (error "read-log: log file is empty"))
+    ;; Drop trailing empty string from final \n
+    (when (and (> (# all-lines) 0) (= (. all-lines (# all-lines)) ""))
+      (table.remove all-lines))
+    (local grep (and args.grep (> (# args.grep) 0) args.grep))
+    (var result-lines [])
+    (var i (or args.offset 1))
+    (var remaining (or args.limit (or (and args.offset 200) (or args.lines 100))))
+    (when (< i 1) (set i 1))
+    (when args.lines
+      (set i (math.max 1 (- (# all-lines) args.lines -1))))
+    (while (and (<= i (# all-lines)) (> remaining 0))
+      (local line (. all-lines i))
+      (when (or (not grep) (string.find line grep 1 true))
+        (table.insert result-lines (.. i ": " line))
+        (set remaining (- remaining 1)))
+      (set i (+ i 1)))
+    {:lines result-lines
+     :total-lines total-count
+     :log-path log-path})
+
+  (fn snapshot [self args]
+    (local unit-id (or args.unit_id (error "snapshot requires :unit_id")))
+    (local unit (mgr:get unit-id))
+    (assert unit (.. "unit not found: " unit-id))
+    (local (ok state) (pcall #(unit:snapshot {})))
+    (if ok
+        {:unit-id unit.id
+         :supported true
+         :state state}
+        (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state)))))
+
   (set self.unit-handle unit-handle)
   (set self.list list)
   (set self.inspect inspect)
@@ -468,6 +585,9 @@
   (set self.apply-patch apply-patch)
   (set self.create-source create-source)
   (set self.reload reload)
+  (set self.run-tests run-tests)
+  (set self.read-log read-log)
+  (set self.snapshot snapshot)
 
   self)
 

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -24,14 +24,44 @@
 (fn path-has-fnl-extension? [path]
   (not= (string.match (or path "") "%.fnl$") nil))
 
+(fn get-unit-root-dir [unit]
+  ;; Find the unit root directory from owned-paths (first directory entry).
+  (local paths (or unit.owned-paths []))
+  (var root nil)
+  (each [_ path (ipairs paths) &until root]
+    (when (and path (fs.exists path))
+      (local st (fs.stat path))
+      (when (and st st.is-dir)
+        (set root path))))
+  root)
+
 (fn derive-source-artifacts [unit]
+  (local loader (classify-loader unit))
+  ;; R1-1: Only filesystem loaders expose source artifacts.
+  (when (not= loader "filesystem")
+    (lua "return {}"))
   (local paths (or unit.owned-paths []))
   (local artifacts [])
+  (local unit-root (get-unit-root-dir unit))
+  (local seen-ids {})
   ;; Collect regular files from owned paths for source artifacts.
   ;; Directories are included in owned-paths but are not source artifacts.
   (each [_ path (ipairs paths)]
     (when (and path (fs.exists path) (not (let [st (fs.stat path)] (and st st.is-dir))))
-      (local source-id (path-basename path))
+      ;; R1-2: For directory units, compute source-id as the path relative to the
+      ;; unit root so that nested artifacts (e.g. components/view.fnl) are
+      ;; addressable by source-id.  For flat units, fall back to basename.
+      (local source-id
+        (if unit-root
+            (let [prefix (.. unit-root "/")]
+              (if (= (string.sub path 1 (# prefix)) prefix)
+                  (string.sub path (+ (# prefix) 1))
+                  (path-basename path)))
+            (path-basename path)))
+      ;; Reject duplicate source-ids to prevent collisions.
+      (assert (not (. seen-ids source-id))
+              (.. "duplicate source-id in unit " unit.id ": " source-id))
+      (tset seen-ids source-id true)
       (local primary (path-has-fnl-extension? path))
       (local file-size (or (and (fs.exists path)
                                 (let [stat (fs.stat path)]
@@ -54,6 +84,10 @@
   (or primary (. artifacts 1)))
 
 (fn build-source-handle [unit]
+  (local loader (classify-loader unit))
+  ;; R1-1: Only filesystem loaders expose source handles.
+  (when (not= loader "filesystem")
+    (lua "return nil"))
   (local artifacts (derive-source-artifacts unit))
   (if (= (length artifacts) 0)
       nil
@@ -91,17 +125,6 @@
                    (string.match source-id "%.%.$")
                    (= source-id "..")))
           (.. operation " :source_id must not contain .. segments")))
-
-(fn get-unit-root-dir [unit]
-  ;; Find the unit root directory from owned-paths (first directory entry).
-  (local paths (or unit.owned-paths []))
-  (var root nil)
-  (each [_ path (ipairs paths) &until root]
-    (when (and path (fs.exists path))
-      (local st (fs.stat path))
-      (when (and st st.is-dir)
-        (set root path))))
-  root)
 
 (fn is-directory-unit? [unit]
   (not= (get-unit-root-dir unit) nil))
@@ -315,6 +338,18 @@
     (local source-id (or args.source_id (error "read-source requires :source_id")))
     (local unit (mgr:get unit-id))
     (assert unit (.. "unit not found: " unit-id))
+    ;; R1-1: Gate on filesystem loader and read capability.
+    (local loader (classify-loader unit))
+    (assert (= loader "filesystem")
+            (.. "read-source: unit " unit-id " loader " loader
+                " does not support source read operations"))
+    (local edit-caps (build-edit-capabilities loader unit))
+    (var has-read false)
+    (each [_ cap (ipairs edit-caps)]
+      (when (= cap "read") (set has-read true)))
+    (assert has-read
+            (.. "read-source: unit " unit-id " loader " loader
+                " does not support read capability"))
     (local target-path (resolve-source-path unit source-id "read-source"))
     (assert (fs.exists target-path)
             (.. "read-source: source file not found: " source-id))

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -69,11 +69,6 @@
       ["run-test"]
       []))
 
-(fn build-snapshot-capabilities [loader]
-  (if (= loader "filesystem")
-      true
-      false))
-
 (fn build-commit-capability [_loader]
   "none")
 
@@ -582,17 +577,26 @@
     (local unit-id (or args.unit_id (error "snapshot requires :unit_id")))
     (local unit (mgr:get unit-id))
     (assert unit (.. "unit not found: " unit-id))
-    (local loader (classify-loader unit))
-    (if (not (build-snapshot-capabilities loader))
+    ;; Call unit:snapshot to detect actual snapshot support.
+    ;; A nil return means there is no real snapshot implementation
+    ;; (noop-snapshot default or missing optional export).
+    ;; A non-nil return means an actual snapshot implementation produced state.
+    ;; Errors from a real implementation are propagated as unexpected failures.
+    (local (ok state) (pcall #(unit:snapshot {})))
+    (if (not ok)
+        ;; Distinguish "missing function" (no capability) from unexpected errors.
+        (if (string.find (tostring state) "missing function" 1 true)
+            {:unit-id unit.id
+             :supported false
+             :state nil}
+            (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state))))
+        (= state nil)
         {:unit-id unit.id
          :supported false
          :state nil}
-        (let [(ok state) (pcall #(unit:snapshot {}))]
-          (if ok
-              {:unit-id unit.id
-               :supported true
-               :state state}
-              (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state)))))))
+        {:unit-id unit.id
+         :supported true
+         :state state}))
 
   (set self.unit-handle unit-handle)
   (set self.list list)

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -38,13 +38,13 @@
                                 (let [stat (fs.stat path)]
                                   (and stat.exists stat.size)))
                            0))
-      (local (hash-ok file-hash) (pcall #(Sha256.hash-file path)))
+      (local file-hash (.. "sha256:" (Sha256.hash-file path)))
       (table.insert artifacts
                     {:source-id source-id
                      :kind "file"
                      :primary primary
                      :size file-size
-                     :hash (if hash-ok file-hash "unknown")})))
+                     :hash file-hash})))
   artifacts)
 
 (fn primary-source-artifact [artifacts]
@@ -151,6 +151,13 @@
   (fn resolve [self args]
     (local description (or args.description
                            (error "resolve requires :description")))
+    (when (not= args.limit nil)
+      (assert (= (type args.limit) :number)
+              "resolve :limit must be a number")
+      (assert (>= args.limit 0)
+              "resolve :limit must be non-negative")
+      (assert (= args.limit (math.floor args.limit))
+              "resolve :limit must be an integer"))
     (local limit (or args.limit 20))
     (local tokens (tokenize description))
     (assert (> (length tokens) 0)
@@ -184,8 +191,8 @@
                   (if (> a.confidence b.confidence) true
                       (< a.confidence b.confidence) false
                       (< a.unit-id b.unit-id))))
-    ;; Apply optional limit
-    (when (and limit (> (length candidates) limit))
+    ;; Apply optional limit via bounded slicing — cannot loop indefinitely
+    (when (> (length candidates) limit)
       (while (> (length candidates) limit)
         (table.remove candidates)))
     {:candidates candidates})

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -578,18 +578,27 @@
     (local unit (mgr:get unit-id))
     (assert unit (.. "unit not found: " unit-id))
     ;; Call unit:snapshot to detect actual snapshot support.
-    ;; A nil return means there is no real snapshot implementation
+    ;; A nil state means there is no real snapshot implementation
     ;; (noop-snapshot default or missing optional export).
-    ;; A non-nil return means an actual snapshot implementation produced state.
-    ;; Errors from a real implementation are propagated as unexpected failures.
+    ;; A non-nil state means an actual snapshot implementation produced data.
+    ;; If the call throws, we inspect the loaded module to distinguish
+    ;; "missing export" (no capability) from a runtime error in a real
+    ;; snapshot function (unexpected failure that must propagate).
     (local (ok state) (pcall #(unit:snapshot {})))
     (if (not ok)
-        ;; Distinguish "missing function" (no capability) from unexpected errors.
-        (if (string.find (tostring state) "missing function" 1 true)
-            {:unit-id unit.id
-             :supported false
-             :state nil}
-            (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state))))
+        ;; Check structurally: did the export function exist on the module?
+        (let [export-name unit.snapshot-export
+              module-name unit.module-name
+              loaded-module (and module-name (. package.loaded module-name))
+              export-fn (and loaded-module export-name (. loaded-module export-name))]
+          (if (and export-name loaded-module (not= (type export-fn) "function"))
+              ;; Module loaded but export function does not exist — missing capability
+              {:unit-id unit.id
+               :supported false
+               :state nil}
+              ;; Export function exists and threw, or we cannot determine —
+              ;; propagate as an unexpected error
+              (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state)))))
         (= state nil)
         {:unit-id unit.id
          :supported false

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -539,9 +539,10 @@
      :stderr result.stderr})
 
   (fn read-log [self args]
-    (local logging (require :logging))
-    (local log-path (logging.get-output-path))
     (local fs (require :fs))
+    (local log-path (or args.log_path
+                        (let [logging (require :logging)]
+                          (logging.get-output-path))))
     (when (not (fs.exists log-path))
       (error (.. "read-log: log file not found: " log-path)))
     (var content (fs.read-file log-path))
@@ -577,35 +578,24 @@
     (local unit-id (or args.unit_id (error "snapshot requires :unit_id")))
     (local unit (mgr:get unit-id))
     (assert unit (.. "unit not found: " unit-id))
-    ;; Call unit:snapshot to detect actual snapshot support.
-    ;; A nil state means there is no real snapshot implementation
-    ;; (noop-snapshot default or missing optional export).
-    ;; A non-nil state means an actual snapshot implementation produced data.
-    ;; If the call throws, we inspect the loaded module to distinguish
-    ;; "missing export" (no capability) from a runtime error in a real
-    ;; snapshot function (unexpected failure that must propagate).
-    (local (ok state) (pcall #(unit:snapshot {})))
-    (if (not ok)
-        ;; Check structurally: did the export function exist on the module?
-        (let [export-name unit.snapshot-export
-              module-name unit.module-name
-              loaded-module (and module-name (. package.loaded module-name))
-              export-fn (and loaded-module export-name (. loaded-module export-name))]
-          (if (and export-name loaded-module (not= (type export-fn) "function"))
-              ;; Module loaded but export function does not exist — missing capability
-              {:unit-id unit.id
-               :supported false
-               :state nil}
-              ;; Export function exists and threw, or we cannot determine —
-              ;; propagate as an unexpected error
-              (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state)))))
-        (= state nil)
+    ;; Determine snapshot support structurally via unit.has-snapshot?
+    ;; before calling unit:snapshot, so we never invoke a noop/default.
+    ;; For Unit: has-snapshot? is true only when a :snapshot function
+    ;; was explicitly provided (defaults to noop otherwise).
+    ;; For ModuleUnit: has-snapshot? is true only when :snapshot-export
+    ;; was explicitly set in the options.
+    ;; For SourceUnit: has-snapshot? is true only when :snapshot-export
+    ;; was explicitly set in the options.
+    (if (not unit.has-snapshot?)
         {:unit-id unit.id
          :supported false
          :state nil}
-        {:unit-id unit.id
-         :supported true
-         :state state}))
+        (let [(ok state) (pcall #(unit:snapshot {}))]
+          (if ok
+              {:unit-id unit.id
+               :supported true
+               :state state}
+              (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state)))))))
 
   (set self.unit-handle unit-handle)
   (set self.list list)

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -64,11 +64,6 @@
          :size primary.size
          :hash primary.hash})))
 
-(fn build-edit-capabilities [loader]
-  (if (= loader "filesystem")
-      ["read" "write" "create" "delete"]
-      []))
-
 (fn build-test-capabilities [loader]
   (if (= loader "filesystem")
       ["run-test"]
@@ -111,6 +106,13 @@
 (fn is-directory-unit? [unit]
   (not= (get-unit-root-dir unit) nil))
 
+(fn build-edit-capabilities [loader unit]
+  (if (= loader "filesystem")
+      (if (is-directory-unit? unit)
+          ["read" "write" "create" "delete"]
+          ["read" "write" "delete"])
+      []))
+
 (fn get-primary-source-path [unit]
   ;; Find the first .fnl file in owned-paths.
   (local paths (or unit.owned-paths []))
@@ -137,18 +139,47 @@
           (.. operation ": unit " unit.id " is a flat unit and cannot create new source artifacts")))
 
 (fn resolve-source-path [unit source-id operation]
-  ;; Resolve a source_id to an absolute file path for a filesystem unit.
-  ;; Rejects invalid source_ids and validates against unit structure.
+  ;; Resolve a source_id to a safe absolute file path for a filesystem unit.
+  ;; Rejects invalid source_ids, path-escape attempts, and symlink traversal.
   (validate-source-id source-id operation)
+  (var root nil)
+  (var raw-joined nil)
   (if (is-directory-unit? unit)
-      (let [root (get-unit-root-dir unit)]
-        (fs.join-path root source-id))
+      (do
+        (set root (get-unit-root-dir unit))
+        (set raw-joined (fs.join-path root source-id)))
       (let [primary-basename (get-primary-source-basename unit)]
         (assert primary-basename
                 (.. operation ": unit " unit.id " has no primary source file"))
         (assert (= source-id primary-basename)
                 (.. operation ": flat unit " unit.id " only accepts source_id " primary-basename))
-        (get-primary-source-path unit))))
+        (local primary-path (get-primary-source-path unit))
+        (set root (fs.parent primary-path))
+        (set raw-joined primary-path)))
+  ;; Path containment check against unit root
+  (local root-absolute (fs.absolute root))
+  (local resolved-absolute (fs.absolute raw-joined))
+  (assert (and (>= (# resolved-absolute) (# root-absolute))
+               (= (string.sub resolved-absolute 1 (# root-absolute)) root-absolute)
+               (or (= (# resolved-absolute) (# root-absolute))
+                   (= (string.sub resolved-absolute (+ (# root-absolute) 1)
+                                  (+ (# root-absolute) 1)) "/")))
+          (.. operation ": source_id escapes unit directory: " source-id))
+  ;; Reject symlink at the resolved path itself
+  (when (fs.exists resolved-absolute)
+    (local st (fs.stat resolved-absolute))
+    (assert (not st.is-symlink)
+            (.. operation ": target is a symlink: " source-id)))
+  ;; Reject symlinked ancestor directories
+  (var current (fs.parent resolved-absolute))
+  (while (and current
+              (> (# current) (# root-absolute))
+              (not= (fs.absolute current) root-absolute))
+    (local st (fs.stat current))
+    (assert (not (and st.exists st.is-symlink))
+            (.. operation ": path ancestor is a symlink: " current))
+    (set current (fs.parent current)))
+  resolved-absolute)
 
 (fn validate-fnl-source [path source]
   (when (path-has-fnl-extension? path)
@@ -164,7 +195,7 @@
   {:unit-id unit.id
    :loader loader
    :source-handle (build-source-handle unit)
-   :edit-capabilities (build-edit-capabilities loader)
+   :edit-capabilities (build-edit-capabilities loader unit)
    :test-capabilities (build-test-capabilities loader)
    :commit-capability (build-commit-capability loader)})
 
@@ -397,10 +428,9 @@
     (validate-source-id source-id "create-source")
     (local root (get-unit-root-dir unit))
     (local target-path (fs.join-path root source-id))
-    ;; Check file does not already exist if expected_absent is true
-    (when args.expected_absent
-      (assert (not (fs.exists target-path))
-              (.. "create-source: file already exists: " source-id)))
+    ;; Always reject overwriting an existing file — create-source only creates new artifacts
+    (assert (not (fs.exists target-path))
+            (.. "create-source: file already exists: " source-id))
     ;; Validate Fennel source before creating
     (validate-fnl-source target-path source)
     ;; Create parent directories if needed
@@ -411,7 +441,7 @@
     (local (write-ok write-err) (pcall fs.write-file target-path source))
     (when (not write-ok)
       (error (.. "create-source failed to write: " (tostring write-err))))
-    ;; Reload the unit; on failure, remove new file and re-raise
+    ;; Reload the unit; on failure, remove the newly created file and re-raise
     (local (reload-ok reload-err) (pcall #(mgr:reload-unit unit-id {})))
     (if reload-ok
         {:unit-id unit.id
@@ -420,7 +450,7 @@
          :reloaded true
          :hash (hash-file target-path)}
         (do
-          ;; Rollback: remove the newly created file
+          ;; Rollback: remove the newly created file (never an overwrite)
           (pcall fs.remove-all target-path)
           (error (.. "create-source reload failed, new file removed: " (tostring reload-err))))))
 

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -425,9 +425,7 @@
     (local unit (mgr:get unit-id))
     (assert unit (.. "unit not found: " unit-id))
     (assert-directory-unit unit "create-source")
-    (validate-source-id source-id "create-source")
-    (local root (get-unit-root-dir unit))
-    (local target-path (fs.join-path root source-id))
+    (local target-path (resolve-source-path unit source-id "create-source"))
     ;; Always reject overwriting an existing file — create-source only creates new artifacts
     (assert (not (fs.exists target-path))
             (.. "create-source: file already exists: " source-id))

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -1,0 +1,200 @@
+;; External Unit MCP Service — loader-neutral unit discovery, handles, inspect, and resolve.
+;; This is a read-only facade over the UnitManager that presents units in a loader-neutral
+;; interface. It does not mutate units or expose raw filesystem paths directly.
+
+(local fs (require :fs))
+(local Sha256 (require :repo/sha256))
+
+;; ── Private helpers ──
+
+(fn require-unit-manager [app]
+  (assert app.unit-manager "ExternalUnitService requires app.unit-manager")
+  app.unit-manager)
+
+(fn classify-loader [unit]
+  (if (and (= unit.source :user)
+           unit.owned-paths
+           (> (length unit.owned-paths) 0))
+      "filesystem"
+      "unknown"))
+
+(fn path-basename [path]
+  (local (name) (string.match path "([^/]+)$"))
+  name)
+
+(fn path-has-fnl-extension? [path]
+  (not= (string.match (or path "") "%.fnl$") nil))
+
+(fn derive-source-artifacts [unit]
+  (local paths (or unit.owned-paths []))
+  (local artifacts [])
+  ;; Collect regular files from owned paths for source artifacts.
+  ;; Directories are included in owned-paths but are not source artifacts.
+  (each [_ path (ipairs paths)]
+    (when (and path (fs.exists path) (not (let [st (fs.stat path)] (and st st.is-dir))))
+      (local source-id (path-basename path))
+      (local primary (path-has-fnl-extension? path))
+      (local file-size (or (and (fs.exists path)
+                                (let [stat (fs.stat path)]
+                                  (and stat.exists stat.size)))
+                           0))
+      (local (hash-ok file-hash) (pcall #(Sha256.hash-file path)))
+      (table.insert artifacts
+                    {:source-id source-id
+                     :kind "file"
+                     :primary primary
+                     :size file-size
+                     :hash (if hash-ok file-hash "unknown")})))
+  artifacts)
+
+(fn primary-source-artifact [artifacts]
+  (var primary nil)
+  (each [_ art (ipairs artifacts) &until primary]
+    (when art.primary
+      (set primary art)))
+  (or primary (. artifacts 1)))
+
+(fn build-source-handle [unit]
+  (local artifacts (derive-source-artifacts unit))
+  (if (= (length artifacts) 0)
+      nil
+      (let [primary (primary-source-artifact artifacts)]
+        {:source-id primary.source-id
+         :kind primary.kind
+         :primary true
+         :size primary.size
+         :hash primary.hash})))
+
+(fn build-edit-capabilities [loader]
+  (if (= loader "filesystem")
+      ["read" "write" "create" "delete"]
+      []))
+
+(fn build-test-capabilities [loader]
+  (if (= loader "filesystem")
+      ["run-test"]
+      []))
+
+(fn build-commit-capability [_loader]
+  "none")
+
+;; ── Handle construction ──
+
+(fn unit-handle [self unit]
+  (local loader (classify-loader unit))
+  {:unit-id unit.id
+   :loader loader
+   :source-handle (build-source-handle unit)
+   :edit-capabilities (build-edit-capabilities loader)
+   :test-capabilities (build-test-capabilities loader)
+   :commit-capability (build-commit-capability loader)})
+
+;; ── Lifecycle export helpers ──
+
+(fn lifecycle-exports [unit]
+  {:init (or unit.load-export "init")
+   :drop (or unit.unload-export "drop")
+   :snapshot (or unit.snapshot-export "snapshot")
+   :restore (or unit.restore-export "restore")})
+
+;; ── Token matching for resolve ──
+
+(fn tokenize [text]
+  (local tokens [])
+  (each [token (string.gmatch (string.lower (or text "")) "%w+")]
+    (table.insert tokens token))
+  tokens)
+
+(fn match-tokens [candidate-text tokens]
+  (local lowered (string.lower (or candidate-text "")))
+  (var matches 0)
+  (each [_ token (ipairs tokens)]
+    (when (string.find lowered token 1 true)
+      (set matches (+ matches 1))))
+  matches)
+
+(fn resolve-candidate-evidence [unit matched-tokens total-tokens]
+  (local confidence (/ matched-tokens total-tokens))
+  (local pct (string.format "%.0f" (* confidence 100)))
+  (.. "matched " matched-tokens "/" total-tokens " tokens across unit id, module name, and source file basenames (" pct "%)"))
+
+;; ── Service ──
+
+(fn ExternalUnitService [opts]
+  (local app (or opts.app (error "ExternalUnitService requires :app")))
+  (local mgr (require-unit-manager app))
+
+  (local self {})
+
+  (fn list [_ args]
+    (local results [])
+    (local units (mgr:list))
+    ;; Collect handles sorted by unit-id for deterministic ordering
+    (each [_ unit (ipairs units)]
+      (table.insert results (unit-handle self unit)))
+    (table.sort results (fn [a b] (< a.unit-id b.unit-id)))
+    results)
+
+  (fn inspect [_ args]
+    (local unit-id (or args.unit_id (error "inspect requires :unit_id")))
+    (local unit (mgr:get unit-id))
+    (assert unit (.. "unit not found: " unit-id))
+    (local loader (classify-loader unit))
+    (local source-handle (build-source-handle unit))
+    (local artifacts (derive-source-artifacts unit))
+    {:unit-id unit.id
+     :loader loader
+     :source-handle source-handle
+     :lifecycle (lifecycle-exports unit)
+     :source-artifacts artifacts})
+
+  (fn resolve [self args]
+    (local description (or args.description
+                           (error "resolve requires :description")))
+    (local limit (or args.limit 20))
+    (local tokens (tokenize description))
+    (assert (> (length tokens) 0)
+            "resolve :description must contain at least one token")
+    (local units (mgr:list))
+    (local candidates [])
+    (each [_ unit (ipairs units)]
+      (local loader (classify-loader unit))
+      (local artifacts (derive-source-artifacts unit))
+      (var total-matches 0)
+      (var max-possible 0)
+      ;; Match against unit id
+      (set total-matches (+ total-matches (match-tokens unit.id tokens)))
+      (set max-possible (+ max-possible (length tokens)))
+      ;; Match against module name
+      (set total-matches (+ total-matches (match-tokens (or unit.module-name "") tokens)))
+      (set max-possible (+ max-possible (length tokens)))
+      ;; Match against source artifact ids (basenames)
+      (each [_ art (ipairs artifacts)]
+        (set total-matches (+ total-matches (match-tokens art.source-id tokens)))
+        (set max-possible (+ max-possible (length tokens))))
+      (when (> total-matches 0)
+        (local confidence (math.min 1.0 (/ total-matches max-possible)))
+        (table.insert candidates
+                      {:unit-id unit.id
+                       :confidence confidence
+                       :evidence (resolve-candidate-evidence unit total-matches (length tokens))})))
+    ;; Sort by confidence descending, then by unit-id for deterministic tie-breaking
+    (table.sort candidates
+                (fn [a b]
+                  (if (> a.confidence b.confidence) true
+                      (< a.confidence b.confidence) false
+                      (< a.unit-id b.unit-id))))
+    ;; Apply optional limit
+    (when (and limit (> (length candidates) limit))
+      (while (> (length candidates) limit)
+        (table.remove candidates)))
+    {:candidates candidates})
+
+  (set self.unit-handle unit-handle)
+  (set self.list list)
+  (set self.inspect inspect)
+  (set self.resolve resolve)
+
+  self)
+
+{:ExternalUnitService ExternalUnitService}

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -69,6 +69,11 @@
       ["run-test"]
       []))
 
+(fn build-snapshot-capabilities [loader]
+  (if (= loader "filesystem")
+      true
+      false))
+
 (fn build-commit-capability [_loader]
   "none")
 
@@ -464,7 +469,8 @@
 
   (fn get-unit-fennel-root [unit]
     ;; Return the directory that serves as the Fennel path base for this unit.
-    ;; For directory units, this is the unit directory itself.
+    ;; For directory units, this is the *parent* of the unit directory (so
+    ;; module <name>.test-<suffix> resolves to <unit-dir>/test-<suffix>.fnl).
     ;; For flat units, this is the parent directory of the primary source file.
     (local paths (or unit.owned-paths []))
     (var root nil)
@@ -472,7 +478,7 @@
       (when (and path (fs.exists path))
         (local st (fs.stat path))
         (if (and st st.is-dir)
-            (set root path)
+            (set root (fs.parent path))
             (set root (fs.parent path)))))
     root)
 
@@ -480,8 +486,15 @@
     (local unit-id (or args.unit_id (error "run-tests requires :unit_id")))
     (local unit (mgr:get unit-id))
     (assert unit (.. "unit not found: " unit-id))
-    (assert (not (= unit.source :builtin))
-            "run-tests: cannot run tests for built-in unit")
+    (local loader (classify-loader unit))
+    (local capabilities (build-test-capabilities loader))
+    (var can-run? false)
+    (each [_ cap (ipairs capabilities)]
+      (when (= cap "run-test")
+        (set can-run? true)))
+    (assert can-run?
+            (.. "run-tests: unit " unit-id " loader " loader
+                " does not support test execution"))
     (local test-name (or args.test_name "init"))
     (local name (or unit.module-name unit.id))
     (local test-module (.. name ".test-" test-name))
@@ -507,14 +520,13 @@
             (assert resolved
                     (.. "run-tests: could not locate space binary from cwd " cwd))
             resolved)))
-    ;; Build Fennel paths from the unit's directory, falling back to app.code-dir
-    (local unit-root (or (get-unit-fennel-root unit)
-                         (and app app.code-dir)))
+    ;; Build Fennel paths from the unit's directory
+    (local unit-root (get-unit-fennel-root unit))
+    (assert unit-root
+            (.. "run-tests: could not determine Fennel path root for unit " unit-id))
     (local unit-fennel-path
-      (if unit-root
-          (.. (fs.join-path unit-root "?" "init.fnl")
-              ";" (fs.join-path unit-root "?.fnl"))
-          ""))
+      (.. (fs.join-path unit-root "?" "init.fnl")
+          ";" (fs.join-path unit-root "?.fnl")))
     (local fennel-path
       (if (> (# unit-fennel-path) 0)
           (.. unit-fennel-path ";" runtime.fennel-path)
@@ -543,12 +555,12 @@
     (local all-lines [])
     (each [line (_G.string.gmatch content "([^\n]*)\n?")]
       (table.insert all-lines line))
-    (local total-count (# all-lines))
-    (when (= total-count 0)
+    (when (= (# all-lines) 0)
       (error "read-log: log file is empty"))
     ;; Drop trailing empty string from final \n
     (when (and (> (# all-lines) 0) (= (. all-lines (# all-lines)) ""))
       (table.remove all-lines))
+    (local total-count (# all-lines))
     (local grep (and args.grep (> (# args.grep) 0) args.grep))
     (var result-lines [])
     (var i (or args.offset 1))
@@ -570,12 +582,17 @@
     (local unit-id (or args.unit_id (error "snapshot requires :unit_id")))
     (local unit (mgr:get unit-id))
     (assert unit (.. "unit not found: " unit-id))
-    (local (ok state) (pcall #(unit:snapshot {})))
-    (if ok
+    (local loader (classify-loader unit))
+    (if (not (build-snapshot-capabilities loader))
         {:unit-id unit.id
-         :supported true
-         :state state}
-        (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state)))))
+         :supported false
+         :state nil}
+        (let [(ok state) (pcall #(unit:snapshot {}))]
+          (if ok
+              {:unit-id unit.id
+               :supported true
+               :state state}
+              (error (.. "snapshot: call failed for unit " unit-id ": " (tostring state)))))))
 
   (set self.unit-handle unit-handle)
   (set self.list list)

--- a/assets/lua/llm/external-unit-mcp/service.fnl
+++ b/assets/lua/llm/external-unit-mcp/service.fnl
@@ -235,6 +235,7 @@
   (local mgr (require-unit-manager app))
 
   (local self {})
+  (tset self :_log_path opts.log_path)
 
   (fn list [_ args]
     (local results [])
@@ -540,7 +541,7 @@
 
   (fn read-log [self args]
     (local fs (require :fs))
-    (local log-path (or args.log_path
+    (local log-path (or self._log_path
                         (let [logging (require :logging)]
                           (logging.get-output-path))))
     (when (not (fs.exists log-path))
@@ -578,15 +579,19 @@
     (local unit-id (or args.unit_id (error "snapshot requires :unit_id")))
     (local unit (mgr:get unit-id))
     (assert unit (.. "unit not found: " unit-id))
-    ;; Determine snapshot support structurally via unit.has-snapshot?
+    (local has-snapshot? (if (= (type unit.has-snapshot?) "function")
+                            (unit.has-snapshot? unit)
+                            unit.has-snapshot?))
+    ;; Determine snapshot support structurally via has-snapshot?
     ;; before calling unit:snapshot, so we never invoke a noop/default.
     ;; For Unit: has-snapshot? is true only when a :snapshot function
     ;; was explicitly provided (defaults to noop otherwise).
-    ;; For ModuleUnit: has-snapshot? is true only when :snapshot-export
-    ;; was explicitly set in the options.
+    ;; For ModuleUnit: has-snapshot? is a function that checks whether
+    ;; the option :snapshot-export was explicitly set OR the loaded
+    ;; module has a matching default snapshot export.
     ;; For SourceUnit: has-snapshot? is true only when :snapshot-export
     ;; was explicitly set in the options.
-    (if (not unit.has-snapshot?)
+    (if (not has-snapshot?)
         {:unit-id unit.id
          :supported false
          :state nil}

--- a/assets/lua/llm/external-unit-mcp/tools.fnl
+++ b/assets/lua/llm/external-unit-mcp/tools.fnl
@@ -7,49 +7,64 @@
 (fn make-tool-registry [opts]
   (ToolRegistry {:namespace-prefix "space_"}))
 
-(fn def-tool [name description input-properties run]
+(fn def-tool [name description input-properties risk run]
   {:name name
    :description description
    :inputSchema {:type "object"
                  :properties input-properties}
+   :risk risk
    :run run})
+
+(local tool-risks {})
+
+(fn get-tool-risks []
+  tool-risks)
 
 (fn register-tools [registry service]
   ;; space_unit_list — list all external units
+  (tset tool-risks "space_unit_list" "normal")
   (registry:register
     (def-tool "space_unit_list"
       "List all external units with loader-neutral handles."
       {}
+      "normal"
       (fn [args]
         (json.dumps (service:list (or args {}))))))
 
   ;; space_unit_inspect — inspect a specific unit
+  (tset tool-risks "space_unit_inspect" "normal")
   (registry:register
     (def-tool "space_unit_inspect"
       "Inspect a unit by id and report its loader, source artifacts, and lifecycle exports."
       {:unit_id {:type "string" :description "The unit identifier."}}
+      "normal"
       (fn [args]
         (json.dumps (service:inspect args)))))
 
   ;; space_unit_resolve — resolve a unit by description
+  (tset tool-risks "space_unit_resolve" "normal")
   (registry:register
     (def-tool "space_unit_resolve"
       "Resolve a unit from a natural-language description with ranked candidates."
       {:description {:type "string" :description "Natural-language description of the unit to find."}
        :limit {:type "integer" :description "Maximum number of candidates to return (default 20)."}}
+      "normal"
       (fn [args]
         (json.dumps (service:resolve args)))))
 
   ;; space_unit_read_source — read a source artifact
+  (tset tool-risks "space_unit_read_source" "filesystem-read")
   (registry:register
     (def-tool "space_unit_read_source"
       "Read the content of a unit source artifact and its current hash."
       {:unit_id {:type "string" :description "The unit identifier."}
        :source_id {:type "string" :description "The source artifact identifier."}}
+      "filesystem-read"
       (fn [args]
         (json.dumps (service:read-source args)))))
 
   ;; space_unit_apply_patch — apply a patch to a unit source
+  (tset tool-risks "space_unit_apply_patch" "filesystem-write")
   (registry:register
     (def-tool "space_unit_apply_patch"
       "Apply an edit (exact replacement or unified diff patch) to a unit source file. Supports stale-content detection via expected_hash."
@@ -59,37 +74,45 @@
        :old {:type "string" :description "Exact text to find and replace."}
        :new {:type "string" :description "New text to replace the old text."}
        :expected_hash {:type "string" :description "Expected current hash of the source (sha256: prefix). Rejects the patch if the file no longer matches."}}
+      "filesystem-write"
       (fn [args]
         (json.dumps (service:apply-patch args)))))
 
   ;; space_unit_create_source — create a new source artifact in a directory unit
+  (tset tool-risks "space_unit_create_source" "filesystem-write")
   (registry:register
     (def-tool "space_unit_create_source"
       "Create a new source file inside a directory-based unit."
       {:unit_id {:type "string" :description "The unit identifier."}
        :source_id {:type "string" :description "The new source file name (relative to unit root)."}
        :source {:type "string" :description "The source content to write."}}
+      "filesystem-write"
       (fn [args]
         (json.dumps (service:create-source args)))))
 
   ;; space_unit_run_tests — run unit tests
+  (tset tool-risks "space_unit_run_tests" "shell")
   (registry:register
     (def-tool "space_unit_run_tests"
       "Run tests for a unit by executing its test module."
       {:unit_id {:type "string" :description "The unit identifier."}
        :test_name {:type "string" :description "The test suffix name (default: 'init')."}}
+      "shell"
       (fn [args]
         (json.dumps (service:run-tests args)))))
 
   ;; space_unit_reload — reload a unit
+  (tset tool-risks "space_unit_reload" "normal")
   (registry:register
     (def-tool "space_unit_reload"
       "Reload a unit to reflect its current source state."
       {:unit_id {:type "string" :description "The unit identifier."}}
+      "normal"
       (fn [args]
         (json.dumps (service:reload args)))))
 
   ;; space_unit_read_log — read application log
+  (tset tool-risks "space_unit_read_log" "filesystem-read")
   (registry:register
     (def-tool "space_unit_read_log"
       "Read recent lines from the application log with optional filtering and pagination."
@@ -97,18 +120,25 @@
        :lines {:type "integer" :description "Number of recent lines to return."}
        :offset {:type "integer" :description "Line offset from the beginning."}
        :limit {:type "integer" :description "Maximum number of lines to return."}}
+      "filesystem-read"
       (fn [args]
-        (json.dumps (service:read-log args)))))
+        (local result (service:read-log args))
+        ;; Do not expose the raw native log-path through the external API
+        (tset result :log-path nil)
+        (json.dumps result))))
 
   ;; space_unit_snapshot — snapshot a unit's state
+  (tset tool-risks "space_unit_snapshot" "normal")
   (registry:register
     (def-tool "space_unit_snapshot"
       "Capture a snapshot of a unit's current state for later restoration."
       {:unit_id {:type "string" :description "The unit identifier."}}
+      "normal"
       (fn [args]
         (json.dumps (service:snapshot args)))))
 
   registry)
 
-{:make-tool-registry make-tool-registry
- :register-tools register-tools}
+{: make-tool-registry
+ : register-tools
+ : get-tool-risks}

--- a/assets/lua/llm/external-unit-mcp/tools.fnl
+++ b/assets/lua/llm/external-unit-mcp/tools.fnl
@@ -1,0 +1,114 @@
+;; External Unit MCP Tools — wraps ExternalUnitService operations in an MCP ToolRegistry
+;; for external OpenCode sessions.
+
+(local ToolRegistry (require :mcp/tool-registry))
+(local json (require :json))
+
+(fn make-tool-registry [opts]
+  (ToolRegistry {:namespace-prefix "space_"}))
+
+(fn def-tool [name description input-properties run]
+  {:name name
+   :description description
+   :inputSchema {:type "object"
+                 :properties input-properties}
+   :run run})
+
+(fn register-tools [registry service]
+  ;; space_unit_list — list all external units
+  (registry:register
+    (def-tool "space_unit_list"
+      "List all external units with loader-neutral handles."
+      {}
+      (fn [args]
+        (json.dumps (service:list (or args {}))))))
+
+  ;; space_unit_inspect — inspect a specific unit
+  (registry:register
+    (def-tool "space_unit_inspect"
+      "Inspect a unit by id and report its loader, source artifacts, and lifecycle exports."
+      {:unit_id {:type "string" :description "The unit identifier."}}
+      (fn [args]
+        (json.dumps (service:inspect args)))))
+
+  ;; space_unit_resolve — resolve a unit by description
+  (registry:register
+    (def-tool "space_unit_resolve"
+      "Resolve a unit from a natural-language description with ranked candidates."
+      {:description {:type "string" :description "Natural-language description of the unit to find."}
+       :limit {:type "integer" :description "Maximum number of candidates to return (default 20)."}}
+      (fn [args]
+        (json.dumps (service:resolve args)))))
+
+  ;; space_unit_read_source — read a source artifact
+  (registry:register
+    (def-tool "space_unit_read_source"
+      "Read the content of a unit source artifact and its current hash."
+      {:unit_id {:type "string" :description "The unit identifier."}
+       :source_id {:type "string" :description "The source artifact identifier."}}
+      (fn [args]
+        (json.dumps (service:read-source args)))))
+
+  ;; space_unit_apply_patch — apply a patch to a unit source
+  (registry:register
+    (def-tool "space_unit_apply_patch"
+      "Apply an edit (exact replacement or unified diff patch) to a unit source file. Supports stale-content detection via expected_hash."
+      {:unit_id {:type "string" :description "The unit identifier."}
+       :source_id {:type "string" :description "The source artifact identifier."}
+       :patch {:type "string" :description "A unified diff patch to apply."}
+       :old {:type "string" :description "Exact text to find and replace."}
+       :new {:type "string" :description "New text to replace the old text."}
+       :expected_hash {:type "string" :description "Expected current hash of the source (sha256: prefix). Rejects the patch if the file no longer matches."}}
+      (fn [args]
+        (json.dumps (service:apply-patch args)))))
+
+  ;; space_unit_create_source — create a new source artifact in a directory unit
+  (registry:register
+    (def-tool "space_unit_create_source"
+      "Create a new source file inside a directory-based unit."
+      {:unit_id {:type "string" :description "The unit identifier."}
+       :source_id {:type "string" :description "The new source file name (relative to unit root)."}
+       :source {:type "string" :description "The source content to write."}}
+      (fn [args]
+        (json.dumps (service:create-source args)))))
+
+  ;; space_unit_run_tests — run unit tests
+  (registry:register
+    (def-tool "space_unit_run_tests"
+      "Run tests for a unit by executing its test module."
+      {:unit_id {:type "string" :description "The unit identifier."}
+       :test_name {:type "string" :description "The test suffix name (default: 'init')."}}
+      (fn [args]
+        (json.dumps (service:run-tests args)))))
+
+  ;; space_unit_reload — reload a unit
+  (registry:register
+    (def-tool "space_unit_reload"
+      "Reload a unit to reflect its current source state."
+      {:unit_id {:type "string" :description "The unit identifier."}}
+      (fn [args]
+        (json.dumps (service:reload args)))))
+
+  ;; space_unit_read_log — read application log
+  (registry:register
+    (def-tool "space_unit_read_log"
+      "Read recent lines from the application log with optional filtering and pagination."
+      {:grep {:type "string" :description "Filter lines containing this substring."}
+       :lines {:type "integer" :description "Number of recent lines to return."}
+       :offset {:type "integer" :description "Line offset from the beginning."}
+       :limit {:type "integer" :description "Maximum number of lines to return."}}
+      (fn [args]
+        (json.dumps (service:read-log args)))))
+
+  ;; space_unit_snapshot — snapshot a unit's state
+  (registry:register
+    (def-tool "space_unit_snapshot"
+      "Capture a snapshot of a unit's current state for later restoration."
+      {:unit_id {:type "string" :description "The unit identifier."}}
+      (fn [args]
+        (json.dumps (service:snapshot args)))))
+
+  registry)
+
+{:make-tool-registry make-tool-registry
+ :register-tools register-tools}

--- a/assets/lua/mcp/tool-registry.fnl
+++ b/assets/lua/mcp/tool-registry.fnl
@@ -95,7 +95,7 @@
           (when (not (or (string.match err-text "^approval_required ")
                          (string.match err-text "^tool denied by approval policy: ")
                          (string.match err-text "^tool approval did not resolve execution state: ")))
-            (logging.error (.. "[mcp] tool " name " error: " err-text)))
+            (logging.warn (.. "[mcp] tool " name " error: " err-text)))
           {:content [{:type "text" :text (.. "Tool execution error: " err-text)}]
            :isError true})))
 
@@ -114,7 +114,7 @@
               result-or-err
               (do
                 (local err-text (tostring result-or-err))
-                (logging.error (.. "[mcp] tool " name " error: " err-text))
+                (logging.warn (.. "[mcp] tool " name " error: " err-text))
                 (on-result {:type :error :message (.. "Tool execution error: " err-text)})
                 :completed)))
         (do
@@ -126,7 +126,7 @@
                 (when (not (or (string.match err-text "^approval_required ")
                                (string.match err-text "^tool denied by approval policy: ")
                                (string.match err-text "^tool approval did not resolve execution state: ")))
-                  (logging.error (.. "[mcp] tool " name " error: " err-text)))
+                  (logging.warn (.. "[mcp] tool " name " error: " err-text)))
                 (on-result {:type :error :message err-text})))
           :completed)))
 

--- a/assets/lua/mcp/tool-registry.fnl
+++ b/assets/lua/mcp/tool-registry.fnl
@@ -95,7 +95,7 @@
           (when (not (or (string.match err-text "^approval_required ")
                          (string.match err-text "^tool denied by approval policy: ")
                          (string.match err-text "^tool approval did not resolve execution state: ")))
-            (logging.warn (.. "[mcp] tool " name " error: " err-text)))
+            (logging.error (.. "[mcp] tool " name " error: " err-text)))
           {:content [{:type "text" :text (.. "Tool execution error: " err-text)}]
            :isError true})))
 
@@ -114,7 +114,7 @@
               result-or-err
               (do
                 (local err-text (tostring result-or-err))
-                (logging.warn (.. "[mcp] tool " name " error: " err-text))
+                (logging.error (.. "[mcp] tool " name " error: " err-text))
                 (on-result {:type :error :message (.. "Tool execution error: " err-text)})
                 :completed)))
         (do
@@ -126,7 +126,7 @@
                 (when (not (or (string.match err-text "^approval_required ")
                                (string.match err-text "^tool denied by approval policy: ")
                                (string.match err-text "^tool approval did not resolve execution state: ")))
-                  (logging.warn (.. "[mcp] tool " name " error: " err-text)))
+                  (logging.error (.. "[mcp] tool " name " error: " err-text)))
                 (on-result {:type :error :message err-text})))
           :completed)))
 

--- a/assets/lua/tests/fast.fnl
+++ b/assets/lua/tests/fast.fnl
@@ -175,8 +175,9 @@
     :tests.test-repo-store
     :tests.test-repo-checks
     :tests.test-repo-presets
-    :tests.test-repo-display
-    :tests.test-panel-transfer]})
+     :tests.test-repo-display
+     :tests.test-panel-transfer
+     :tests.test-external-unit-mcp]})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -1238,6 +1238,87 @@
 (table.insert tests {:name "external-unit-mcp: write tool errors propagate as MCP tool errors"
                      :fn test-write-tool-errors-propagate-as-mcp-tool-errors})
 
+;; ── Fix round 1: R1-1, R1-2 ──
+
+(fn test-read-log-mcp-json-contains-no-native-path-field []
+  (with-temp-dir
+    (fn [dir]
+      (local fixture-path (fs.join-path dir "controlled.log"))
+      (local fixture-content "alpha\nbeta\ngamma\n")
+      (fs.write-file fixture-path fixture-content)
+      (with-service* dir
+        (fn [mgr _dir] nil)
+        {:log_path fixture-path}
+        (fn [_mgr service]
+          (local json (require :json))
+          (local registry (ExternalUnitMcpTools.make-tool-registry {:app {}}))
+          (ExternalUnitMcpTools.register-tools registry service)
+          (local result (registry:call "space_unit_read_log" {}))
+          (assert (= result.isError false) "read-log should not error")
+          (local text (. result.content 1 :text))
+          (assert (not= text nil) "content text should not be nil")
+          (local parsed (json.loads text))
+          (assert (= (type parsed) "table") "should parse as a table")
+          ;; Verify no native path field is present in the JSON
+          (assert (= parsed.log-path nil)
+                  "MCP JSON must not expose native log-path")
+          (assert (= (. parsed "log-path") nil)
+                  "MCP JSON must not expose log-path with hyphenated key")
+          ;; Verify expected fields are still present
+          (assert parsed.lines "read-log missing lines")
+          (assert parsed.total-lines "read-log missing total-lines"))))))
+
+(table.insert tests {:name "external-unit-mcp: space_unit_read_log MCP JSON contains no native path field"
+                     :fn test-read-log-mcp-json-contains-no-native-path-field})
+
+(fn test-external-tools-carry-explicit-risk-labels []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local registry (ExternalUnitMcpTools.make-tool-registry {:app {}}))
+          (ExternalUnitMcpTools.register-tools registry service)
+          (local risks (ExternalUnitMcpTools.get-tool-risks))
+          ;; Verify risk labels are present for all 10 tools
+          (local expected-risks
+            {:space_unit_apply_patch "filesystem-write"
+             :space_unit_create_source "filesystem-write"
+             :space_unit_run_tests "shell"
+             :space_unit_read_source "filesystem-read"
+             :space_unit_read_log "filesystem-read"
+             :space_unit_list "normal"
+             :space_unit_inspect "normal"
+             :space_unit_resolve "normal"
+             :space_unit_reload "normal"
+             :space_unit_snapshot "normal"})
+          (each [tool-name expected-risk (pairs expected-risks)]
+            (local actual-risk (. risks tool-name))
+            (assert actual-risk
+                    (.. "tool '" tool-name "' missing risk label"))
+            (assert (= actual-risk expected-risk)
+                    (.. "tool '" tool-name "' expected risk '" expected-risk
+                        "', got '" (or actual-risk "nil") "'")))
+          ;; Verify no extra tools in the risk map
+          (var risk-count 0)
+          (each [_ _ (pairs risks)]
+            (set risk-count (+ risk-count 1)))
+          (assert (= risk-count 10)
+                  (.. "risk map should have exactly 10 entries, got " risk-count)))))))
+
+(table.insert tests {:name "external-unit-mcp: external tools carry explicit risk labels for write/test operations"
+                     :fn test-external-tools-carry-explicit-risk-labels})
+
 (local main
   (fn []
     (local runner (require :tests/runner))

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -390,6 +390,230 @@
 (table.insert tests {:name "external-unit-mcp: source artifacts have sha256: prefix"
                      :fn test-source-artifacts-have-sha256-prefix})
 
+;; ── Task 2: Source Read, Patch, Create, and Reload ──
+
+(fn test-read-source-returns-content-and-hash []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local result (service:read-source {:unit_id "user-bubble-overlay"
+                                               :source_id "bubble-overlay.fnl"}))
+          (assert result.unit-id "read-source missing unit_id")
+          (assert (= result.unit-id "user-bubble-overlay") "unit_id mismatch")
+          (assert result.source-id "read-source missing source_id")
+          (assert (= result.source-id "bubble-overlay.fnl") "source_id mismatch")
+          (assert result.content "read-source missing content")
+          (assert (= (type result.content) "string") "content should be a string")
+          (assert (> (# result.content) 0) "content should not be empty")
+          (assert result.hash "read-source missing hash")
+          (assert (= (string.sub result.hash 1 7) "sha256:")
+                  "hash should be sha256: prefixed")
+          (assert (> (# result.hash) 7) "hash should contain digest"))))))
+
+(table.insert tests {:name "external-unit-mcp: read-source returns content and hash"
+                     :fn test-read-source-returns-content-and-hash})
+
+(fn test-apply-patch-exact-replacement-reloads-unit []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local original-content (fs.read-file bubble-path))
+          ;; Perform an exact text replacement
+          (local old-text "(fn init [] (set app.__bubble-loaded true) true)")
+          (local new-text "(fn init [] (set app.__bubble-loaded true) 42)")
+          (local result (service:apply-patch
+                          {:unit_id "user-bubble-overlay"
+                           :source_id "bubble-overlay.fnl"
+                           :old old-text
+                           :new new-text}))
+          (assert result.unit-id "apply-patch missing unit_id")
+          (assert result.source-id "apply-patch missing source_id")
+          (assert result.reloaded "apply-patch should report reloaded")
+          (assert (= result.reloaded true) "reloaded should be true")
+          (assert result.hash "apply-patch missing hash")
+          (assert (= (string.sub result.hash 1 7) "sha256:") "hash should be sha256: prefixed")
+          ;; Verify the file was actually changed
+          (local updated-content (fs.read-file bubble-path))
+          (assert (not= updated-content original-content) "file should be changed")
+          (assert (string.find updated-content "42" 1 true)
+                  "file should contain the new text"))))))
+
+(table.insert tests {:name "external-unit-mcp: apply-patch exact replacement reloads unit"
+                     :fn test-apply-patch-exact-replacement-reloads-unit})
+
+(fn test-apply-patch-rejects-stale-expected-hash []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local original-content (fs.read-file bubble-path))
+          (local (ok err) (pcall #(service:apply-patch
+                                    {:unit_id "user-bubble-overlay"
+                                     :source_id "bubble-overlay.fnl"
+                                     :old "(fn init [] (set app.__bubble-loaded true) true)"
+                                     :new "(fn init [] (set app.__bubble-loaded true) 42)"
+                                     :expected_hash "sha256:0000000000000000000000000000000000000000000000000000000000000000"})))
+          (assert (not ok) "should reject stale expected hash")
+          (assert (string.find err "hash" 1 true)
+                  "error should mention hash")
+          ;; Verify the file was NOT changed
+          (local current-content (fs.read-file bubble-path))
+          (assert (= current-content original-content) "file should remain unchanged"))))))
+
+(table.insert tests {:name "external-unit-mcp: apply-patch rejects stale expected hash"
+                     :fn test-apply-patch-rejects-stale-expected-hash})
+
+(fn test-apply-patch-unified-diff-reloads-unit []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local original-content (fs.read-file bubble-path))
+          ;; Construct a unified diff patch that appends :version 2 to the module table
+          (local patch-text
+            (.. "*** Begin Patch\n"
+                "*** Update File: bubble-overlay.fnl\n"
+                "@@ -4,2 +4,2 @@\n"
+                " (fn restore [state] (set app.__restored state) true)\n"
+                "-{:init init :drop drop :snapshot snapshot :restore restore}\n"
+                "+{:init init :drop drop :snapshot snapshot :restore restore :version 2}\n"
+                "*** End Patch\n"))
+          (local result (service:apply-patch
+                          {:unit_id "user-bubble-overlay"
+                           :source_id "bubble-overlay.fnl"
+                           :patch patch-text}))
+          (assert result.unit-id "apply-patch missing unit_id")
+          (assert result.source-id "apply-patch missing source_id")
+          (assert result.reloaded "apply-patch should report reloaded")
+          (assert (= result.reloaded true) "reloaded should be true")
+          (assert result.hash "apply-patch missing hash")
+          ;; Verify the file was actually changed
+          (local updated-content (fs.read-file bubble-path))
+          (assert (not= updated-content original-content) "file should be changed")
+          (assert (string.find updated-content ":version 2" 1 true)
+                  "file should contain :version 2"))))))
+
+(table.insert tests {:name "external-unit-mcp: apply-patch unified diff reloads unit"
+                     :fn test-apply-patch-unified-diff-reloads-unit})
+
+(fn test-create-source-creates-directory-unit-artifact-and-reloads []
+  (with-temp-dir
+    (fn [dir]
+      (local unit-dir (fs.join-path dir "dir-unit"))
+      (fs.create-dirs unit-dir)
+      (local init-path (fs.join-path unit-dir "init.fnl"))
+      (fs.write-file init-path
+        (.. "(fn init [] true)\n"
+            "(fn drop [] true)\n"
+            "{:init init :drop drop}"))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. unit-dir "/?.fnl;" unit-dir "/?/init.fnl;" dir "/?.fnl;" dir "/?/init.fnl"))
+          (local unit (Units.ModuleUnit
+                        {:id "user-dir-unit"
+                         :module-name "dir-unit"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [unit-dir init-path]}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          (local new-source "(fn helper [] \"hello\")\n{:helper helper}")
+          (local result (service:create-source
+                          {:unit_id "user-dir-unit"
+                           :source_id "helper.fnl"
+                           :source new-source
+                           :expected_absent true}))
+          (assert result.unit-id "create-source missing unit_id")
+          (assert (= result.unit-id "user-dir-unit") "unit_id mismatch")
+          (assert result.source-id "create-source missing source_id")
+          (assert (= result.source-id "helper.fnl") "source_id mismatch")
+          (assert result.created "create-source should report created")
+          (assert result.reloaded "create-source should report reloaded")
+          (assert (= result.reloaded true) "reloaded should be true")
+          (assert result.hash "create-source missing hash")
+          (assert (= (string.sub result.hash 1 7) "sha256:") "hash should be sha256: prefixed")
+          ;; Verify the file exists and has correct content
+          (local new-path (fs.join-path unit-dir "helper.fnl"))
+          (assert (fs.exists new-path) "new file should exist")
+          (assert (= (fs.read-file new-path) new-source) "file content should match"))))))
+
+(table.insert tests {:name "external-unit-mcp: create-source creates directory-unit artifact and reloads"
+                     :fn test-create-source-creates-directory-unit-artifact-and-reloads})
+
+(fn test-create-source-fails-for-flat-unit []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local (ok err) (pcall #(service:create-source
+                                    {:unit_id "user-bubble-overlay"
+                                     :source_id "new-file.fnl"
+                                     :source "(fn init [] true)\n(fn drop [] true)\n{:init init :drop drop}"})))
+          (assert (not ok) "should reject create for flat unit")
+          (assert (string.find (or err "") "create" 1 true)
+                  "error should mention create"))))))
+
+(table.insert tests {:name "external-unit-mcp: create-source fails loudly for flat unit without create capability"
+                     :fn test-create-source-fails-for-flat-unit})
+
 (local main
   (fn []
     (local runner (require :tests/runner))

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -1,0 +1,296 @@
+;; External Unit MCP Service tests — loader-neutral discovery, handles, inspect, resolve.
+;; Run: FENNEL_PATH="..." FENNEL_MACRO_PATH="..." SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-external-unit-mcp:main
+
+(local tests [])
+(local fs (require :fs))
+(local fennel (require :fennel))
+(local Units (require :units))
+(local UnitManager (require :unit-manager))
+(local tempfile (require :tempfile))
+
+(local ExternalUnitService (require :llm/external-unit-mcp/service))
+
+(fn with-temp-dir [f]
+  (local handle (tempfile.TemporaryDirectory {:prefix "ext-unit-mcp-test-"}))
+  (local path handle.path)
+  (local (ok result) (pcall f path))
+  (handle:drop)
+  (if ok
+      result
+      (error result)))
+
+(fn with-service [dir mgr-populate f]
+  (local mgr (UnitManager {}))
+  (mgr-populate mgr dir)
+  (local service (ExternalUnitService.ExternalUnitService {:app {:unit-manager mgr}}))
+  (f mgr service)
+  (mgr:clear))
+
+;; ── Helpers ──
+
+(fn write-unit-file [dir name content]
+  (local path (fs.join-path dir (.. name ".fnl")))
+  (fs.write-file path content)
+  path)
+
+(fn write-bubble-unit [dir]
+  (write-unit-file dir "bubble-overlay"
+    (.. "(fn init [] (set app.__bubble-loaded true) true)\n"
+        "(fn drop [] (set app.__bubble-loaded false) true)\n"
+        "(fn snapshot [] app.__bubble-loaded)\n"
+        "(fn restore [state] (set app.__restored state) true)\n"
+        "{:init init :drop drop :snapshot snapshot :restore restore}")))
+
+(fn write-simple-unit [dir name]
+  (write-unit-file dir name
+    (.. "(fn init [] true)\n"
+        "(fn drop [] true)\n"
+        "{:init init :drop drop}")))
+
+;; ── Tests ──
+
+(fn test-list-returns-loader-neutral-handles []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (write-simple-unit dir "util-module")
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          ;; Register a filesystem-backed user unit (bubble-overlay)
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit)
+          ;; Register a builtin/non-filesystem unit
+          (local builtin-unit (Units.Unit {:id "builtin-hud"
+                                           :source :builtin
+                                           :load (fn [_] true)
+                                           :unload (fn [_] true)}))
+          (mgr:register builtin-unit))
+        (fn [mgr service]
+          (local results (service:list {}))
+          ;; Should return two handles
+          (assert (= (length results) 2) (.. "expected 2 handles, got " (length results)))
+          ;; Find handles by unit-id since results are sorted by unit-id
+          (var bubble-handle nil)
+          (var builtin-handle nil)
+          (each [_ h (ipairs results)]
+            (if (= h.unit-id "user-bubble-overlay") (set bubble-handle h)
+                (= h.unit-id "builtin-hud") (set builtin-handle h)))
+          (assert bubble-handle "should find bubble-overlay handle")
+          (assert builtin-handle "should find builtin-hud handle")
+          ;; Both handles have the required shape
+          (each [_ handle (ipairs results)]
+            (assert handle.unit-id "handle missing unit-id")
+            (assert handle.loader "handle missing loader")
+            ;; source-handle key must exist, but may be nil for unknown loaders
+            (assert (= (type handle.source-handle) (if (= handle.loader "filesystem") "table" "nil"))
+                    (.. "handle has incorrect source-handle type for " handle.loader))
+            (assert handle.edit-capabilities "handle missing edit-capabilities")
+            (assert handle.test-capabilities "handle missing test-capabilities")
+            (assert handle.commit-capability "handle missing commit-capability"))
+          ;; Filesystem unit
+          (assert (= bubble-handle.loader "filesystem")
+                  (.. "expected filesystem loader, got " bubble-handle.loader))
+          (assert bubble-handle.source-handle.source-id "source-handle missing source-id")
+          (assert (= bubble-handle.source-handle.kind "file") "source-handle kind should be file")
+          (assert bubble-handle.source-handle.primary "source-handle should be primary")
+          (assert (> bubble-handle.source-handle.size 0) "source-handle size should be > 0")
+          (assert (= (type bubble-handle.source-handle.hash) "string") "source-handle hash should be string")
+          (assert (> (# bubble-handle.source-handle.hash) 0) "source-handle hash should not be empty")
+          ;; Unknown unit (builtin has no owned paths)
+          (assert (= builtin-handle.loader "unknown")
+                  (.. "expected unknown loader, got " builtin-handle.loader))
+          (assert (= builtin-handle.source-handle nil) "unknown unit should have nil source-handle")
+          ;; Unknown unit has no edit capabilities
+          (assert (= (length builtin-handle.edit-capabilities) 0)
+                  "unknown unit should have no edit capabilities"))))))
+
+(table.insert tests {:name "external-unit-mcp: list returns loader-neutral handles"
+                     :fn test-list-returns-loader-neutral-handles})
+
+(fn test-inspect-reports-source-artifacts-and-lifecycle-exports []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [mgr service]
+          (local result (service:inspect {:unit_id "user-bubble-overlay"}))
+          (assert result.unit-id "inspect missing unit-id")
+          (assert (= result.unit-id "user-bubble-overlay") "unit-id mismatch")
+          (assert (= result.loader "filesystem") "inspect loader mismatch")
+          (assert result.source-handle "inspect missing source-handle")
+          ;; Lifecycle exports
+          (assert result.lifecycle "inspect missing lifecycle")
+          (assert (= result.lifecycle.init "init") "lifecycle init should default to 'init'")
+          (assert (= result.lifecycle.drop "drop") "lifecycle drop should default to 'drop'")
+          (assert (= result.lifecycle.snapshot "snapshot")
+                  "lifecycle snapshot should default to 'snapshot'")
+          (assert (= result.lifecycle.restore "restore")
+                  "lifecycle restore should default to 'restore'")
+          ;; Source artifacts
+          (assert result.source-artifacts "inspect missing source-artifacts")
+          (assert (= (type result.source-artifacts) "table")
+                  "source-artifacts should be a table")
+          (assert (> (length result.source-artifacts) 0)
+                  "source-artifacts should not be empty"))))))
+
+(table.insert tests {:name "external-unit-mcp: inspect reports source artifacts and lifecycle exports"
+                     :fn test-inspect-reports-source-artifacts-and-lifecycle-exports})
+
+(fn test-resolve-ranks-vague-description-candidates []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (write-simple-unit dir "util-module")
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit)
+          (local util-unit (Units.ModuleUnit
+                              {:id "user-util-module"
+                               :module-name "util-module"
+                               :module-paths fennel-paths
+                               :source :user
+                               :suppress-run-main? true
+                               :owned-paths [(fs.join-path dir "util-module.fnl")]}))
+          (mgr:register util-unit))
+        (fn [_mgr service]
+          ;; Resolve with vague description matching bubble unit
+          (local result (service:resolve {:description "bubble overlay unit"}))
+          (assert result.candidates "resolve missing candidates")
+          (assert (= (type result.candidates) "table") "candidates should be a table")
+          (assert (> (length result.candidates) 0)
+                  "should return at least one candidate for matching description")
+          ;; The top candidate should be bubble-overlay
+          (local top (. result.candidates 1))
+          (assert top.unit-id "candidate missing unit-id")
+          (assert (= top.unit-id "user-bubble-overlay")
+                  (.. "top candidate should be bubble-overlay, got " top.unit-id))
+          (assert top.confidence "candidate missing confidence")
+          (assert (>= top.confidence 0) "confidence should be non-negative")
+          (assert (<= top.confidence 1) "confidence should be <= 1")
+          (assert top.evidence "candidate missing evidence")
+          (assert (= (type top.evidence) "string") "evidence should be a string")
+          ;; Verify confidence of bubble is higher than util
+          (when (> (length result.candidates) 1)
+            (local second (. result.candidates 2))
+            (assert (>= top.confidence second.confidence)
+                    "bubble overlay should have higher confidence than util")))))))
+
+(table.insert tests {:name "external-unit-mcp: resolve ranks vague description candidates"
+                     :fn test-resolve-ranks-vague-description-candidates})
+
+(fn test-unit-handle-produces-loader-neutral-shape []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit)
+          ;; Also register a unit with missing owned paths (unknown loader)
+          (local orphan-unit (Units.Unit {:id "orphan"
+                                           :source :user
+                                           :load (fn [_] true)
+                                           :unload (fn [_] true)}))
+          (mgr:register orphan-unit))
+        (fn [mgr service]
+          (local user-unit (mgr:get "user-bubble-overlay"))
+          (local orphan-unit (mgr:get "orphan"))
+          ;; Filesystem handle
+          (local handle (service:unit-handle user-unit))
+          (assert (= handle.loader "filesystem") "filesystem unit should have filesystem loader")
+          (assert handle.source-handle "filesystem unit should have source-handle")
+          (assert (> (length handle.edit-capabilities) 0)
+                  "filesystem unit should have edit capabilities")
+          ;; Orphan handle (user source but no owned paths => unknown loader)
+          (local orphan-handle (service:unit-handle orphan-unit))
+          (assert (= orphan-handle.loader "unknown")
+                  (.. "orphan unit should have unknown loader, got " orphan-handle.loader))
+          (assert (= orphan-handle.source-handle nil) "orphan unit should have nil source-handle"))))))
+
+(table.insert tests {:name "external-unit-mcp: unit-handle produces loader-neutral shape"
+                     :fn test-unit-handle-produces-loader-neutral-shape})
+
+(fn test-service-asserts-missing-unit-manager []
+  (local (ok err) (pcall #(ExternalUnitService.ExternalUnitService {:app {}})))
+  (assert (not ok) "should reject missing unit-manager")
+  (assert (string.find err "unit-manager" 1 true)
+          "error should mention unit-manager"))
+
+(table.insert tests {:name "external-unit-mcp: asserts missing unit-manager"
+                     :fn test-service-asserts-missing-unit-manager})
+
+(fn test-list-returns-deterministic-ordering []
+  (with-temp-dir
+    (fn [dir]
+      (local z-path (write-unit-file dir "z-unit"
+                     (.. "(fn init [] true)\n(fn drop [] true)\n{:init init :drop drop}")))
+      (local a-path (write-unit-file dir "a-unit"
+                     (.. "(fn init [] true)\n(fn drop [] true)\n{:init init :drop drop}")))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (mgr:register (Units.ModuleUnit
+                          {:id "user-a-unit"
+                           :module-name "a-unit"
+                           :module-paths fennel-paths
+                           :source :user
+                           :suppress-run-main? true
+                           :owned-paths [a-path]}))
+          (mgr:register (Units.ModuleUnit
+                          {:id "user-z-unit"
+                           :module-name "z-unit"
+                           :module-paths fennel-paths
+                           :source :user
+                           :suppress-run-main? true
+                           :owned-paths [z-path]})))
+        (fn [_mgr service]
+          (local results (service:list {}))
+          (assert (= (length results) 2))
+          ;; Deterministic ordering: by unit-id for test stability
+          (assert (= (. results 1 :unit-id) "user-a-unit") "should be sorted by unit-id")
+          (assert (= (. results 2 :unit-id) "user-z-unit") "should be sorted by unit-id"))))))
+
+(table.insert tests {:name "external-unit-mcp: list returns deterministic ordering"
+                     :fn test-list-returns-deterministic-ordering})
+
+(local main
+  (fn []
+    (local runner (require :tests/runner))
+    (runner.run-tests {:name "external-unit-mcp"
+                       :tests tests})))
+
+{:name "external-unit-mcp"
+ :tests tests
+ :main main}

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -1109,6 +1109,135 @@
 (table.insert tests {:name "external-unit-mcp: run-tests rejects unknown loader without run-test capability"
                      :fn test-run-tests-rejects-unknown-loader})
 
+;; ── Task 4: External Unit MCP Tool Registry ──
+
+(local ExternalUnitMcpTools (require :llm/external-unit-mcp/tools))
+
+(fn test-tool-registry-exposes-minimal-external-tool-set []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local registry (ExternalUnitMcpTools.make-tool-registry {:app {}}))
+          (ExternalUnitMcpTools.register-tools registry service)
+          (local tools-list (registry:list))
+          (assert (= (length tools-list) 10)
+                  (.. "expected 10 tools, got " (length tools-list)))
+          (local expected-names
+            ["space_unit_apply_patch"
+             "space_unit_create_source"
+             "space_unit_inspect"
+             "space_unit_list"
+             "space_unit_read_log"
+             "space_unit_read_source"
+             "space_unit_reload"
+             "space_unit_resolve"
+             "space_unit_run_tests"
+             "space_unit_snapshot"])
+          (each [_ tool (ipairs tools-list)]
+            (assert (= (string.sub tool.name 1 6) "space_")
+                    (.. "tool '" tool.name "' must use space_ prefix"))
+            (assert (not= tool.description nil)
+                    (.. "tool '" tool.name "' missing description"))
+            (assert (> (# tool.description) 0)
+                    (.. "tool '" tool.name "' description must not be empty"))
+            (assert tool.inputSchema
+                    (.. "tool '" tool.name "' missing inputSchema")))
+          (local actual-names [])
+          (each [_ tool (ipairs tools-list)]
+            (table.insert actual-names tool.name))
+          (assert (= (length actual-names) (length expected-names))
+                  "should have exactly 10 tools")
+          (each [i expected-name (ipairs expected-names)]
+            (assert (= expected-name (. actual-names i))
+                    (.. "tool at index " i " should be " expected-name
+                        ", got " (. actual-names i)))))))))
+
+(table.insert tests {:name "external-unit-mcp: tool registry exposes minimal external tool set"
+                     :fn test-tool-registry-exposes-minimal-external-tool-set})
+
+(fn test-tool-calls-return-json-service-responses []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local json (require :json))
+          (local registry (ExternalUnitMcpTools.make-tool-registry {:app {}}))
+          (ExternalUnitMcpTools.register-tools registry service)
+          (local result (registry:call "space_unit_list" {}))
+          (assert (= result.isError false) "list should not error")
+          (assert (= (length result.content) 1) "should have one content item")
+          (assert (= (. result.content 1 :type) "text") "content should be text")
+          (local text (. result.content 1 :text))
+          (assert (not= text nil) "content text should not be nil")
+          (assert (> (# text) 0) "content text should not be empty")
+          (local parsed (json.loads text))
+          (assert (= (type parsed) "table") "should parse as a table")
+          (assert (>= (length parsed) 1) "should have at least one unit in list"))))))
+
+(table.insert tests {:name "external-unit-mcp: tool calls return JSON service responses"
+                     :fn test-tool-calls-return-json-service-responses})
+
+(fn test-write-tool-errors-propagate-as-mcp-tool-errors []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit)
+          ;; Also register a unit without filesystem backing (unknown loader)
+          (local orphan-unit (Units.Unit {:id "orphan"
+                                           :source :user
+                                           :load (fn [_] true)
+                                           :unload (fn [_] true)}))
+          (mgr:register orphan-unit))
+        (fn [_mgr service]
+          (local registry (ExternalUnitMcpTools.make-tool-registry {:app {}}))
+          (ExternalUnitMcpTools.register-tools registry service)
+          ;; Calling create-source on a flat unit should error
+          (local result (registry:call "space_unit_create_source"
+                                        {:unit_id "user-bubble-overlay"
+                                         :source_id "new.fnl"
+                                         :source "(fn init [] true)\n(fn drop [] true)\n{:init init :drop drop}"}))
+          (assert (= result.isError true) "write tool on unsupported loader should return isError == true")
+          (assert (= (length result.content) 1) "error should have one content item")
+          (assert (= (. result.content 1 :type) "text") "error content should be text")
+          (assert (string.find (. result.content 1 :text) "create" 1 true)
+                  (.. "error should mention the write operation, got: " (. result.content 1 :text))))))))
+
+(table.insert tests {:name "external-unit-mcp: write tool errors propagate as MCP tool errors"
+                     :fn test-write-tool-errors-propagate-as-mcp-tool-errors})
+
 (local main
   (fn []
     (local runner (require :tests/runner))

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -19,12 +19,18 @@
       result
       (error result)))
 
-(fn with-service [dir mgr-populate f]
+(fn with-service* [dir mgr-populate service-opts f]
   (local mgr (UnitManager {}))
   (mgr-populate mgr dir)
-  (local service (ExternalUnitService.ExternalUnitService {:app {:unit-manager mgr}}))
+  (local full-opts {:app {:unit-manager mgr}})
+  (each [k v (pairs (or service-opts {}))]
+    (tset full-opts k v))
+  (local service (ExternalUnitService.ExternalUnitService full-opts))
   (f mgr service)
   (mgr:clear))
+
+(fn with-service [dir mgr-populate f]
+  (with-service* dir mgr-populate {} f))
 
 ;; ── Helpers ──
 
@@ -867,7 +873,51 @@
                   "unsupported snapshot should have nil state"))))))
 
 (table.insert tests {:name "external-unit-mcp: snapshot returns unsupported for filesystem unit without snapshot export"
-                     :fn test-snapshot-returns-unsupported-for-filesystem-unit-without-snapshot})
+                      :fn test-snapshot-returns-unsupported-for-filesystem-unit-without-snapshot})
+
+(fn test-snapshot-supports-module-unit-with-default-snapshot-export []
+  ;; R1-3: A ModuleUnit constructed without explicit :snapshot-export but
+  ;; whose module exports a default "snapshot" function must report
+  ;; supported=true and return the snapshot state — i.e. the unit must
+  ;; still be called even when :snapshot-export was not explicitly set.
+  (with-temp-dir
+    (fn [dir]
+      (local default-snap-path (write-unit-file dir "default-snapshot"
+                                  (.. "(fn init [] true)\n"
+                                      "(fn drop [] true)\n"
+                                      "(fn snapshot [] {:items [1 2 3] :version 1})\n"
+                                      "{:init init :drop drop :snapshot snapshot}")))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          ;; Construct ModuleUnit WITHOUT :snapshot-export — defaults to "snapshot"
+          (local unit (Units.ModuleUnit
+                        {:id "user-default-snap"
+                         :module-name "default-snapshot"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [default-snap-path]}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          (local result (service:snapshot {:unit_id "user-default-snap"}))
+          (assert result.unit-id "snapshot missing unit-id")
+          (assert (= result.unit-id "user-default-snap") "unit-id mismatch")
+          (assert (= result.supported true)
+                  (.. "module with default snapshot export should be supported, got "
+                      (tostring result.supported)))
+          (assert (not= result.state nil)
+                  "module with default snapshot export should have non-nil state")
+          (assert (= (type result.state) "table")
+                  (.. "state should be a table, got " (type result.state)))
+          (assert (= result.state.version 1)
+                  (.. "state.version should be 1, got " (tostring result.state.version)))
+          (assert (= (length result.state.items) 3)
+                  "state.items should have 3 items"))))))
+
+(table.insert tests {:name "external-unit-mcp: snapshot supports ModuleUnit with default snapshot export"
+                      :fn test-snapshot-supports-module-unit-with-default-snapshot-export})
+
 
 (fn test-snapshot-propagates-error-from-real-snapshot-implementation []
   ;; R1-3: a filesystem unit with an actual snapshot function that throws
@@ -906,18 +956,20 @@
   ;; read-log returns structured lines, total-lines, and log-path.
   ;; R1-4: uses an isolated controlled log fixture with a known exact
   ;; newline-terminated line count instead of the live application log.
+  ;; The controlled fixture is injected via ExternalUnitService opts
+  ;; (:log_path), not via a public args.log_path on read-log itself.
   (with-temp-dir
     (fn [dir]
-      (with-service dir
+      ;; Create a controlled log fixture with exactly 5 lines
+      ;; and a trailing newline (newline-terminated).
+      (local fixture-path (fs.join-path dir "controlled.log"))
+      (local fixture-content "alpha\nbeta\ngamma\ndelta\nepsilon\n")
+      (fs.write-file fixture-path fixture-content)
+      (with-service* dir
         (fn [mgr _dir] nil)  ;; no units needed
+        {:log_path fixture-path}
         (fn [_mgr service]
-          ;; Create a controlled log fixture with exactly 5 lines
-          ;; and a trailing newline (newline-terminated).
-          (local fixture-path (fs.join-path dir "controlled.log"))
-          (local fixture-content "alpha\nbeta\ngamma\ndelta\nepsilon\n")
-          (fs.write-file fixture-path fixture-content)
-          ;; Read the controlled fixture via the :log_path seam
-          (local result (service:read-log {:log_path fixture-path}))
+          (local result (service:read-log {}))
           (assert result.lines "read-log missing lines")
           (assert (= (type result.lines) "table") "lines should be a table")
           ;; total-lines must exactly match the known fixture count (5)
@@ -937,7 +989,7 @@
             (assert (= line (. expected i))
                     (.. "line " i " mismatch: " line " vs " (. expected i))))
           ;; grep filtering: only lines containing "ta" (beta, delta)
-          (local filtered (service:read-log {:log_path fixture-path :grep "ta"}))
+          (local filtered (service:read-log {:grep "ta"}))
           (assert (= (length filtered.lines) 2)
                   (.. "grep for 'ta' should find 2 lines, got " (length filtered.lines)))
           (assert (= filtered.total-lines 5) "total-lines should still be 5")

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -903,59 +903,48 @@
                      :fn test-snapshot-propagates-error-from-real-snapshot-implementation})
 
 (fn test-read-log-returns-filtered-recent-lines []
-  ;; read-log should work against the current application log file.
-  ;; It returns structured lines, total-lines, and log-path.
-  ;; R1-4: total-lines is verified against a controlled fixture:
-  ;; we write exactly 3 known lines with a unique run marker, grep for
-  ;; them to confirm they exist, then independently read the raw log file
-  ;; and assert total-lines matches the actual normalized line count.
+  ;; read-log returns structured lines, total-lines, and log-path.
+  ;; R1-4: uses an isolated controlled log fixture with a known exact
+  ;; newline-terminated line count instead of the live application log.
   (with-temp-dir
     (fn [dir]
       (with-service dir
         (fn [mgr _dir] nil)  ;; no units needed
         (fn [_mgr service]
-          (local logging (require :logging))
-          ;; Generate a unique marker so previous test runs don't accumulate
-          (local marker (.. "R1-4-FIX-" (tostring (os.time)) "-" (tostring (math.random 1000000 9999999))))
-          ;; Write exactly 3 controlled fixture lines
-          (logging.info (.. marker "-LINE-1"))
-          (logging.info (.. marker "-LINE-2"))
-          (logging.info (.. marker "-LINE-3"))
-          (logging.flush)
-          (local result (service:read-log {:lines 500 :grep marker}))
-          ;; The 3 fixture lines just written must be found
-          (assert (= (length result.lines) 3)
-                  (.. "grep for unique marker should find exactly 3 lines, got "
-                      (length result.lines)))
+          ;; Create a controlled log fixture with exactly 5 lines
+          ;; and a trailing newline (newline-terminated).
+          (local fixture-path (fs.join-path dir "controlled.log"))
+          (local fixture-content "alpha\nbeta\ngamma\ndelta\nepsilon\n")
+          (fs.write-file fixture-path fixture-content)
+          ;; Read the controlled fixture via the :log_path seam
+          (local result (service:read-log {:log_path fixture-path}))
+          (assert result.lines "read-log missing lines")
+          (assert (= (type result.lines) "table") "lines should be a table")
+          ;; total-lines must exactly match the known fixture count (5)
           (assert result.total-lines "read-log missing total-lines")
           (assert (= (type result.total-lines) "number")
                   "total-lines should be a number")
-          (assert (>= result.total-lines 3)
-                  "total-lines should be at least 3")
+          (assert (= result.total-lines 5)
+                  (.. "total-lines should be 5 for 5-line newline-terminated fixture, got "
+                      result.total-lines))
           (assert result.log-path "read-log missing log-path")
-          ;; Independently verify total-lines by reading the raw log file
-          ;; and applying the same normalization logic.
-          (local log-content (fs.read-file result.log-path))
-          (assert log-content "should be able to read log file")
-          (var raw-lines [])
-          (each [line (string.gmatch log-content "([^\n]*)\n?")]
-            (table.insert raw-lines line))
-          ;; Drop trailing empty string from final \n (same logic as read-log)
-          (when (and (> (# raw-lines) 0) (= (. raw-lines (# raw-lines)) ""))
-            (table.remove raw-lines))
-          (local expected-total (# raw-lines))
-          (assert (= result.total-lines expected-total)
-                  (.. "total-lines " result.total-lines
-                      " does not match raw line count " expected-total
-                      " — trailing empty entry may not be normalized"))
-          ;; Verify no returned line number exceeds total-lines
-          (each [_ line (ipairs result.lines)]
-            (local (line-num-str) (string.match line "^(%d+):"))
-            (when line-num-str
-              (local line-num (tonumber line-num-str))
-              (assert (<= line-num result.total-lines)
-                      (.. "line number " line-num " exceeds total-lines "
-                          result.total-lines)))))))))
+          (assert (= result.log-path fixture-path) "log-path should match fixture path")
+          ;; Verify all 5 lines are present and line numbers are correct
+          (assert (= (length result.lines) 5)
+                  (.. "expected 5 lines, got " (length result.lines)))
+          (local expected ["1: alpha" "2: beta" "3: gamma" "4: delta" "5: epsilon"])
+          (each [i line (ipairs result.lines)]
+            (assert (= line (. expected i))
+                    (.. "line " i " mismatch: " line " vs " (. expected i))))
+          ;; grep filtering: only lines containing "ta" (beta, delta)
+          (local filtered (service:read-log {:log_path fixture-path :grep "ta"}))
+          (assert (= (length filtered.lines) 2)
+                  (.. "grep for 'ta' should find 2 lines, got " (length filtered.lines)))
+          (assert (= filtered.total-lines 5) "total-lines should still be 5")
+          (assert (= (. filtered.lines 1) "2: beta")
+                  (.. "first grep hit: " (. filtered.lines 1)))
+          (assert (= (. filtered.lines 2) "4: delta")
+                  (.. "second grep hit: " (. filtered.lines 2))))))))
 
 (table.insert tests {:name "external-unit-mcp: read-log returns filtered recent lines"
                      :fn test-read-log-returns-filtered-recent-lines})

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -4,6 +4,7 @@
 (local tests [])
 (local fs (require :fs))
 (local fennel (require :fennel))
+(local logging (require :logging))
 (local Units (require :units))
 (local UnitManager (require :unit-manager))
 (local tempfile (require :tempfile))
@@ -1224,11 +1225,20 @@
         (fn [_mgr service]
           (local registry (ExternalUnitMcpTools.make-tool-registry {:app {}}))
           (ExternalUnitMcpTools.register-tools registry service)
-          ;; Calling create-source on a flat unit should error
+          ;; Calling create-source on a flat unit should error.
+          ;; Temporarily stub logging.error to capture the expected failure
+          ;; without polluting test output.
+          (local orig-error logging.error)
+          (local captured-errors [])
+          (set logging.error (fn [msg] (table.insert captured-errors msg)))
           (local result (registry:call "space_unit_create_source"
                                         {:unit_id "user-bubble-overlay"
                                          :source_id "new.fnl"
                                          :source "(fn init [] true)\n(fn drop [] true)\n{:init init :drop drop}"}))
+          (set logging.error orig-error)
+          (assert (= (# captured-errors) 1) "expected one tool error to be captured")
+          (assert (string.find (. captured-errors 1) "create-source" 1 true)
+                  "captured error should mention create-source")
           (assert (= result.isError true) "write tool on unsupported loader should return isError == true")
           (assert (= (length result.content) 1) "error should have one content item")
           (assert (= (. result.content 1 :type) "text") "error content should be text")

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -815,6 +815,28 @@
 (table.insert tests {:name "external-unit-mcp: snapshot returns unit state with capability metadata"
                      :fn test-snapshot-returns-unit-state-with-capability-metadata})
 
+(fn test-snapshot-returns-unsupported-for-unknown-loader []
+  ;; R1-3: Unknown loaders must return supported=false, not an error.
+  (with-temp-dir
+    (fn [dir]
+      (with-service dir
+        (fn [mgr _dir]
+          ;; Register a unit with no owned paths (unknown loader)
+          (local orphan-unit (Units.Unit {:id "orphan"
+                                           :source :user
+                                           :load (fn [_] true)
+                                           :unload (fn [_] true)}))
+          (mgr:register orphan-unit))
+        (fn [_mgr service]
+          (local result (service:snapshot {:unit_id "orphan"}))
+          (assert result.unit-id "snapshot missing unit-id")
+          (assert (= result.unit-id "orphan") "unit-id mismatch")
+          (assert (= result.supported false) "unknown loader should report snapshot unsupported")
+          (assert (= result.state nil) "unsupported snapshot should have nil state"))))))
+
+(table.insert tests {:name "external-unit-mcp: snapshot returns unsupported for unknown loader"
+                     :fn test-snapshot-returns-unsupported-for-unknown-loader})
+
 (fn test-read-log-returns-filtered-recent-lines []
   ;; read-log should work against the current application log file.
   ;; It returns structured lines, total-lines, and log-path.
@@ -833,8 +855,18 @@
           (assert result.total-lines "read-log missing total-lines")
           (assert (= (type result.total-lines) "number") "total-lines should be a number")
           (assert (>= result.total-lines 0) "total-lines should be non-negative")
+          (assert (> result.total-lines 0) "total-lines should be positive with log content")
           (assert result.log-path "read-log missing log-path")
           (assert (= (type result.log-path) "string") "log-path should be a string")
+          ;; R1-4: total-lines must match the actual line count, not include a
+          ;; trailing empty entry from a final newline.
+          (each [_ line (ipairs result.lines)]
+            (local (line-num-str) (string.match line "^(%d+):"))
+            (local line-num (tonumber line-num-str))
+            (assert line-num (.. "line should be prefixed with number: " line))
+            (assert (<= line-num result.total-lines)
+                    (.. "line number " line-num " exceeds total-lines " result.total-lines
+                        " — total-lines likely includes a trailing empty entry")))
           ;; Verify grep filtering
           (local grep-result (service:read-log {:lines 200 :grep "TEST-MARKER-READ-LOG"}))
           (assert (> (length grep-result.lines) 0)
@@ -849,7 +881,10 @@
 (fn test-run-tests-executes-unit-test-module []
   (with-temp-dir
     (fn [dir]
-      ;; Create a directory-based unit with a test module
+      ;; Create a directory-based unit with a test module at the standard location:
+      ;; <unit-dir>/test-init.fnl (not nested under the module name).
+      ;; get-unit-fennel-root returns the parent of unit-dir, so Fennel path
+      ;; <parent>/?.fnl resolves module run-tests-unit.test-init to <unit-dir>/test-init.fnl.
       (local unit-dir (fs.join-path dir "run-tests-unit"))
       (fs.create-dirs unit-dir)
       (local init-path (fs.join-path unit-dir "init.fnl"))
@@ -857,10 +892,8 @@
         (.. "(fn init [] true)\n"
             "(fn drop [] true)\n"
             "{:init init :drop drop}"))
-      ;; Create the test module: run-tests-unit/test-init.fnl
-      (local test-dir (fs.join-path unit-dir "run-tests-unit"))
-      (fs.create-dirs test-dir)
-      (local test-path (fs.join-path test-dir "test-init.fnl"))
+      ;; Create the test module at the standard location: unit-dir/test-init.fnl
+      (local test-path (fs.join-path unit-dir "test-init.fnl"))
       (fs.write-file test-path
         (.. "(fn main []\n"
             "  (print \"ALL TESTS PASSED\")\n"
@@ -869,8 +902,9 @@
             "{:main main :tests tests}"))
       (with-service dir
         (fn [mgr _dir]
-          (local fennel-paths (.. unit-dir "/?.fnl;" unit-dir "/?/init.fnl;"
-                                  dir "/?.fnl;" dir "/?/init.fnl"))
+          ;; Fennel path must include the parent directory (dir) so that
+          ;; module run-tests-unit.test-init resolves to dir/run-tests-unit/test-init.fnl
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
           (local unit (Units.ModuleUnit
                         {:id "user-run-tests-unit"
                          :module-name "run-tests-unit"
@@ -895,6 +929,28 @@
 
 (table.insert tests {:name "external-unit-mcp: run-tests executes unit test module"
                      :fn test-run-tests-executes-unit-test-module})
+
+(fn test-run-tests-rejects-unknown-loader []
+  ;; R1-2: run-tests must fail loudly when the loader lacks run-test capability.
+  (with-temp-dir
+    (fn [dir]
+      (with-service dir
+        (fn [mgr _dir]
+          ;; Register an unknown-loader unit (no owned paths)
+          (local orphan-unit (Units.Unit {:id "orphan"
+                                           :source :user
+                                           :load (fn [_] true)
+                                           :unload (fn [_] true)}))
+          (mgr:register orphan-unit))
+        (fn [_mgr service]
+          (local (ok err) (pcall #(service:run-tests {:unit_id "orphan"})))
+          (assert (not ok) "should reject run-tests for unknown loader")
+          (assert (or (string.find (or err "") "does not support" 1 true)
+                      (string.find (or err "") "test execution" 1 true))
+                  (.. "error should mention lack of test support, got: " (or err ""))))))))
+
+(table.insert tests {:name "external-unit-mcp: run-tests rejects unknown loader without run-test capability"
+                     :fn test-run-tests-rejects-unknown-loader})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -869,30 +869,72 @@
 (table.insert tests {:name "external-unit-mcp: snapshot returns unsupported for filesystem unit without snapshot export"
                      :fn test-snapshot-returns-unsupported-for-filesystem-unit-without-snapshot})
 
+(fn test-snapshot-propagates-error-from-real-snapshot-implementation []
+  ;; R1-3: a filesystem unit with an actual snapshot function that throws
+  ;; an error containing "missing function" must propagate that error,
+  ;; not silently return supported=false.
+  (with-temp-dir
+    (fn [dir]
+      (local thrower-path (write-unit-file dir "snapshot-thrower"
+                             (.. "(fn init [] true)\n"
+                                 "(fn drop [] true)\n"
+                                 "(fn snapshot []\n"
+                                 "  (error \"missing function foo in snapshot\"))\n"
+                                 "{:init init :drop drop :snapshot snapshot}")))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local unit (Units.ModuleUnit
+                        {:id "user-snapshot-thrower"
+                         :module-name "snapshot-thrower"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [thrower-path]
+                         :snapshot-export "snapshot"}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          (local (ok err) (pcall #(service:snapshot {:unit_id "user-snapshot-thrower"})))
+          (assert (not ok) "should propagate error from real snapshot implementation")
+          (assert (string.find (or err "") "missing function foo" 1 true)
+                  (.. "error should contain the snapshot function's message, got: " (or err ""))))))))
+
+(table.insert tests {:name "external-unit-mcp: snapshot propagates error from real snapshot implementation"
+                     :fn test-snapshot-propagates-error-from-real-snapshot-implementation})
+
 (fn test-read-log-returns-filtered-recent-lines []
   ;; read-log should work against the current application log file.
   ;; It returns structured lines, total-lines, and log-path.
+  ;; R1-4: total-lines is verified against a controlled fixture:
+  ;; we write exactly 3 known lines with a unique run marker, grep for
+  ;; them to confirm they exist, then independently read the raw log file
+  ;; and assert total-lines matches the actual normalized line count.
   (with-temp-dir
     (fn [dir]
       (with-service dir
         (fn [mgr _dir] nil)  ;; no units needed
         (fn [_mgr service]
           (local logging (require :logging))
-          ;; Write a distinctive log marker so we can find it
-          (logging.info "TEST-MARKER-READ-LOG: hello from external-unit-mcp test")
+          ;; Generate a unique marker so previous test runs don't accumulate
+          (local marker (.. "R1-4-FIX-" (tostring (os.time)) "-" (tostring (math.random 1000000 9999999))))
+          ;; Write exactly 3 controlled fixture lines
+          (logging.info (.. marker "-LINE-1"))
+          (logging.info (.. marker "-LINE-2"))
+          (logging.info (.. marker "-LINE-3"))
           (logging.flush)
-          (local result (service:read-log {:lines 50}))
-          (assert result.lines "read-log missing lines")
-          (assert (= (type result.lines) "table") "lines should be a table")
+          (local result (service:read-log {:lines 500 :grep marker}))
+          ;; The 3 fixture lines just written must be found
+          (assert (= (length result.lines) 3)
+                  (.. "grep for unique marker should find exactly 3 lines, got "
+                      (length result.lines)))
           (assert result.total-lines "read-log missing total-lines")
-          (assert (= (type result.total-lines) "number") "total-lines should be a number")
-          (assert (>= result.total-lines 0) "total-lines should be non-negative")
-          (assert (> result.total-lines 0) "total-lines should be positive with log content")
+          (assert (= (type result.total-lines) "number")
+                  "total-lines should be a number")
+          (assert (>= result.total-lines 3)
+                  "total-lines should be at least 3")
           (assert result.log-path "read-log missing log-path")
-          (assert (= (type result.log-path) "string") "log-path should be a string")
-          ;; R1-4: total-lines must match the actual line count, not include a
-          ;; trailing empty entry from a final newline. Verify independently
-          ;; by reading the raw log file and computing the expected count.
+          ;; Independently verify total-lines by reading the raw log file
+          ;; and applying the same normalization logic.
           (local log-content (fs.read-file result.log-path))
           (assert log-content "should be able to read log file")
           (var raw-lines [])
@@ -905,22 +947,15 @@
           (assert (= result.total-lines expected-total)
                   (.. "total-lines " result.total-lines
                       " does not match raw line count " expected-total
-                      " — total-lines likely includes a trailing empty entry"))
-          ;; Also verify no returned line number exceeds total-lines
+                      " — trailing empty entry may not be normalized"))
+          ;; Verify no returned line number exceeds total-lines
           (each [_ line (ipairs result.lines)]
             (local (line-num-str) (string.match line "^(%d+):"))
-            (local line-num (tonumber line-num-str))
-            (assert line-num (.. "line should be prefixed with number: " line))
-            (assert (<= line-num result.total-lines)
-                    (.. "line number " line-num " exceeds total-lines " result.total-lines
-                        " — total-lines likely includes a trailing empty entry")))
-          ;; Verify grep filtering
-          (local grep-result (service:read-log {:lines 200 :grep "TEST-MARKER-READ-LOG"}))
-          (assert (> (length grep-result.lines) 0)
-                  "grep should find the marker line")
-          (each [_ line (ipairs grep-result.lines)]
-            (assert (string.find line "TEST-MARKER-READ-LOG" 1 true)
-                    (.. "grep-filtered line should contain marker: " line))))))))
+            (when line-num-str
+              (local line-num (tonumber line-num-str))
+              (assert (<= line-num result.total-lines)
+                      (.. "line number " line-num " exceeds total-lines "
+                          result.total-lines)))))))))
 
 (table.insert tests {:name "external-unit-mcp: read-log returns filtered recent lines"
                      :fn test-read-log-returns-filtered-recent-lines})

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -729,6 +729,61 @@
 (table.insert tests {:name "external-unit-mcp: read-source rejects path escape via .."
                      :fn test-read-source-rejects-path-escape})
 
+(fn test-create-source-rejects-symlinked-ancestor []
+  ;; Create a directory unit, place a symlinked directory inside it pointing
+  ;; outside the unit root, then attempt create-source through the symlink.
+  ;; This verifies the safe resolver is used for create-source as well.
+  (with-temp-dir
+    (fn [dir]
+      (local unit-dir (fs.join-path dir "dir-unit"))
+      (fs.create-dirs unit-dir)
+      (local init-path (fs.join-path unit-dir "init.fnl"))
+      (fs.write-file init-path
+        (.. "(fn init [] true)\n"
+            "(fn drop [] true)\n"
+            "{:init init :drop drop}"))
+      ;; Create a directory outside the unit root
+      (local outside-dir (fs.join-path dir "outside"))
+      (fs.create-dirs outside-dir)
+      ;; Create a symlink inside the unit dir pointing outside
+      (local symlink-path (fs.join-path unit-dir "escape-hatch"))
+      (local Process (require :process))
+      (local symlink-result (Process.run {:args ["ln" "-s" outside-dir symlink-path]
+                                         :merge-stderr true}))
+      (assert (= symlink-result.exit-code 0)
+              (.. "symlink creation failed: " (or symlink-result.stderr symlink-result.stdout)))
+      ;; Verify the symlink was created
+      (local symlink-stat (fs.stat symlink-path))
+      (assert symlink-stat.is-symlink "expected symlink")
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. unit-dir "/?.fnl;" unit-dir "/?/init.fnl;" dir "/?.fnl;" dir "/?/init.fnl"))
+          (local unit (Units.ModuleUnit
+                        {:id "user-dir-unit"
+                         :module-name "dir-unit"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [unit-dir init-path]}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          ;; Attempt create-source through the symlinked directory
+          (local (ok err) (pcall #(service:create-source
+                                    {:unit_id "user-dir-unit"
+                                     :source_id "escape-hatch/evil.fnl"
+                                     :source "(fn init [] true)\n(fn drop [] true)\n{:init init :drop drop}"})))
+          (assert (not ok) "should reject create through symlinked ancestor")
+          (assert (or (string.find (or err "") "symlink" 1 true)
+                      (string.find (or err "") "escape" 1 true))
+                  (.. "error should mention symlink or path issue, got: " (or err "")))
+          ;; Verify no file was created through the symlink
+          (local escaped-path (fs.join-path outside-dir "evil.fnl"))
+          (assert (not (fs.exists escaped-path))
+                  "file must not be created outside unit root"))))))
+
+(table.insert tests {:name "external-unit-mcp: create-source rejects symlinked ancestor directory"
+                     :fn test-create-source-rejects-symlinked-ancestor})
+
 (local main
   (fn []
     (local runner (require :tests/runner))

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -102,7 +102,9 @@
           (assert bubble-handle.source-handle.primary "source-handle should be primary")
           (assert (> bubble-handle.source-handle.size 0) "source-handle size should be > 0")
           (assert (= (type bubble-handle.source-handle.hash) "string") "source-handle hash should be string")
-          (assert (> (# bubble-handle.source-handle.hash) 0) "source-handle hash should not be empty")
+          (assert (= (string.sub bubble-handle.source-handle.hash 1 7) "sha256:")
+                  "source-handle hash should be sha256: prefixed")
+          (assert (> (# bubble-handle.source-handle.hash) 7) "source-handle hash should contain digest")
           ;; Unknown unit (builtin has no owned paths)
           (assert (= builtin-handle.loader "unknown")
                   (.. "expected unknown loader, got " builtin-handle.loader))
@@ -284,6 +286,109 @@
 
 (table.insert tests {:name "external-unit-mcp: list returns deterministic ordering"
                      :fn test-list-returns-deterministic-ordering})
+
+(fn test-resolve-rejects-negative-limit []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local (ok err) (pcall #(service:resolve {:description "unit" :limit -1})))
+          (assert (not ok) "should reject negative limit")
+          (assert (string.find err "limit" 1 true)
+                  "error should mention limit"))))))
+
+(table.insert tests {:name "external-unit-mcp: resolve rejects negative limit"
+                     :fn test-resolve-rejects-negative-limit})
+
+(fn test-resolve-rejects-non-integer-limit []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local (ok err) (pcall #(service:resolve {:description "unit" :limit 1.5})))
+          (assert (not ok) "should reject non-integer limit")
+          (assert (string.find err "integer" 1 true)
+                  "error should mention integer"))))))
+
+(table.insert tests {:name "external-unit-mcp: resolve rejects non-integer limit"
+                     :fn test-resolve-rejects-non-integer-limit})
+
+(fn test-resolve-accepts-nil-limit []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          ;; nil limit should default to 20 — this must complete without error
+          (local result (service:resolve {:description "unit"}))
+          (assert result.candidates "nil limit should default and return candidates"))))))
+
+(table.insert tests {:name "external-unit-mcp: resolve accepts nil limit (defaults to 20)"
+                     :fn test-resolve-accepts-nil-limit})
+
+(fn test-source-artifacts-have-sha256-prefix []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local result (service:inspect {:unit_id "user-bubble-overlay"}))
+          ;; Source handle hash must have sha256: prefix
+          (assert (and result.source-handle result.source-handle.hash)
+                  "source-handle should have a hash")
+          (assert (= (string.sub result.source-handle.hash 1 7) "sha256:")
+                  "source-handle hash must be sha256: prefixed")
+          ;; Source artifacts must have sha256: prefix
+          (each [_ art (ipairs result.source-artifacts)]
+            (assert art.hash "artifact missing hash")
+            (assert (= (string.sub art.hash 1 7) "sha256:")
+                    (.. "artifact " art.source-id " hash must be sha256: prefixed, got "
+                        (string.sub (or art.hash "") 1 20)))))))))
+
+(table.insert tests {:name "external-unit-mcp: source artifacts have sha256: prefix"
+                     :fn test-source-artifacts-have-sha256-prefix})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -784,6 +784,118 @@
 (table.insert tests {:name "external-unit-mcp: create-source rejects symlinked ancestor directory"
                      :fn test-create-source-rejects-symlinked-ancestor})
 
+;; ── Task 3: External Unit Test, Log, and Snapshot Operations ──
+
+(fn test-snapshot-returns-unit-state-with-capability-metadata []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]
+                                :snapshot-export "snapshot"}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          (local result (service:snapshot {:unit_id "user-bubble-overlay"}))
+          (assert result.unit-id "snapshot missing unit-id")
+          (assert (= result.unit-id "user-bubble-overlay") "unit-id mismatch")
+          (assert (= result.supported true) "snapshot should be supported")
+          (assert (not= result.state nil) "snapshot state should not be nil for unit with snapshot export")
+          ;; The bubble unit's snapshot returns whether bubble was loaded
+          (assert (= (type result.state) "boolean")
+                  (.. "state should be boolean, got " (type result.state))))))))
+
+(table.insert tests {:name "external-unit-mcp: snapshot returns unit state with capability metadata"
+                     :fn test-snapshot-returns-unit-state-with-capability-metadata})
+
+(fn test-read-log-returns-filtered-recent-lines []
+  ;; read-log should work against the current application log file.
+  ;; It returns structured lines, total-lines, and log-path.
+  (with-temp-dir
+    (fn [dir]
+      (with-service dir
+        (fn [mgr _dir] nil)  ;; no units needed
+        (fn [_mgr service]
+          (local logging (require :logging))
+          ;; Write a distinctive log marker so we can find it
+          (logging.info "TEST-MARKER-READ-LOG: hello from external-unit-mcp test")
+          (logging.flush)
+          (local result (service:read-log {:lines 50}))
+          (assert result.lines "read-log missing lines")
+          (assert (= (type result.lines) "table") "lines should be a table")
+          (assert result.total-lines "read-log missing total-lines")
+          (assert (= (type result.total-lines) "number") "total-lines should be a number")
+          (assert (>= result.total-lines 0) "total-lines should be non-negative")
+          (assert result.log-path "read-log missing log-path")
+          (assert (= (type result.log-path) "string") "log-path should be a string")
+          ;; Verify grep filtering
+          (local grep-result (service:read-log {:lines 200 :grep "TEST-MARKER-READ-LOG"}))
+          (assert (> (length grep-result.lines) 0)
+                  "grep should find the marker line")
+          (each [_ line (ipairs grep-result.lines)]
+            (assert (string.find line "TEST-MARKER-READ-LOG" 1 true)
+                    (.. "grep-filtered line should contain marker: " line))))))))
+
+(table.insert tests {:name "external-unit-mcp: read-log returns filtered recent lines"
+                     :fn test-read-log-returns-filtered-recent-lines})
+
+(fn test-run-tests-executes-unit-test-module []
+  (with-temp-dir
+    (fn [dir]
+      ;; Create a directory-based unit with a test module
+      (local unit-dir (fs.join-path dir "run-tests-unit"))
+      (fs.create-dirs unit-dir)
+      (local init-path (fs.join-path unit-dir "init.fnl"))
+      (fs.write-file init-path
+        (.. "(fn init [] true)\n"
+            "(fn drop [] true)\n"
+            "{:init init :drop drop}"))
+      ;; Create the test module: run-tests-unit/test-init.fnl
+      (local test-dir (fs.join-path unit-dir "run-tests-unit"))
+      (fs.create-dirs test-dir)
+      (local test-path (fs.join-path test-dir "test-init.fnl"))
+      (fs.write-file test-path
+        (.. "(fn main []\n"
+            "  (print \"ALL TESTS PASSED\")\n"
+            "  (print \"1/1 passing\"))\n"
+            "(fn tests [])\n"
+            "{:main main :tests tests}"))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. unit-dir "/?.fnl;" unit-dir "/?/init.fnl;"
+                                  dir "/?.fnl;" dir "/?/init.fnl"))
+          (local unit (Units.ModuleUnit
+                        {:id "user-run-tests-unit"
+                         :module-name "run-tests-unit"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [unit-dir init-path]}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          (local result (service:run-tests {:unit_id "user-run-tests-unit"
+                                             :test_name "init"}))
+          (assert (= result.passed true) "tests should pass")
+          (assert (= result.exit-code 0)
+                  (.. "exit-code should be 0, got " result.exit-code
+                      " stdout: " (or result.stdout "")
+                      " stderr: " (or result.stderr "")))
+          (assert result.stdout "run-tests missing stdout")
+          (assert (or (string.find result.stdout "PASS" 1 true)
+                      (string.find result.stdout "passing" 1 true)
+                      (string.find result.stdout "ALL TESTS" 1 true))
+                  (.. "stdout should contain success indicator: " result.stdout)))))))
+
+(table.insert tests {:name "external-unit-mcp: run-tests executes unit test module"
+                     :fn test-run-tests-executes-unit-test-module})
+
 (local main
   (fn []
     (local runner (require :tests/runner))

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -229,12 +229,26 @@
         (fn [mgr service]
           (local user-unit (mgr:get "user-bubble-overlay"))
           (local orphan-unit (mgr:get "orphan"))
-          ;; Filesystem handle
+          ;; Flat filesystem handle: should have read/write/delete but NOT create
           (local handle (service:unit-handle user-unit))
           (assert (= handle.loader "filesystem") "filesystem unit should have filesystem loader")
           (assert handle.source-handle "filesystem unit should have source-handle")
           (assert (> (length handle.edit-capabilities) 0)
-                  "filesystem unit should have edit capabilities")
+                  "flat filesystem unit should have edit capabilities")
+          ;; Flat unit must not advertise create
+          (var has-create false)
+          (each [_ cap (ipairs handle.edit-capabilities)]
+            (when (= cap "create")
+              (set has-create true)))
+          (assert (not has-create) "flat unit should not advertise create capability")
+          ;; Flat unit must have read and write
+          (var has-read false)
+          (var has-write false)
+          (each [_ cap (ipairs handle.edit-capabilities)]
+            (when (= cap "read") (set has-read true))
+            (when (= cap "write") (set has-write true)))
+          (assert has-read "flat unit should have read capability")
+          (assert has-write "flat unit should have write capability")
           ;; Orphan handle (user source but no owned paths => unknown loader)
           (local orphan-handle (service:unit-handle orphan-unit))
           (assert (= orphan-handle.loader "unknown")
@@ -568,8 +582,7 @@
           (local result (service:create-source
                           {:unit_id "user-dir-unit"
                            :source_id "helper.fnl"
-                           :source new-source
-                           :expected_absent true}))
+                           :source new-source}))
           (assert result.unit-id "create-source missing unit_id")
           (assert (= result.unit-id "user-dir-unit") "unit_id mismatch")
           (assert result.source-id "create-source missing source_id")
@@ -613,6 +626,108 @@
 
 (table.insert tests {:name "external-unit-mcp: create-source fails loudly for flat unit without create capability"
                      :fn test-create-source-fails-for-flat-unit})
+
+;; ── Fix round 1: R1-1, R1-2, R1-3 ──
+
+(fn test-directory-unit-has-create-capability []
+  (with-temp-dir
+    (fn [dir]
+      (local unit-dir (fs.join-path dir "dir-unit"))
+      (fs.create-dirs unit-dir)
+      (local init-path (fs.join-path unit-dir "init.fnl"))
+      (fs.write-file init-path
+        (.. "(fn init [] true)\n"
+            "(fn drop [] true)\n"
+            "{:init init :drop drop}"))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. unit-dir "/?.fnl;" unit-dir "/?/init.fnl;" dir "/?.fnl;" dir "/?/init.fnl"))
+          (local unit (Units.ModuleUnit
+                        {:id "user-dir-unit"
+                         :module-name "dir-unit"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [unit-dir init-path]}))
+          (mgr:register unit))
+        (fn [mgr service]
+          (local handle (service:unit-handle (mgr:get "user-dir-unit")))
+          ;; Directory unit must have create capability
+          (var has-create false)
+          (each [_ cap (ipairs handle.edit-capabilities)]
+            (when (= cap "create")
+              (set has-create true)))
+          (assert has-create "directory unit should advertise create capability"))))))
+
+(table.insert tests {:name "external-unit-mcp: directory unit has create capability"
+                     :fn test-directory-unit-has-create-capability})
+
+(fn test-create-source-rejects-existing-file []
+  (with-temp-dir
+    (fn [dir]
+      (local unit-dir (fs.join-path dir "dir-unit"))
+      (fs.create-dirs unit-dir)
+      (local init-path (fs.join-path unit-dir "init.fnl"))
+      (fs.write-file init-path
+        (.. "(fn init [] true)\n"
+            "(fn drop [] true)\n"
+            "{:init init :drop drop}"))
+      ;; Pre-create a file that create-source would try to create
+      (local existing-path (fs.join-path unit-dir "existing.fnl"))
+      (fs.write-file existing-path "(fn helper [] true)\n{:helper helper}")
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. unit-dir "/?.fnl;" unit-dir "/?/init.fnl;" dir "/?.fnl;" dir "/?/init.fnl"))
+          (local unit (Units.ModuleUnit
+                        {:id "user-dir-unit"
+                         :module-name "dir-unit"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [unit-dir init-path]}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          (local original-content (fs.read-file existing-path))
+          (local (ok err) (pcall #(service:create-source
+                                    {:unit_id "user-dir-unit"
+                                     :source_id "existing.fnl"
+                                     :source "(fn helper [] true)\n{:helper helper}"})))
+          (assert (not ok) "should reject create for existing file")
+          (assert (string.find (or err "") "already exists" 1 true)
+                  "error should mention already exists")
+          ;; Verify the existing file was NOT overwritten
+          (assert (= (fs.read-file existing-path) original-content)
+                  "existing file should remain unchanged"))))))
+
+(table.insert tests {:name "external-unit-mcp: create-source rejects existing file"
+                     :fn test-create-source-rejects-existing-file})
+
+(fn test-read-source-rejects-path-escape []
+  (with-temp-dir
+    (fn [dir]
+      (local bubble-path (write-bubble-unit dir))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local bubble-unit (Units.ModuleUnit
+                               {:id "user-bubble-overlay"
+                                :module-name "bubble-overlay"
+                                :module-paths fennel-paths
+                                :source :user
+                                :suppress-run-main? true
+                                :owned-paths [bubble-path]}))
+          (mgr:register bubble-unit))
+        (fn [_mgr service]
+          ;; Attempt to read via path with .. segment
+          (local (ok err) (pcall #(service:read-source
+                                    {:unit_id "user-bubble-overlay"
+                                     :source_id "../etc/passwd"})))
+          (assert (not ok) "should reject .. path segment")
+          (assert (string.find (or err "") ".." 1 true)
+                  "error should mention .."))))))
+
+(table.insert tests {:name "external-unit-mcp: read-source rejects path escape via .."
+                     :fn test-read-source-rejects-path-escape})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -1319,6 +1319,64 @@
 (table.insert tests {:name "external-unit-mcp: external tools carry explicit risk labels for write/test operations"
                      :fn test-external-tools-carry-explicit-risk-labels})
 
+;; ── Task 5: External Unit MCP Bridge ──
+
+(local ExternalUnitMcpBridge (require :llm/external-unit-mcp/bridge))
+
+(fn test-bridge-starts-loopback-server-and-writes-isolated-opencode-config []
+  (with-temp-dir
+    (fn [dir]
+      (local data-dir (fs.join-path dir "bridge-data"))
+      (fs.create-dirs data-dir)
+      ;; Create a minimal mock tool registry with a :list method for the bridge
+      (local mock-tools {:list (fn [] [])})
+      (local bridge (ExternalUnitMcpBridge.ExternalUnitMcpBridge
+                      {:tools mock-tools
+                       :data-dir data-dir}))
+      (bridge:start)
+      (local status (bridge:status))
+      ;; status fields
+      (assert (= status.started? true) "bridge should report started")
+      (assert (= status.host "127.0.0.1") "bridge should bind to loopback")
+      (assert (> status.port 0) "bridge should have a valid port")
+      ;; opencode-env
+      (local env (bridge:opencode-env))
+      (assert env.XDG_CONFIG_HOME "should have XDG_CONFIG_HOME")
+      (assert (= env.XDG_CONFIG_HOME status.config-root)
+              "XDG_CONFIG_HOME should match config-root from status")
+      ;; config-path is under data-dir, not under global ~/.config/opencode
+      (assert status.config-path "should have config-path")
+      (assert (= (string.sub status.config-path 1 (# data-dir)) data-dir)
+              "config-path should be under the provided temp data-dir, not global ~/.config/opencode")
+      ;; Check written config content
+      (local json (require :json))
+      (local raw (fs.read-file status.config-path))
+      (local config (json.loads raw))
+      ;; MCP config
+      (assert config.mcp "config should have mcp")
+      (assert config.mcp.space-unit-dev "config should have mcp.space-unit-dev")
+      (assert (= config.mcp.space-unit-dev.type "remote")
+              "MCP type should be remote")
+      (assert (= config.mcp.space-unit-dev.enabled true)
+              "MCP should be enabled")
+      (assert (= config.mcp.space-unit-dev.url status.url)
+              "MCP url should match status.url")
+      ;; Deny native OpenCode tools
+      (local perms config.permission)
+      (assert perms "config should have permission")
+      (assert (= perms.read "deny") "read should be denied")
+      (assert (= perms.write "deny") "write should be denied")
+      (assert (= perms.edit "deny") "edit should be denied")
+      (assert (= perms.grep "deny") "grep should be denied")
+      (assert (= perms.glob "deny") "glob should be denied")
+      (assert (= perms.list "deny") "list should be denied")
+      (assert (= perms.bash "deny") "bash should be denied")
+      ;; Clean up
+      (bridge:stop))))
+
+(table.insert tests {:name "external-unit-mcp: bridge starts loopback server and writes isolated opencode config"
+                     :fn test-bridge-starts-loopback-server-and-writes-isolated-opencode-config})
+
 (local main
   (fn []
     (local runner (require :tests/runner))

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -952,6 +952,40 @@
 (table.insert tests {:name "external-unit-mcp: snapshot propagates error from real snapshot implementation"
                      :fn test-snapshot-propagates-error-from-real-snapshot-implementation})
 
+(fn test-snapshot-errors-on-default-export-module-load-failure []
+  ;; R1-3: A ModuleUnit without explicit :snapshot-export whose module fails
+  ;; to load (e.g. a compile error) must propagate the load error, not
+  ;; silently return supported=false. The defect was that has-snapshot?
+  ;; used pcall(require-module) and treated the load failure as "no
+  ;; snapshot capability" instead of propagating it.
+  (with-temp-dir
+    (fn [dir]
+      (local bad-path (write-unit-file dir "broken-module"
+                        "(fn init [] tru\n"  ;; missing closing paren + bad bool
+                        "(fn drop [] true)\n"
+                        "{:init init :drop drop}\n"))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          ;; No :snapshot-export — the lazy has-snapshot? will try to
+          ;; load the module and must propagate the compile error.
+          (local unit (Units.ModuleUnit
+                        {:id "user-broken-module"
+                         :module-name "broken-module"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [bad-path]}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          (local (ok err) (pcall #(service:snapshot {:unit_id "user-broken-module"})))
+          (assert (not ok) "should propagate module load error, not return supported=false")
+          (assert (string.find (or err "") "broken-module" 1 true)
+                  (.. "error should mention the failing module name, got: " (or err ""))))))))
+
+(table.insert tests {:name "external-unit-mcp: snapshot errors on default-export module load failure"
+                     :fn test-snapshot-errors-on-default-export-module-load-failure})
+
 (fn test-read-log-returns-filtered-recent-lines []
   ;; read-log returns structured lines, total-lines, and log-path.
   ;; R1-4: uses an isolated controlled log fixture with a known exact

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -791,6 +791,135 @@
 (table.insert tests {:name "external-unit-mcp: create-source rejects symlinked ancestor directory"
                      :fn test-create-source-rejects-symlinked-ancestor})
 
+;; ── Final review fix: R1-1 & R1-2 ──
+
+;; R1-1: Gate source artifact/source-handle derivation and read-source on explicit
+;;        filesystem/read capability. For loader "unknown", return no source handle/artifacts
+;;        and make read-source fail loudly with an unsupported-loader error.
+
+(fn test-builtin-unit-with-owned-paths-returns-unknown-loader []
+  (with-temp-dir
+    (fn [dir]
+      ;; Create a real .fnl file so the unit has owned paths, but mark it as builtin.
+      (local dummy-path (write-unit-file dir "builtin-with-path"
+                          (.. "(fn init [] true)\n(fn drop [] true)\n{:init init :drop drop}")))
+      (with-service dir
+        (fn [mgr _dir]
+          ;; Unit with source :builtin and owned-paths — current class rules say
+          ;; "unknown" because source is not :user.
+          (local builtin-unit (Units.Unit {:id "builtin-with-ownership"
+                                            :source :builtin
+                                            :owned-paths [dummy-path]
+                                            :load (fn [_] true)
+                                            :unload (fn [_] true)}))
+          (mgr:register builtin-unit))
+        (fn [_mgr service]
+          ;; list: loader must be "unknown", source-handle must be nil
+          (local results (service:list {}))
+          (var found nil)
+          (each [_ h (ipairs results)]
+            (when (= h.unit-id "builtin-with-ownership")
+              (set found h)))
+          (assert found "should find builtin-with-ownership in list")
+          (assert (= found.loader "unknown")
+                  (.. "builtin unit should have unknown loader, got " found.loader))
+          (assert (= found.source-handle nil)
+                  "builtin unit should have nil source-handle even with owned paths")
+          ;; inspect: source-artifacts must be empty
+          (local info (service:inspect {:unit_id "builtin-with-ownership"}))
+          (assert (= info.loader "unknown"))
+          (assert (= info.source-handle nil))
+          (assert (= (length info.source-artifacts) 0)
+                  "builtin unit should have zero source-artifacts")
+          ;; read-source: must fail loudly
+          (local (ok err) (pcall #(service:read-source
+                                    {:unit_id "builtin-with-ownership"
+                                     :source_id "builtin-with-path.fnl"})))
+          (assert (not ok) "read-source should fail for unknown loader")
+          (assert (string.find (or err "") "does not support" 1 true)
+                  (.. "error should mention unsupported operation, got: " (or err ""))))))))
+
+(table.insert tests {:name "external-unit-mcp: builtin unit with owned paths returns unknown loader and rejects read-source"
+                     :fn test-builtin-unit-with-owned-paths-returns-unknown-loader})
+
+;; R1-2: For filesystem directory units, compute source-id as the path relative to the
+;;       unit root for file artifacts under that root, and verify inspect -> read-source
+;;       round-trips a nested artifact.
+
+(fn test-directory-unit-inspect-read-source-roundtrips-nested-artifact []
+  (with-temp-dir
+    (fn [dir]
+      (local unit-dir (fs.join-path dir "nested-unit"))
+      (fs.create-dirs unit-dir)
+      ;; Create a subdirectory with a nested .fnl file
+      (local components-dir (fs.join-path unit-dir "components"))
+      (fs.create-dirs components-dir)
+      (local view-path (fs.join-path components-dir "view.fnl"))
+      (fs.write-file view-path
+        (.. "(fn view [] {:color \"blue\" :size 12})\n{:view view}"))
+      ;; Create init.fnl at the unit root
+      (local init-path (fs.join-path unit-dir "init.fnl"))
+      (fs.write-file init-path
+        (.. "(fn init [] true)\n(fn drop [] true)\n{:init init :drop drop}"))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. unit-dir "/?.fnl;" unit-dir "/?/init.fnl;"
+                                  dir "/?.fnl;" dir "/?/init.fnl"))
+          (local unit (Units.ModuleUnit
+                        {:id "user-nested-unit"
+                         :module-name "nested-unit"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [unit-dir init-path view-path]}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          ;; inspect: verify source-ids use relative paths, not basenames
+          (local info (service:inspect {:unit_id "user-nested-unit"}))
+          (assert info.source-artifacts (> (length info.source-artifacts) 0)
+                  "should have source artifacts")
+          ;; Collect source-ids
+          (local ids {})
+          (each [_ art (ipairs info.source-artifacts)]
+            (tset ids art.source-id true))
+          ;; The nested file must be addressable by its relative path
+          (assert (. ids "components/view.fnl")
+                  (.. "expected components/view.fnl in source artifacts, got keys: "
+                      (let [ks []]
+                        (each [k _ (pairs ids)] (table.insert ks k))
+                        (table.concat ks ", "))))
+          ;; The root init.fnl must still use its basename
+          (assert (. ids "init.fnl")
+                  "expected init.fnl in source artifacts")
+          ;; read-source round-trip for the nested artifact
+          (local nested-content (service:read-source
+                                  {:unit_id "user-nested-unit"
+                                   :source_id "components/view.fnl"}))
+          (assert nested-content.content "should have content")
+          (assert (string.find nested-content.content ":color \"blue\"" 1 true)
+                  (.. "content should contain original source, got: "
+                      nested-content.content))
+          ;; read-source round-trip for the root artifact
+          (local root-content (service:read-source
+                                {:unit_id "user-nested-unit"
+                                 :source_id "init.fnl"}))
+          (assert root-content.content "should have content")
+          (assert (string.find root-content.content "init []" 1 true)
+                  (.. "content should contain init, got: " root-content.content))
+          ;; Verify basename-only lookup (view.fnl) still works for the root
+          ;; init.fnl since it sits directly at root, but view.fnl without
+          ;; the "components/" prefix should NOT work — it's not under root.
+          (local (bad-ok bad-err) (pcall #(service:read-source
+                                            {:unit_id "user-nested-unit"
+                                             :source_id "view.fnl"})))
+          (assert (not bad-ok)
+                  "read-source with basename view.fnl should fail for nested file")
+          (assert (string.find (or bad-err "") "not found" 1 true)
+                  (.. "error should mention not found, got: " (or bad-err ""))))))))
+
+(table.insert tests {:name "external-unit-mcp: directory unit inspect-to-read-source round-trips nested artifact"
+                     :fn test-directory-unit-inspect-read-source-roundtrips-nested-artifact})
+
 ;; ── Task 3: External Unit Test, Log, and Snapshot Operations ──
 
 (fn test-snapshot-returns-unit-state-with-capability-metadata []

--- a/assets/lua/tests/test-external-unit-mcp.fnl
+++ b/assets/lua/tests/test-external-unit-mcp.fnl
@@ -837,6 +837,38 @@
 (table.insert tests {:name "external-unit-mcp: snapshot returns unsupported for unknown loader"
                      :fn test-snapshot-returns-unsupported-for-unknown-loader})
 
+(fn test-snapshot-returns-unsupported-for-filesystem-unit-without-snapshot []
+  ;; R1-3 remaining: a filesystem unit without an actual snapshot export
+  ;; must return supported=false, not supported=true with nil state.
+  (with-temp-dir
+    (fn [dir]
+      (local simple-path (write-unit-file dir "no-snapshot"
+                            (.. "(fn init [] true)\n"
+                                "(fn drop [] true)\n"
+                                "{:init init :drop drop}")))
+      (with-service dir
+        (fn [mgr _dir]
+          (local fennel-paths (.. dir "/?.fnl;" dir "/?/init.fnl"))
+          (local unit (Units.ModuleUnit
+                        {:id "user-no-snapshot"
+                         :module-name "no-snapshot"
+                         :module-paths fennel-paths
+                         :source :user
+                         :suppress-run-main? true
+                         :owned-paths [simple-path]}))
+          (mgr:register unit))
+        (fn [_mgr service]
+          (local result (service:snapshot {:unit_id "user-no-snapshot"}))
+          (assert result.unit-id "snapshot missing unit-id")
+          (assert (= result.unit-id "user-no-snapshot") "unit-id mismatch")
+          (assert (= result.supported false)
+                  "filesystem unit without snapshot export should report unsupported")
+          (assert (= result.state nil)
+                  "unsupported snapshot should have nil state"))))))
+
+(table.insert tests {:name "external-unit-mcp: snapshot returns unsupported for filesystem unit without snapshot export"
+                     :fn test-snapshot-returns-unsupported-for-filesystem-unit-without-snapshot})
+
 (fn test-read-log-returns-filtered-recent-lines []
   ;; read-log should work against the current application log file.
   ;; It returns structured lines, total-lines, and log-path.
@@ -859,7 +891,22 @@
           (assert result.log-path "read-log missing log-path")
           (assert (= (type result.log-path) "string") "log-path should be a string")
           ;; R1-4: total-lines must match the actual line count, not include a
-          ;; trailing empty entry from a final newline.
+          ;; trailing empty entry from a final newline. Verify independently
+          ;; by reading the raw log file and computing the expected count.
+          (local log-content (fs.read-file result.log-path))
+          (assert log-content "should be able to read log file")
+          (var raw-lines [])
+          (each [line (string.gmatch log-content "([^\n]*)\n?")]
+            (table.insert raw-lines line))
+          ;; Drop trailing empty string from final \n (same logic as read-log)
+          (when (and (> (# raw-lines) 0) (= (. raw-lines (# raw-lines)) ""))
+            (table.remove raw-lines))
+          (local expected-total (# raw-lines))
+          (assert (= result.total-lines expected-total)
+                  (.. "total-lines " result.total-lines
+                      " does not match raw line count " expected-total
+                      " — total-lines likely includes a trailing empty entry"))
+          ;; Also verify no returned line number exceeds total-lines
           (each [_ line (ipairs result.lines)]
             (local (line-num-str) (string.match line "^(%d+):"))
             (local line-num (tonumber line-num-str))

--- a/assets/lua/tools/external-unit-mcp-server.fnl
+++ b/assets/lua/tools/external-unit-mcp-server.fnl
@@ -6,6 +6,13 @@
   (global app (or app {}))
   (local fs (require :fs))
   (local EngineModule (require :engine))
+
+  ;; Install headless engine before any require that may auto-create one.
+  ;; `main.fnl` auto-creates app.engine with Engine {} when absent, so we
+  ;; must ensure the headless flag is already set before requiring :main.
+  (when (not app.engine)
+    (set app.engine (EngineModule.Engine {:headless true})))
+
   (local appdirs (require :appdirs))
   (local UnitManager (require :unit-manager))
   (local tempfile (require :tempfile))
@@ -14,10 +21,6 @@
   (local ExternalUnitService (require :llm/external-unit-mcp/service))
   (local ExternalUnitMcpBridge (require :llm/external-unit-mcp/bridge))
   (local Main (require :main))
-
-  ;; Ensure app.engine exists
-  (when (not app.engine)
-    (set app.engine (EngineModule.Engine {:headless true})))
 
   ;; Initialize app dirs
   (local data-dir (appdirs.user-data-dir "space"))

--- a/assets/lua/tools/external-unit-mcp-server.fnl
+++ b/assets/lua/tools/external-unit-mcp-server.fnl
@@ -1,0 +1,59 @@
+;; External Unit MCP Server — standalone entrypoint that boots an isolated
+;; loopback MCP server exposing external unit development tools.
+;; Usage: ./build/space -m tools.external-unit-mcp-server:main
+
+(fn main []
+  (global app (or app {}))
+  (local fs (require :fs))
+  (local EngineModule (require :engine))
+  (local appdirs (require :appdirs))
+  (local UnitManager (require :unit-manager))
+  (local tempfile (require :tempfile))
+  (local callbacks (require :callbacks))
+  (local ExternalUnitMcpTools (require :llm/external-unit-mcp/tools))
+  (local ExternalUnitService (require :llm/external-unit-mcp/service))
+  (local ExternalUnitMcpBridge (require :llm/external-unit-mcp/bridge))
+  (local Main (require :main))
+
+  ;; Ensure app.engine exists
+  (when (not app.engine)
+    (set app.engine (EngineModule.Engine {:headless true})))
+
+  ;; Initialize app dirs
+  (local data-dir (appdirs.user-data-dir "space"))
+  (set app.user-data-dir data-dir)
+  (set app.code-dir (fs.join-path data-dir "code"))
+
+  ;; Ensure unit manager
+  (when (not app.unit-manager)
+    (set app.unit-manager (UnitManager {})))
+
+  ;; Load user code units
+  (Main.ensure-user-code-units!)
+
+  ;; Create the service and tool registry
+  (local service (ExternalUnitService.ExternalUnitService {:app app}))
+  (local registry (ExternalUnitMcpTools.make-tool-registry {:app app}))
+  (ExternalUnitMcpTools.register-tools registry service)
+
+  ;; Create a temporary data directory for the bridge's isolated OpenCode config
+  (local temp-handle (tempfile.TemporaryDirectory {:prefix "ext-unit-mcp-server-"}))
+  (local bridge-data-dir temp-handle.path)
+
+  ;; Create and start the bridge
+  (local bridge (ExternalUnitMcpBridge.ExternalUnitMcpBridge
+                  {:tools registry
+                   :data-dir bridge-data-dir}))
+  (bridge:start)
+
+  (local status (bridge:status))
+  (local env (bridge:opencode-env))
+
+  (print (.. "MCP_URL=" status.url))
+  (print (.. "OPENCODE_XDG_CONFIG_HOME=" env.XDG_CONFIG_HOME))
+  (io.stdout:flush)
+
+  ;; Run the event loop — this blocks indefinitely
+  (callbacks.run-loop {:poll-http true :sleep-ms 10}))
+
+{:main main}

--- a/assets/lua/units.fnl
+++ b/assets/lua/units.fnl
@@ -20,6 +20,7 @@
   (local load-fn (assert-fn spec :load))
   (local unload-fn (assert-fn spec :unload))
   (local snapshot-fn (or spec.snapshot noop-snapshot))
+  (local has-snapshot? (not= spec.snapshot nil))
   (local restore-fn (or spec.restore noop-restore))
   (var loaded? false)
   (var connected-signals {})
@@ -34,6 +35,7 @@
    :parent-id spec.parent-id
    :source (or spec.source :user)
    :owned-paths (clone-list spec.owned-paths)
+   :has-snapshot? has-snapshot?
    :loaded? (fn [_self] loaded?)
    :load (fn [self ctx]
            (load-fn ctx)
@@ -242,6 +244,7 @@
   (tset self :unload-export unload-export)
   (tset self :snapshot-export snapshot-export)
   (tset self :restore-export restore-export)
+  (tset self :has-snapshot? explicit-snapshot?)
   self)
 
 (fn SourceUnit [opts]
@@ -310,6 +313,7 @@
                                    (call-export restore-export state))
                                  true)}))
   (tset self :force-purge-module-cache! (fn [_self] (clear-module)))
+  (tset self :has-snapshot? (not= snapshot-export nil))
   self)
 
 {:Unit Unit

--- a/assets/lua/units.fnl
+++ b/assets/lua/units.fnl
@@ -244,7 +244,11 @@
   (tset self :unload-export unload-export)
   (tset self :snapshot-export snapshot-export)
   (tset self :restore-export restore-export)
-  (tset self :has-snapshot? explicit-snapshot?)
+  (tset self :has-snapshot? (fn [_self]
+                               (or explicit-snapshot?
+                                   (let [(ok module) (pcall require-module)]
+                                     (and ok (= (type (. module snapshot-export))
+                                                "function"))))))
   self)
 
 (fn SourceUnit [opts]

--- a/assets/lua/units.fnl
+++ b/assets/lua/units.fnl
@@ -246,9 +246,11 @@
   (tset self :restore-export restore-export)
   (tset self :has-snapshot? (fn [_self]
                                (or explicit-snapshot?
-                                   (let [(ok module) (pcall require-module)]
-                                     (and ok (= (type (. module snapshot-export))
-                                                "function"))))))
+                                   (let [(ok module-or-err) (pcall require-module)]
+                                     (if (not ok)
+                                         (error module-or-err)
+                                         (= (type (. module-or-err snapshot-export))
+                                            "function"))))))
   self)
 
 (fn SourceUnit [opts]

--- a/docs/dev/notes/agent-presets.md
+++ b/docs/dev/notes/agent-presets.md
@@ -429,8 +429,8 @@ app bootstrap's `app.mcp-tools` registry.
 
 Do not add Space-specific user-unit behavior to global `~/.config/opencode`. The
 external unit MCP bridge writes an isolated config and prints
-`OPENCODE_XDG_CONFIG_HOME` so external OpenCode sessions can consume Space unit
-tools without polluting the user's global configuration.
+`OPENCODE_XDG_CONFIG_HOME=<path>` as a label; external OpenCode sessions
+consume it by setting `XDG_CONFIG_HOME` to the printed path.
 
 ## Tests
 

--- a/docs/dev/notes/agent-presets.md
+++ b/docs/dev/notes/agent-presets.md
@@ -414,6 +414,24 @@ Template variables in prompt fragments are resolved by the future prompt compose
 - `assets/lua/activities.fnl`: expose activity context enrichment when presets need selection/tool-target facts beyond shell state.
 - `assets/lua/tests/fast.fnl`: add preset unit tests once modules land.
 
+### Internal Unit Presets vs. External Unit MCP
+
+The `space_unit_*` tools registered through `llm/presets/builtins/units.fnl`
+(`space_unit_list`, `space_unit_inspect`, `space_unit_edit`, `space_unit_apply_patch`,
+`space_unit_reload`, etc.) are **internal Space agent tools**. They expect the
+full app runtime (`app.mcp-tools`, `app.unit-manager`, `app.code-dir`) and adapt
+to context through the preset system.
+
+External user-unit development uses the separate `llm/external-unit-mcp/*`
+subsystem instead. The external MCP registry is loader-neutral, runs in a
+headless engine with an isolated OpenCode config, and does not depend on the
+app bootstrap's `app.mcp-tools` registry.
+
+Do not add Space-specific user-unit behavior to global `~/.config/opencode`. The
+external unit MCP bridge writes an isolated config and prints
+`OPENCODE_XDG_CONFIG_HOME` so external OpenCode sessions can consume Space unit
+tools without polluting the user's global configuration.
+
 ## Tests
 
 Add `assets/lua/tests/test-agent-presets.fnl`:
@@ -469,6 +487,7 @@ Extend live MCP coverage later only after offline tests cover sync ownership and
 ## References
 
 - [remote mcp](./remote-mcp)
+- [external unit mcp](./external-unit-mcp)
 - [drawing architecture](./drawing-architecture)
 - [graph](./graph)
 - [composable states](./composable-states)

--- a/docs/dev/notes/external-unit-mcp.md
+++ b/docs/dev/notes/external-unit-mcp.md
@@ -1,0 +1,316 @@
+---
+type: dev-note
+tags:
+  - note
+---
+
+# External Unit MCP
+
+## Overview
+
+External unit MCP is a separate Space-owned MCP surface that lets external
+OpenCode sessions develop user units through Space MCP tools instead of direct
+filesystem edits. The subsystem lives under `assets/lua/llm/external-unit-mcp/`
+with a standalone entrypoint at `assets/lua/tools/external-unit-mcp-server.fnl`.
+
+```
+external opencode  <->  HTTP/SSE  <->  ExternalUnitMcpBridge  <->  ExternalUnitService
+                                        (isolated config)           (loader-neutral)
+```
+
+The external bridge writes an isolated OpenCode configuration into a temporary
+directory and prints the environment variables the external OpenCode session
+must use. It never mutates global `~/.config/opencode`.
+
+## Separation from Internal Agent MCP
+
+Space has two distinct MCP registries and two separate tool surfaces:
+
+| Surface | Registry | Tools Location | Audience |
+|---------|----------|---------------|----------|
+| Internal agent MCP | `app.mcp-tools` (bootstrap-owned) | `llm/presets/builtins/units.fnl`, scene, drawing, graph adapters | Space's own agent |
+| External unit MCP | Standalone `ToolRegistry` | `llm/external-unit-mcp/tools.fnl` | External OpenCode sessions |
+
+The internal registry serves the Space agent's runtime context (scene
+manipulation, canvas drawing, graph navigation, app-level operations) through
+`app.mcp-tools`. Preset-based tools like `space_unit_list`, `space_unit_edit`,
+and `space_unit_apply_patch` exposed through internal presets
+(`llm/presets/builtins/units.fnl`) are internal Space agent tools and expect the
+full app runtime.
+
+The external registry serves external user-unit development and exposes
+loader-neutral operations (`space_unit_resolve`, `space_unit_inspect`,
+`space_unit_read_source`, `space_unit_apply_patch`, `space_unit_create_source`,
+`space_unit_run_tests`, `space_unit_reload`, `space_unit_read_log`,
+`space_unit_snapshot`, `space_unit_list`) through
+`llm/external-unit-mcp/tools.fnl`.
+
+Do not add Space-specific user-unit behavior to global `~/.config/opencode`.
+
+## Starting the Server
+
+```bash
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tools.external-unit-mcp-server:main
+```
+
+The server boots a headless engine, creates a temporary data directory for the
+isolated OpenCode config, starts a loopback HTTP/SSE MCP server, and prints:
+
+```
+MCP_URL=http://127.0.0.1:<port>/mcp
+OPENCODE_XDG_CONFIG_HOME=/tmp/ext-unit-mcp-server-<...>/external-unit-opencode-config
+```
+
+## Connecting an External OpenCode Session
+
+Point an external OpenCode session at the printed config root without modifying
+global `~/.config/opencode`:
+
+```bash
+OPENCODE_XDG_CONFIG_HOME=<printed-config-root> opencode ...
+```
+
+The bridge writes an isolated `opencode.json` inside that directory that:
+- Denies all native tool permissions (filesystem, shell, web, etc.)
+- Enables only the `space-unit-dev` MCP server pointing at the loopback URL
+
+The external session only has access to the `space_unit_*` MCP tools. It cannot
+read arbitrary files or run arbitrary commands through the host.
+
+## Resolution Workflow
+
+External unit development follows this high-level workflow:
+
+1. **`space_unit_list`** — List all external units with loader-neutral handles.
+2. **`space_unit_resolve`** — Find a unit by natural-language description;
+   returns ranked candidates.
+3. **`space_unit_inspect`** — Inspect a unit by id: loader, source artifacts,
+   lifecycle exports (init/drop/snapshot/restore), and edit/test capabilities.
+4. **Read source** — `space_unit_read_source` returns the content of a source
+   artifact and its current hash.
+5. **Edit source** — `space_unit_apply_patch` applies an edit (exact replacement
+   or unified diff patch) with optional stale-content detection via
+   `expected_hash`. `space_unit_create_source` creates a new source file inside
+   a directory-based unit.
+6. **Test** — `space_unit_run_tests` runs tests for a unit by executing its test
+   module in a subprocess.
+7. **Reload** — `space_unit_reload` triggers a reload of the unit to reflect
+   its current source state.
+8. **Read log** — `space_unit_read_log` reads recent lines from the application
+   log with optional filtering and pagination.
+9. **Snapshot** — `space_unit_snapshot` captures a unit's current state for
+   later restoration.
+
+## Safety Model
+
+### Loopback-Only Binding
+
+The external MCP server binds to `127.0.0.1` by default. Non-loopback binds are
+disabled.
+
+### Isolated OpenCode Config
+
+The bridge writes an isolated config that denies all native tool permissions
+(filesystem, shell, web, etc.). External OpenCode sessions cannot read arbitrary
+files, write outside the bridge-managed config, or run commands.
+
+### Stale-Content Protection
+
+`space_unit_apply_patch` supports an optional `expected_hash` parameter. When
+provided, the patch is rejected if the file's current hash no longer matches.
+This prevents concurrent edits from silently overwriting each other.
+
+### Path Containment
+
+All source read/write operations resolve source-ids relative to the unit root
+and enforce path containment. Source-ids must be relative, must not contain
+`..` segments or NUL bytes, and must not escape the unit directory. Symlink
+ancestors and targets are rejected.
+
+### Loader Capability Checks
+
+Tools fail loudly when a loader lacks a requested capability. For example,
+non-filesystem loaders cannot read or write source files.
+
+### Risk Labels
+
+Each external tool carries a risk label (`normal`, `filesystem-read`,
+`filesystem-write`, `shell`, `destructive`) exported via `get-tool-risks`.
+
+## Common Local Storage Is Not the Contract
+
+`app.code-dir` — the Space user-data code directory — is common local storage
+where user units happen to live today. It is an implementation detail, not the
+external contract. The external tools operate on unit handles and source-ids,
+not on raw filesystem paths.
+
+External OpenCode sessions must never construct paths into `app.code-dir`.
+Future units may be backed by database records, remote hosts, generated stores,
+or other loaders.
+
+## Direct Filesystem Edits
+
+Direct filesystem edits are an escape hatch only. The external MCP tools
+(`space_unit_apply_patch`, `space_unit_create_source`, `space_unit_read_source`)
+are the supported editing path. Direct filesystem edits skip stale-content
+protection, path containment, and reload integration.
+
+If an external OpenCode session must use native filesystem tools, that requires
+explicit human approval and a Space-reported local filesystem source handle.
+
+## Tool Reference
+
+### space_unit_list
+
+List all external units with loader-neutral handles. Returns `unit-id`, `loader`,
+`source-handle`, `edit-capabilities`, `test-capabilities`, and `commit-capability`
+for each unit. Sorted by unit-id.
+
+### space_unit_resolve
+
+Resolve a unit from a natural-language description. Accepts:
+- `description` (string, required): natural-language description to match
+- `limit` (integer, optional): max candidates to return (default 20)
+
+Returns ranked candidates with `unit-id`, `confidence` (0.0–1.0), and `evidence`.
+Matches against unit id, module name, and source file basenames.
+
+### space_unit_inspect
+
+Inspect a unit by id. Accepts `unit_id` (string, required). Returns:
+- `unit-id`, `loader`
+- `source-handle` with `source-id`, `kind`, `primary`, `size`, `hash`
+- `lifecycle` with `init`, `drop`, `snapshot`, `restore` export names
+- `source-artifacts` listing all source files with hashes
+
+### space_unit_read_source
+
+Read the content of a unit source artifact. Accepts:
+- `unit_id` (string, required)
+- `source_id` (string, required): the source artifact identifier
+
+Returns `unit-id`, `source-id`, `content` (the file text), and `hash`
+(sha256-prefixed).
+
+### space_unit_apply_patch
+
+Apply an edit to a unit source file. Accepts:
+- `unit_id` (string, required)
+- `source_id` (string, required)
+- `patch` (string): a unified diff patch
+- `old` (string): exact text to find and replace
+- `new` (string): replacement text
+- `expected_hash` (string, optional): reject patch if file hash differs
+
+Exactly one of `patch` or `old`+`new` must be provided. The unit is
+automatically reloaded after a successful patch. On reload failure, the
+original source is restored. On patch-apply failure in diff mode, the
+source is also restored.
+
+### space_unit_create_source
+
+Create a new source file inside a directory-based unit. Accepts:
+- `unit_id` (string, required)
+- `source_id` (string, required): new file name relative to unit root
+- `source` (string, required): file content
+
+Rejects overwriting existing files. Creates parent directories as needed.
+Validates Fennel source before writing. The unit is reloaded after creation.
+On reload failure, the new file is removed.
+
+### space_unit_run_tests
+
+Run tests for a unit. Accepts:
+- `unit_id` (string, required)
+- `test_name` (string, optional): test suffix name (default: "init")
+
+Executes `<module-name>.test-<test-name>:main` in a subprocess with a
+headless engine. Returns `passed`, `exit-code`, `stdout`, and `stderr`.
+
+### space_unit_reload
+
+Reload a unit to reflect its current source state. Accepts `unit_id` (string,
+required). Returns `unit-id` and `reloaded` status.
+
+### space_unit_read_log
+
+Read recent lines from the application log. Accepts:
+- `grep` (string, optional): filter lines containing this substring
+- `lines` (integer, optional): number of recent lines (default 100)
+- `offset` (integer, optional): start from this line number
+- `limit` (integer, optional): max lines when using offset
+
+The response never exposes the raw native log-path through the external API.
+
+### space_unit_snapshot
+
+Capture a unit's current state for later restoration. Accepts `unit_id` (string,
+required). Returns `unit-id`, `supported` (bool), and `state` if supported.
+
+## Architecture
+
+### Service Layer (`llm/external-unit-mcp/service.fnl`)
+
+`ExternalUnitService` wraps `UnitManager` and provides loader-neutral operations:
+unit listing, inspection, resolution (token-based matching), source
+reading/writing/patching, test execution, log reading, and snapshot capture.
+
+Internal helpers handle:
+- `classify-loader` — maps unit source type to loader name ("filesystem" for
+  user units with owned paths)
+- `derive-source-artifacts` — enumerates files from owned-paths with hashes
+- `resolve-source-path` — safe file path resolution with containment checks
+  and symlink rejection
+- `validate-fnl-source` — compiles Fennel source to catch syntax errors early
+
+### Tools Layer (`llm/external-unit-mcp/tools.fnl`)
+
+Wraps the service in MCP tool definitions using `ToolRegistry` with namespace
+prefix `space_`. Each tool carries a risk label.
+
+### Bridge Layer (`llm/external-unit-mcp/bridge.fnl`)
+
+`ExternalUnitMcpBridge` owns the loopback MCP HTTP server and isolated OpenCode
+configuration. It:
+- Creates a temporary data directory
+- Starts an HTTP/SSE MCP server on a random loopback port
+- Writes an isolated `opencode.json` denying all native permissions
+- Exposes `status()` for connection diagnostics and `opencode-env()` for the
+  environment variables an external session must use
+
+### Standalone Entrypoint (`tools/external-unit-mcp-server.fnl`)
+
+Boots a headless engine, initializes app dirs, loads user code units, creates
+the service and tool registry, starts the bridge, prints the connection
+environment, and enters the run loop.
+
+## Files
+
+### Fennel
+
+- `assets/lua/llm/external-unit-mcp/service.fnl` — loader-neutral unit operations
+- `assets/lua/llm/external-unit-mcp/tools.fnl` — MCP tool definitions
+- `assets/lua/llm/external-unit-mcp/bridge.fnl` — loopback server and isolated config
+- `assets/lua/tools/external-unit-mcp-server.fnl` — standalone entrypoint
+
+### Tests
+
+- `assets/lua/tests/test-external-unit-mcp.fnl` — service, tools, bridge, and
+  integration tests
+
+## Test Command
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-external-unit-mcp:main
+```
+
+## See also
+
+- [Remote Mcp](./remote-mcp)
+- [Agent Presets](./agent-presets)
+- [Reloadable Units](/dev/reloadable-units)

--- a/docs/dev/notes/external-unit-mcp.md
+++ b/docs/dev/notes/external-unit-mcp.md
@@ -62,13 +62,19 @@ MCP_URL=http://127.0.0.1:<port>/mcp
 OPENCODE_XDG_CONFIG_HOME=/tmp/ext-unit-mcp-server-<...>/external-unit-opencode-config
 ```
 
+The server prints `OPENCODE_XDG_CONFIG_HOME=` as a label; the OpenCode process
+itself reads the standard `XDG_CONFIG_HOME` environment variable. See the next
+section for how to connect.
+
 ## Connecting an External OpenCode Session
 
-Point an external OpenCode session at the printed config root without modifying
-global `~/.config/opencode`:
+The server prints `OPENCODE_XDG_CONFIG_HOME=<path>` as a label; the actual
+environment variable OpenCode consumes is `XDG_CONFIG_HOME`. Point an
+external OpenCode session at the printed config root without modifying global
+`~/.config/opencode`:
 
 ```bash
-OPENCODE_XDG_CONFIG_HOME=<printed-config-root> opencode ...
+XDG_CONFIG_HOME=<printed-config-root> opencode ...
 ```
 
 The bridge writes an isolated `opencode.json` inside that directory that:

--- a/docs/dev/notes/index.md
+++ b/docs/dev/notes/index.md
@@ -28,6 +28,7 @@ Architecture notes, design sketches, debugging logs, and explorations. These are
 - [Drawing Architecture](./drawing-architecture)
 - [Drawing Raster Implementation](./drawing-raster-implementation)
 - [Entity Store](./entity-store)
+- [External Unit Mcp](./external-unit-mcp)
 - [Focus Change Ordering](./focus-change-ordering)
 - [Force Layout Barnes Hut](./force-layout-barnes-hut)
 - [Gccjit](./gccjit)

--- a/docs/dev/notes/remote-mcp.md
+++ b/docs/dev/notes/remote-mcp.md
@@ -74,6 +74,56 @@ Session IDs come from the native `uuid.v4` binding. Sessions track `created` and
 - `assets/lua/mcp/handler.fnl`: MCP initialize, tools/list, tools/call, sessions
 - `assets/lua/mcp/server-http.fnl`: HTTP/SSE transport wrapper
 - `assets/lua/tools/mcp-remote-server.fnl`: server entrypoint for opencode SSE mode; it requires the app bootstrap-owned `app.mcp-tools` registry rather than installing stub tools
+- `assets/lua/tools/external-unit-mcp-server.fnl`: standalone external unit-development MCP server entrypoint
+- `assets/lua/llm/external-unit-mcp/service.fnl`: loader-neutral unit operations
+- `assets/lua/llm/external-unit-mcp/tools.fnl`: external unit MCP tool definitions
+- `assets/lua/llm/external-unit-mcp/bridge.fnl`: loopback server and isolated OpenCode config
+
+## Internal vs. External MCP Registries
+
+Space has two separate MCP tool registries exposed through different server
+entrypoints. Both bind loopback by default and use the same MCP HTTP/SSE
+transport, but they serve different audiences with different tool sets.
+
+### Internal Agent MCP Server
+
+`assets/lua/tools/mcp-remote-server.fnl` (module `tools.mcp-remote-server:main`)
+
+- Serves the app bootstrap-owned `app.mcp-tools` registry.
+- Registry uses `ToolRegistry {:namespace-prefix "space_"}`.
+- Tools are registered by the preset system (`llm/presets/builtins/`) and
+  adapt to the current app context (scene, canvas, graph, drawing).
+- The Space agent uses this surface for runtime operations: scene manipulation,
+  canvas drawing, graph navigation, unit management, file and shell access.
+- Internal agent tools include `space_unit_*` tools from
+  `llm/presets/builtins/units.fnl` that expect the full app runtime.
+
+### External Unit MCP Server
+
+`assets/lua/tools/external-unit-mcp-server.fnl` (module `tools.external-unit-mcp-server:main`)
+
+- Creates its own standalone `ToolRegistry` with namespace prefix `space_`.
+- Tools are registered from `llm/external-unit-mcp/tools.fnl`.
+- Exposes loader-neutral unit development tools: `space_unit_resolve`,
+  `space_unit_inspect`, `space_unit_read_source`, `space_unit_apply_patch`,
+  `space_unit_create_source`, `space_unit_run_tests`, `space_unit_reload`,
+  `space_unit_read_log`, `space_unit_snapshot`, `space_unit_list`.
+- Uses `ExternalUnitMcpBridge` (`llm/external-unit-mcp/bridge.fnl`) which
+  writes an **isolated** OpenCode config into a temporary directory and prints
+  `OPENCODE_XDG_CONFIG_HOME` for the external session.
+- Does **not** mutate global `~/.config/opencode`.
+- Denies all native tool permissions (filesystem, shell, web, etc.) in the
+  generated config so external sessions can only use `space_unit_*` MCP tools.
+- Headless engine — no graphics window.
+
+### Shared Infrastructure
+
+Both servers reuse the same infrastructure:
+- `mcp/tool-registry.fnl` for tool registration and change notifications
+- `mcp/protocol.fnl` for JSON-RPC helpers
+- `mcp/handler.fnl` for MCP lifecycle (initialize, tools/list, tools/call)
+- `mcp/server-http.fnl` for HTTP/SSE transport
+- C++ `http_server` binding for loopback HTTP and main-thread dispatch
 
 ## Tests
 
@@ -81,6 +131,7 @@ Session IDs come from the native `uuid.v4` binding. Sessions track `created` and
 - `assets/lua/tests/test-http-server.fnl`: HTTP server binding, lifecycle guards, SSE delivery/cleanup
 - `assets/lua/tests/test-mcp-http.fnl`: direct HTTP MCP integration, status diagnostics, loopback guard, SSE reconnect/list_changed behavior, and force-SSE pre-stream rejection
 - `assets/lua/tests/test-mcp-live.fnl`: opencode live integration, gated by `MCP_LIVE_TESTS=1`
+- `assets/lua/tests/test-external-unit-mcp.fnl`: external unit MCP service, tools, bridge, and integration tests
 
 Live tests write opencode config under an isolated `/tmp/space/tests/opencode-mcp-live-*` `XDG_CONFIG_HOME`; they no longer mutate the user’s real `~/.config/opencode`.
 
@@ -111,4 +162,6 @@ SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
 
 ## See also
 
+- [External Unit MCP](./external-unit-mcp)
+- [Agent Presets](./agent-presets)
 - [Agent Tools](/dev/features/agent-tools), [Agent Runner System](/dev/features/agent-runner-system)`

--- a/docs/dev/notes/remote-mcp.md
+++ b/docs/dev/notes/remote-mcp.md
@@ -110,7 +110,8 @@ transport, but they serve different audiences with different tool sets.
   `space_unit_read_log`, `space_unit_snapshot`, `space_unit_list`.
 - Uses `ExternalUnitMcpBridge` (`llm/external-unit-mcp/bridge.fnl`) which
   writes an **isolated** OpenCode config into a temporary directory and prints
-  `OPENCODE_XDG_CONFIG_HOME` for the external session.
+  `OPENCODE_XDG_CONFIG_HOME=<path>` (a label; the caller must set
+  `XDG_CONFIG_HOME` to that path).
 - Does **not** mutate global `~/.config/opencode`.
 - Denies all native tool permissions (filesystem, shell, web, etc.) in the
   generated config so external sessions can only use `space_unit_*` MCP tools.

--- a/docs/dev/reloadable-units.md
+++ b/docs/dev/reloadable-units.md
@@ -436,6 +436,53 @@ If we had implemented dependency graphs, escalation logic, and staged transactio
 
 ## Recommended Next Steps
 
+
+### Units as Loader-Backed Runtime Objects
+
+The unit system is intentionally loader-neutral at the abstraction layer. A unit
+is a runtime object with an id, lifecycle exports (init/drop/snapshot/restore),
+and a backing loader that owns the source of truth.
+
+Today's user units are filesystem-backed: their source lives as `.fnl` files
+under `app.code-dir`, their loader is `"filesystem"`, and their owned-paths
+point to real files on disk. But that is an implementation detail. Future units
+may be backed by database records, remote hosts, generated stores, or other
+loaders.
+
+Callers should use unit handles and source-ids instead of constructing raw
+filesystem paths. The `ExternalUnitService` in
+`assets/lua/llm/external-unit-mcp/service.fnl` classifies each unit's loader and
+exposes loader-neutral operations (resolve, inspect, read-source, apply-patch,
+create-source, reload). Operations fail loudly when the loader lacks a requested
+capability rather than silently falling back to filesystem assumptions.
+
+### External Editing Through MCP Tools
+
+When external OpenCode sessions need to edit user units, they should use the
+`space_unit_*` external MCP tools rather than direct filesystem edits:
+
+- `space_unit_read_source` / `space_unit_apply_patch` / `space_unit_create_source`
+  for source editing with stale-content protection, path containment, Fennel
+  validation, and automatic reload.
+
+- `space_unit_reload` for explicit reload operations.
+
+- `space_unit_run_tests` for test execution in a subprocess.
+
+- `space_unit_read_log` for inspecting the application log after edits.
+
+Direct filesystem edits skip all of these protections: stale-content detection,
+path containment enforcement, source validation, symlink rejection, and reload
+integration. They are an escape hatch that requires explicit human approval and
+a Space-reported local filesystem source handle.
+
+The external unit MCP subsystem lives under `assets/lua/llm/external-unit-mcp/`
+with a standalone entrypoint at `assets/lua/tools/external-unit-mcp-server.fnl`.
+It boots a headless engine, creates an isolated OpenCode config, and exposes
+loader-neutral unit tools on loopback. See [External Unit MCP](./external-unit-mcp)
+for the full workflow.
+
+
 The next useful work is probably one of these:
 
 ### 1. Extract another meaningful child unit

--- a/docs/dev/reloadable-units.md
+++ b/docs/dev/reloadable-units.md
@@ -479,7 +479,7 @@ a Space-reported local filesystem source handle.
 The external unit MCP subsystem lives under `assets/lua/llm/external-unit-mcp/`
 with a standalone entrypoint at `assets/lua/tools/external-unit-mcp-server.fnl`.
 It boots a headless engine, creates an isolated OpenCode config, and exposes
-loader-neutral unit tools on loopback. See [External Unit MCP](./external-unit-mcp)
+loader-neutral unit tools on loopback. See [External Unit MCP](./notes/external-unit-mcp)
 for the full workflow.
 
 

--- a/docs/plans/2026-07-26-external-unit-mcp.md
+++ b/docs/plans/2026-07-26-external-unit-mcp.md
@@ -1,0 +1,581 @@
+# External Unit Development MCP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a separate Space-owned MCP surface that lets external OpenCode sessions resolve, inspect, edit, test, reload, and review user units through loader-aware Space tools instead of direct filesystem edits.
+
+**Architecture:** Add a new external-unit MCP subsystem under `assets/lua/llm/external-unit-mcp/` with a loader-neutral service facade over today’s filesystem-backed `UnitManager` units. Register the external tools into their own `ToolRegistry` and expose them through a separate loopback MCP bridge and standalone tool entrypoint; do not replace or reuse the internal Space agent MCP bridge. Current filesystem-backed units are adapted into loader-neutral handle/source shapes, leaving database/remote loaders as future extensions.
+
+**Tech Stack:** Fennel/Lua modules, existing `mcp/tool-registry`, `mcp/server-http`, `http_server`, `UnitManager`, `Units.ModuleUnit`, `repo/sha256`, `llm/tools/apply-patch`, `process`, `json`, `logging`, `callbacks.run-loop`.
+
+## Global Constraints
+
+- Do not add Space-specific behavior to global `~/.config/opencode`.
+- OpenCode should never infer a user-unit path from the platform's Space user-data code directory.
+- The external surface exposes high-level unit operations, not raw paths.
+- User units commonly live under Space's local user code directory, but that is an implementation detail, not the contract.
+- Future units may be backed by a local filesystem directory, database records, remote hosts, generated stores, or other loaders.
+- External unit development should not grant broad native filesystem access.
+- Unit reads and writes go through Space MCP tools.
+- Native OpenCode filesystem access is fallback-only and requires explicit human approval plus a Space-reported local filesystem source handle.
+- The MCP server binds to loopback by default.
+- Risk labels remain explicit for filesystem writes, shell/test execution, destructive operations, and remote actions.
+- Tool responses must fail loudly when a loader lacks a requested capability.
+- Patches should include stale-content protection where the loader can provide hashes or versions.
+- Out of scope: Changing global `~/.config/opencode` to include Space-specific unit guidance.
+- Out of scope: Replacing the existing internal agent MCP bridge.
+- Out of scope: Implementing every future loader type.
+- Out of scope: Building a general repository workbench for user units.
+- Out of scope: Allowing non-loopback MCP binds by default.
+
+---
+
+### Task 1: Loader-Neutral Unit Discovery, Handles, Inspect, and Resolve
+
+**Files:**
+- Create: `assets/lua/llm/external-unit-mcp/service.fnl`
+- Create: `assets/lua/tests/test-external-unit-mcp.fnl`
+- Modify: `assets/lua/tests/fast.fnl`
+
+**Interfaces:**
+- Consumes: existing `UnitManager`, `Units.Unit`, `Units.ModuleUnit`, `fs`, `json`, `repo/sha256`
+- Produces:
+  - `ExternalUnitService.ExternalUnitService(opts: {:app table}) -> service`
+  - `service:list(args: table) -> table`
+  - `service:inspect(args: {:unit_id string}) -> table`
+  - `service:resolve(args: {:description string, :limit number?}) -> table`
+  - `service:unit-handle(unit: table) -> table`
+  - Handle shape:
+    - `:unit-id string`
+    - `:loader string`
+    - `:source-handle table`
+    - `:edit-capabilities table`
+    - `:test-capabilities table`
+    - `:commit-capability string`
+  - Source artifact shape:
+    - `:source-id string`
+    - `:kind string`
+    - `:primary boolean`
+    - `:size number`
+    - `:hash string`
+
+- [ ] **Step 1: Add focused failing tests for list, inspect, and vague resolve**
+
+Add `assets/lua/tests/test-external-unit-mcp.fnl` with helpers that create a temporary `app.unit-manager`, register filesystem-backed units, and assert loader-neutral output. Include tests named:
+
+- `external-unit-mcp: list returns loader-neutral handles`
+- `external-unit-mcp: inspect reports source artifacts and lifecycle exports`
+- `external-unit-mcp: resolve ranks vague description candidates`
+
+Expected assertions:
+- User filesystem units report `loader == "filesystem"`.
+- Built-in/non-filesystem units report `loader == "unknown"` and no edit capabilities.
+- Handles include `unit-id`, `source-handle`, `edit-capabilities`, `test-capabilities`, and `commit-capability`.
+- Inspect includes lifecycle exports `init`, `drop`, `snapshot`, `restore` defaults.
+- Resolve accepts a description such as `"bubble overlay unit"` and returns the matching unit candidate without requiring an exact unit id.
+
+- [ ] **Step 2: Register the new test module in `assets/lua/tests/fast.fnl`**
+
+Add `:tests.test-external-unit-mcp` near the other MCP/agent/unit tests so `make test` includes it.
+
+- [ ] **Step 3: Run the focused test and confirm it fails because the service module does not exist**
+
+Run:
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-external-unit-mcp:main
+```
+
+Expected: FAIL with a missing module or missing `ExternalUnitService` error.
+
+- [ ] **Step 4: Implement `assets/lua/llm/external-unit-mcp/service.fnl` discovery/inspect/resolve**
+
+Implement only read-only discovery in this task:
+- Require `:unit-manager` through `opts.app.unit-manager`; assert loudly if absent.
+- Classify current units as:
+  - `"filesystem"` when `unit.source == :user` and at least one owned path exists.
+  - `"unknown"` otherwise.
+- For filesystem units, derive source artifacts from existing owned paths without making `app.code-dir` part of the external contract.
+- Compute `sha256:<hex>` with `repo/sha256.hash-file` for file artifacts.
+- Return deterministic ordering from `list` and `resolve`.
+- `resolve` should score simple lowercase token matches against unit id, module name, artifact ids, and owned path basenames; return candidates with `:confidence` and `:evidence`.
+
+- [ ] **Step 5: Re-run the focused test until Task 1 tests pass**
+
+Run the same focused command from Step 3.
+
+Expected: PASS.
+
+---
+
+### Task 2: Loader-Neutral Source Read, Patch, Create, and Reload Operations
+
+**Files:**
+- Modify: `assets/lua/llm/external-unit-mcp/service.fnl`
+- Modify: `assets/lua/tests/test-external-unit-mcp.fnl`
+
+**Interfaces:**
+- Consumes:
+  - Task 1 `ExternalUnitService`
+  - existing `llm/tools/apply-patch.call(args, ctx)`
+  - existing `repo/sha256.hash-file(path)`
+  - existing `app.unit-manager:reload-unit(unit-id, ctx)`
+- Produces:
+  - `service:read-source(args: {:unit_id string, :source_id string}) -> table`
+  - `service:apply-patch(args: {:unit_id string, :source_id string, :patch string?, :old string?, :new string?, :expected_hash string?}) -> table`
+  - `service:create-source(args: {:unit_id string, :source_id string, :source string, :expected_absent boolean?}) -> table`
+  - `service:reload(args: {:unit_id string}) -> table`
+
+- [ ] **Step 1: Add failing tests for source read and exact patch with stale hash protection**
+
+Extend `test-external-unit-mcp.fnl` with tests named:
+
+- `external-unit-mcp: read-source returns content and hash`
+- `external-unit-mcp: apply-patch exact replacement reloads unit`
+- `external-unit-mcp: apply-patch rejects stale expected hash`
+
+Expected assertions:
+- `read-source` returns `unit-id`, `source-id`, `content`, and `hash`.
+- `apply-patch` with `old`/`new` modifies only one exact match, reloads the unit, and returns `reloaded == true`.
+- `apply-patch` with an incorrect `expected_hash` fails before writing and leaves source unchanged.
+
+- [ ] **Step 2: Add failing tests for unified patch and source creation capability**
+
+Add tests named:
+
+- `external-unit-mcp: apply-patch unified diff reloads unit`
+- `external-unit-mcp: create-source creates directory-unit artifact and reloads`
+- `external-unit-mcp: create-source fails loudly for flat unit without create capability`
+
+Expected assertions:
+- Unified patches are applied through `llm/tools/apply-patch` with the filesystem unit root as `cwd`.
+- Directory units can create a new loader-relative source artifact.
+- Flat single-file units fail loudly for `create-source` because the current filesystem loader cannot create sibling artifacts safely for that shape.
+
+- [ ] **Step 3: Run focused tests and confirm new tests fail**
+
+Run:
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-external-unit-mcp:main
+```
+
+Expected: FAIL with missing method errors.
+
+- [ ] **Step 4: Implement loader-relative source resolution and mutation**
+
+In `service.fnl`:
+- Require `unit_id` and `source_id`; do not accept absolute paths.
+- Reject `..`, absolute paths, drive-letter paths, and NUL bytes in `source_id`.
+- For filesystem directory units, resolve `source_id` under the unit directory.
+- For filesystem flat units, allow only the primary source artifact for read/patch and reject create.
+- Reject built-in or unknown-loader units for write operations.
+- Verify `expected_hash` before writing when provided.
+- Validate `.fnl` source with `fennel.compile-string` before reload.
+- On write/reload failure, restore the old source and surface the reload error.
+
+- [ ] **Step 5: Re-run focused tests until Task 2 tests pass**
+
+Run the focused test command from Step 3.
+
+Expected: PASS.
+
+---
+
+### Task 3: External Unit Test, Log, and Snapshot Operations
+
+**Files:**
+- Modify: `assets/lua/llm/external-unit-mcp/service.fnl`
+- Modify: `assets/lua/tests/test-external-unit-mcp.fnl`
+
+**Interfaces:**
+- Consumes:
+  - Task 1 and Task 2 service
+  - existing `process.Process.run`
+  - existing `logging.get-output-path`
+  - existing `unit:snapshot(ctx)`
+- Produces:
+  - `service:run-tests(args: {:unit_id string, :test_name string?}) -> table`
+  - `service:read-log(args: {:lines number?, :offset number?, :limit number?, :grep string?}) -> table`
+  - `service:snapshot(args: {:unit_id string}) -> table`
+
+- [ ] **Step 1: Add failing tests for snapshot and log reading**
+
+Extend `test-external-unit-mcp.fnl` with tests named:
+
+- `external-unit-mcp: snapshot returns unit state with capability metadata`
+- `external-unit-mcp: read-log returns filtered recent lines`
+
+Expected assertions:
+- `snapshot` returns `unit-id`, `supported == true`, and `state`.
+- `read-log` returns `lines`, `total-lines`, and `log-path`, and honors `grep`.
+
+- [ ] **Step 2: Add a focused test for `run-tests`**
+
+Add test `external-unit-mcp: run-tests executes unit test module`.
+
+Use a temporary directory unit with `test-init.fnl` exporting `{:main main :tests tests}` and assert:
+- result has `passed == true`
+- `exit-code == 0`
+- stdout contains `PASS` or the runner success output
+
+- [ ] **Step 3: Run focused tests and confirm new tests fail**
+
+Run:
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-external-unit-mcp:main
+```
+
+Expected: FAIL with missing methods.
+
+- [ ] **Step 4: Implement `run-tests`, `read-log`, and `snapshot`**
+
+In `service.fnl`:
+- `run-tests` should mirror the existing unit test subprocess behavior from `assets/lua/llm/presets/builtins/units.fnl`, but return a structured table instead of plain text.
+- `read-log` should fail loudly if no log file exists or it is empty.
+- `snapshot` should call `unit:snapshot({})`; if the loader/unit cannot snapshot, return `supported == false` only for an explicit missing capability, not for unexpected errors.
+
+- [ ] **Step 5: Re-run focused tests until Task 3 tests pass**
+
+Run the focused test command from Step 3.
+
+Expected: PASS.
+
+---
+
+### Task 4: External Unit MCP Tool Registry
+
+**Files:**
+- Create: `assets/lua/llm/external-unit-mcp/tools.fnl`
+- Modify: `assets/lua/tests/test-external-unit-mcp.fnl`
+
+**Interfaces:**
+- Consumes:
+  - Task 1–3 `ExternalUnitService`
+  - existing `mcp/tool-registry`
+- Produces:
+  - `ExternalUnitMcpTools.make-tool-registry(opts: {:app table, :service table?}) -> ToolRegistry`
+  - `ExternalUnitMcpTools.register-tools(registry: table, service: table) -> table`
+  - MCP tools:
+    - `space_unit_resolve`
+    - `space_unit_list`
+    - `space_unit_inspect`
+    - `space_unit_read_source`
+    - `space_unit_apply_patch`
+    - `space_unit_create_source`
+    - `space_unit_run_tests`
+    - `space_unit_reload`
+    - `space_unit_read_log`
+    - `space_unit_snapshot`
+
+- [ ] **Step 1: Add failing tests for tool registration and JSON responses**
+
+Extend `test-external-unit-mcp.fnl` with tests named:
+
+- `external-unit-mcp: tool registry exposes minimal external tool set`
+- `external-unit-mcp: tool calls return JSON service responses`
+- `external-unit-mcp: write tool errors propagate as MCP tool errors`
+
+Expected assertions:
+- Registry namespace prefix is `space_`.
+- The registry lists exactly the ten external unit tool names above.
+- Calling `space_unit_list` returns JSON parseable output.
+- Calling a write tool for an unsupported loader returns `isError == true`.
+
+- [ ] **Step 2: Run focused tests and confirm tool module is missing**
+
+Run:
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-external-unit-mcp:main
+```
+
+Expected: FAIL with missing `llm/external-unit-mcp/tools`.
+
+- [ ] **Step 3: Implement `tools.fnl`**
+
+Implement:
+- `make-tool-registry` creates `ToolRegistry {:namespace-prefix "space_"}`.
+- `register-tools` registers the ten tools with non-empty descriptions and object `inputSchema`.
+- Each tool calls the matching service method and returns `json.dumps` of the structured table.
+- Tool input uses canonical keys only: `unit_id`, `source_id`, `description`, `limit`, `patch`, `old`, `new`, `expected_hash`, `source`, `test_name`, `lines`, `offset`, `grep`.
+
+- [ ] **Step 4: Re-run focused tests until Task 4 tests pass**
+
+Run the focused test command from Step 2.
+
+Expected: PASS.
+
+---
+
+### Task 5: Separate External Unit MCP Bridge and Standalone Server Entrypoint
+
+**Files:**
+- Create: `assets/lua/llm/external-unit-mcp/bridge.fnl`
+- Create: `assets/lua/tools/external-unit-mcp-server.fnl`
+- Modify: `assets/lua/tests/test-external-unit-mcp.fnl`
+
+**Interfaces:**
+- Consumes:
+  - Task 4 `ExternalUnitMcpTools.make-tool-registry`
+  - existing `mcp/server-http`
+  - existing `http_server`
+  - existing `json-utils.JsonUtils.write-json!`
+  - existing `callbacks.run-loop`
+- Produces:
+  - `ExternalUnitMcpBridge.ExternalUnitMcpBridge(opts: {:tools table, :data-dir string, :host string?, :http-server-factory function?, :mcp-server-factory function?}) -> bridge`
+  - `bridge:start() -> bridge`
+  - `bridge:stop() -> bridge`
+  - `bridge:opencode-env() -> {:XDG_CONFIG_HOME string}`
+  - `bridge:status() -> table`
+  - Standalone entrypoint: `./build/space -m tools.external-unit-mcp-server:main`
+
+- [ ] **Step 1: Add failing bridge tests**
+
+Extend `test-external-unit-mcp.fnl` with test `external-unit-mcp: bridge starts loopback server and writes isolated opencode config`.
+
+Expected assertions:
+- `status.started? == true`
+- `status.host == "127.0.0.1"`
+- `status.port > 0`
+- `bridge:opencode-env().XDG_CONFIG_HOME == status.config-root`
+- `status.config-path` is under the provided temp `data-dir`, not under global `~/.config/opencode`
+- written config has `mcp.space-unit-dev.type == "remote"`, `enabled == true`, and `url == status.url`
+- native OpenCode tools `read`, `write`, `edit`, `grep`, `glob`, `list`, and `bash` are denied
+
+- [ ] **Step 2: Run focused tests and confirm bridge module is missing**
+
+Run:
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-external-unit-mcp:main
+```
+
+Expected: FAIL with missing `llm/external-unit-mcp/bridge`.
+
+- [ ] **Step 3: Implement `bridge.fnl` as a separate bridge from `llm/agent/opencode-mcp-bridge.fnl`**
+
+Implement the same production lifecycle expectations as the internal bridge, but with external-unit names:
+- Config root: `<data-dir>/external-unit-opencode-config`
+- Config path: `<config-root>/opencode/opencode.json`
+- MCP config key: `space-unit-dev`
+- Remote URL: `http://127.0.0.1:<port>/mcp`
+- Server: `MCPHTTPServer {:http-server ..., :tools tools, :force-sse true}`
+- Deny native OpenCode filesystem/shell tools by default.
+- On startup failure, stop the server and clear partial state.
+- Do not import or mutate the internal `AgentOpencodeMcpBridge`.
+
+- [ ] **Step 4: Implement `tools/external-unit-mcp-server.fnl`**
+
+The entrypoint should:
+- Create or reuse global `app`.
+- Ensure `app.engine` exists with `EngineModule.Engine {:headless true}` if absent.
+- Require `:main` only to access `Main.ensure-user-code-units!`; do not call `app.init`.
+- Initialize `app.user-data-dir` and `app.code-dir` using `appdirs.user-data-dir "space"` and `fs.join-path`.
+- Ensure `app.unit-manager` exists.
+- Call `Main.ensure-user-code-units!`.
+- Create the external unit MCP tool registry with `ExternalUnitMcpTools.make-tool-registry {:app app}`.
+- Create `ExternalUnitMcpBridge` with a temp data dir.
+- Start it, print `MCP_URL=<url>` and `OPENCODE_XDG_CONFIG_HOME=<config-root>`, flush stdout, then run `callbacks.run-loop {:poll-http true :sleep-ms 10}`.
+
+- [ ] **Step 5: Re-run focused tests until Task 5 tests pass**
+
+Run the focused test command from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 6: Manually smoke-test the standalone module starts and prints connection info**
+
+Run with a timeout so the long-running server is stopped by the shell:
+
+```bash
+timeout 2s env \
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tools.external-unit-mcp-server:main
+```
+
+Expected: process prints `MCP_URL=http://127.0.0.1:<port>/mcp` and `OPENCODE_XDG_CONFIG_HOME=<temp path>` before timeout exits.
+
+---
+
+### Task 6: Documentation Updates
+
+**Files:**
+- Create: `docs/dev/notes/external-unit-mcp.md`
+- Modify: `docs/dev/notes/remote-mcp.md`
+- Modify: `docs/dev/notes/agent-presets.md`
+- Modify: `docs/dev/reloadable-units.md`
+
+**Interfaces:**
+- Consumes:
+  - Task 1–5 implemented behavior and exact tool names
+- Produces:
+  - Developer documentation for external unit MCP workflow, safety model, and separation from the internal Space agent bridge
+
+- [ ] **Step 1: Create `docs/dev/notes/external-unit-mcp.md`**
+
+Document:
+- Purpose: external OpenCode user-unit development through Space MCP tools.
+- Command to start the server:
+  ```bash
+  SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+  ./build/space -m tools.external-unit-mcp-server:main
+  ```
+- How to use printed `OPENCODE_XDG_CONFIG_HOME` with OpenCode without modifying global config.
+- Required resolution workflow:
+  1. `space_unit_resolve`
+  2. `space_unit_inspect`
+  3. `space_unit_read_source`
+  4. edit through `space_unit_apply_patch` or `space_unit_create_source`
+  5. `space_unit_run_tests`
+  6. `space_unit_reload`
+  7. `space_unit_read_log`
+- State that `app.code-dir` / Space user-data code directory is common local storage, not the external contract.
+- State that direct filesystem edits are an escape hatch only.
+
+- [ ] **Step 2: Update `docs/dev/notes/remote-mcp.md`**
+
+Add a section distinguishing:
+- `assets/lua/tools/mcp-remote-server.fnl`: existing app bootstrap-owned/internal agent-facing MCP registry.
+- `assets/lua/tools/external-unit-mcp-server.fnl`: external unit-development MCP registry.
+- Both bind loopback by default.
+- External unit MCP has loader-neutral tools and does not mutate global OpenCode config.
+
+- [ ] **Step 3: Update `docs/dev/notes/agent-presets.md`**
+
+Add a short note near the unit preset/tool section:
+- Existing `llm/presets/builtins/units.fnl` tools are internal Space agent tools.
+- External user-unit development uses `llm/external-unit-mcp/*` instead.
+- Do not add Space-specific user-unit behavior to global `~/.config/opencode`.
+
+- [ ] **Step 4: Update `docs/dev/reloadable-units.md`**
+
+Add a section explaining:
+- Units are loader-backed runtime objects.
+- Current user units are filesystem-backed, but callers should use unit handles/source ids instead of constructing paths.
+- External editing should go through `space_unit_*` external MCP tools.
+
+- [ ] **Step 5: Run docs-adjacent focused tests**
+
+Run:
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-external-unit-mcp:main
+```
+
+Expected: PASS.
+
+---
+
+### Task 7: Final Integration Validation
+
+**Files:**
+- Modify: no production files unless validation exposes a defect
+
+**Interfaces:**
+- Consumes:
+  - All previous tasks
+- Produces:
+  - Observable acceptance evidence for the implementation
+
+- [ ] **Step 1: Run the external unit MCP focused suite**
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-external-unit-mcp:main
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run existing MCP HTTP transport coverage because the new bridge uses the same transport**
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-mcp-http:main
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run existing internal agent/unit coverage to verify separation and compatibility**
+
+```bash
+FENNEL_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+FENNEL_MACRO_PATH="$(pwd)/assets/lua/?.fnl;$(pwd)/assets/lua/?/init.fnl" \
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+./build/space -m tests.test-agent-units:main
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the standard full suite from AGENTS.md**
+
+```bash
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data \
+SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="$(pwd)/assets" \
+make test
+```
+
+Expected: PASS.
+
+## Invariants and Compatibility Requirements
+
+- Existing internal Space agent MCP bridge in `assets/lua/llm/agent/opencode-mcp-bridge.fnl` remains unchanged in purpose and is not replaced.
+- Existing internal agent unit tools in `assets/lua/llm/presets/builtins/units.fnl` remain available for the in-app agent.
+- External MCP tools return loader-neutral handles and source ids; callers must not construct paths from `app.code-dir`.
+- Current implementation may adapt filesystem-backed units only, but response shapes must not prevent database, remote, generated, or unknown loaders later.
+- Unsupported loader operations fail loudly with MCP tool errors.
+- Loopback remains the default bind behavior.
+- No code writes to global `~/.config/opencode`.
+
+## Observable Acceptance Criteria
+
+- `space_unit_resolve` accepts vague descriptions and returns zero, one, or multiple candidates with confidence and evidence.
+- `space_unit_list` and `space_unit_inspect` expose loader metadata, handles, source summaries, lifecycle exports, and capabilities.
+- `space_unit_read_source`, `space_unit_apply_patch`, and `space_unit_create_source` operate through Space’s unit service and enforce stale hash checks when supplied.
+- `space_unit_run_tests`, `space_unit_reload`, `space_unit_read_log`, and `space_unit_snapshot` are available through the external MCP registry.
+- External MCP bridge writes isolated OpenCode config outside global `~/.config/opencode`.
+- Documentation clearly separates repository development, internal Space agent MCP, and external user-unit MCP.
+
+## Explicitly Out of Scope
+
+- Database, remote, generated, or remote-host loader implementations.
+- Persistent unit registry redesign.
+- Broad repository workbench tools for arbitrary repo files.
+- Non-loopback external MCP binds by default.
+- Global OpenCode configuration changes.
+- Replacing or removing the existing internal Space agent bridge.

--- a/docs/specs/2026-07-26-external-unit-mcp-design.md
+++ b/docs/specs/2026-07-26-external-unit-mcp-design.md
@@ -1,0 +1,168 @@
+# External Unit Development MCP Design
+
+## Purpose
+
+Space already has robust in-app unit tooling for discovering, editing, testing,
+reloading, and inspecting user units. The external OpenCode workflow should use
+that same unit abstraction instead of editing user-unit files directly from the
+Space repository checkout.
+
+The goal is to add a Space-owned MCP surface for external development sessions.
+OpenCode launched from this repository can connect to that MCP surface and work
+on user units through loader-aware tools, while the normal Space repository
+workflow remains unchanged.
+
+## Problem
+
+User units commonly live under Space's local user code directory, but that is an
+implementation detail, not the contract. Future units may be backed by a local
+filesystem directory, database records, remote hosts, generated stores, or other
+loaders. A workflow that grants OpenCode direct filesystem access teaches the
+wrong model and cannot generalize to non-filesystem units.
+
+The current internal OpenCode MCP bridge is intentionally scoped to the in-app
+agent provider. It starts a loopback MCP server, writes isolated OpenCode config,
+and denies native OpenCode tools for internally spawned agent sessions. External
+development from this repository needs a related but separate surface with an
+explicit unit-development contract.
+
+## Design
+
+Add a second MCP entry point for external unit development. It should be separate
+from the internal agent bridge, but reuse the same underlying Space unit systems
+where possible.
+
+The external surface exposes high-level unit operations, not raw paths. Tools
+resolve units, inspect loader metadata, read source, apply patches, create files
+when supported, run tests, reload units, and read logs through Space. Space owns
+the loader-specific behavior, rollback, validation, approval risk labels, and
+future support for non-filesystem sources.
+
+The external OpenCode workflow treats a unit target as a resolved handle:
+
+```text
+unit-id: concrete registered unit id
+loader: filesystem | database | remote | generated | unknown
+source-handle: loader-defined opaque identifier
+edit-capabilities: loader-supported operations
+test-capabilities: loader-supported test operations
+commit-capability: none | git | loader-versioned | remote-pr | unknown
+```
+
+OpenCode should never infer a user-unit path from the platform's Space user-data
+code directory. That directory is a common current storage location, but the MCP
+tool response is the authority.
+
+## Tools
+
+The external MCP should start with this minimal tool set:
+
+- `space_unit_resolve`: Accept a vague natural-language description and return
+  zero, one, or multiple candidate unit handles with confidence and evidence.
+- `space_unit_list`: List registered units and loader metadata.
+- `space_unit_inspect`: Inspect one unit's metadata, lifecycle exports,
+  capabilities, source summary, and test summary.
+- `space_unit_read_source`: Read a source artifact by unit handle and
+  loader-relative source id.
+- `space_unit_apply_patch`: Apply an exact or unified patch through the unit
+  loader, then validate and reload when supported.
+- `space_unit_create_source`: Create a new source artifact when the loader
+  supports it.
+- `space_unit_run_tests`: Run loader-defined unit tests.
+- `space_unit_reload`: Reload the unit through Space's unit manager.
+- `space_unit_read_log`: Read recent Space log lines, with optional filtering.
+- `space_unit_snapshot`: Capture loader/runtime state when supported, for review
+  and rollback evidence.
+
+Existing internal unit tool implementations may be reused behind these external
+tools, but the external contract should use loader-neutral names and responses
+where the current internal tools are filesystem-oriented.
+
+## Unit Resolution Workflow
+
+The user should not need to know a unit id. Before editing, the workflow resolves
+a concrete target:
+
+1. Call `space_unit_resolve` with the user's description.
+2. If exactly one high-confidence candidate is returned, use it.
+3. If multiple plausible candidates are returned, ask the user to choose.
+4. If no candidate is returned, ask whether to create a new unit or provide more
+   context.
+
+Resolution evidence may include unit id, module name, source summary, activity
+registration, UI labels, log mentions, test filenames, loaded state, and loader
+metadata.
+
+## OpenCode Integration
+
+Do not add Space-specific behavior to global `~/.config/opencode`.
+
+Space repository guidance should document how to connect an external OpenCode
+session to the external unit MCP endpoint. If OpenCode requires config files for
+remote MCP, the repository should provide a helper that writes an isolated
+temporary config rather than modifying the user's global config.
+
+The normal Space repository development workflow remains the default for source
+changes under this checkout. The external unit workflow applies only when the
+task is about user units or loader-backed unit source outside the repository.
+
+## Safety and Permissions
+
+External unit development should not grant broad native filesystem access.
+
+- Unit reads and writes go through Space MCP tools.
+- Native OpenCode filesystem access is fallback-only and requires explicit human
+  approval plus a Space-reported local filesystem source handle.
+- The MCP server binds to loopback by default.
+- Risk labels remain explicit for filesystem writes, shell/test execution,
+  destructive operations, and remote actions.
+- Tool responses must fail loudly when a loader lacks a requested capability.
+- Patches should include stale-content protection where the loader can provide
+  hashes or versions.
+
+## Validation
+
+The validation ladder for unit work is:
+
+1. Resolve the intended unit and inspect its capabilities.
+2. Add or update a focused unit test through the unit tooling when feasible.
+3. Run the focused test through `space_unit_run_tests`.
+4. Apply the implementation through MCP unit tools.
+5. Re-run focused tests.
+6. Reload the unit and inspect recent logs.
+7. Run broader Space tests only when the unit change depends on modified engine,
+   built-in asset, or app-level contracts.
+
+Reviewer evidence should come from MCP tool transcripts, before/after source
+content or loader versions, test output, reload result, and log checks.
+
+## Documentation Updates
+
+The implementation should update repository documentation to clarify:
+
+- The Space user-data code directory is common local storage, not the unit contract.
+- User units are loader-backed runtime objects.
+- External OpenCode should use the external Space unit MCP surface by default.
+- Direct filesystem edits are an escape hatch, not the normal workflow.
+
+## Out of Scope
+
+- Changing global `~/.config/opencode` to include Space-specific unit guidance.
+- Replacing the existing internal agent MCP bridge.
+- Implementing every future loader type.
+- Building a general repository workbench for user units.
+- Allowing non-loopback MCP binds by default.
+
+## Acceptance Criteria
+
+- External unit development has a separate MCP entry point from the internal
+  agent bridge.
+- OpenCode can connect to the external MCP without modifying global opencode
+  config.
+- A vague user description can be resolved to candidate unit handles before
+  editing.
+- Unit source changes go through Space loader-aware tools by default.
+- Focused tests, reload, and log inspection are available through the MCP
+  workflow.
+- Documentation clearly separates Space repository development from external
+  user-unit development.


### PR DESCRIPTION
## Summary
- add loader-neutral ExternalUnitService operations for discovery, inspect/resolve, source read/patch/create/reload, tests, logs, and snapshots
- add isolated external unit MCP tool registry, bridge, and standalone server entrypoint
- document the external unit workflow and separation from the internal agent MCP bridge

## Testing
- SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets make test