### PR TITLE
fix(ui): keep activity selector rail visible

### DIFF
--- a/assets/lua/activity-dock-view.fnl
+++ b/assets/lua/activity-dock-view.fnl
@@ -101,28 +101,26 @@
         {:padding false}))
 
     (fn build-content []
-      (local show-dock?
+      (local builders [(FlexChild (build-feature-rail) 0)])
+      (local show-activity-panel?
         (and app.canvas
              (= app.active-interaction-surface :canvas)
              (= app.canvas-visible? true)))
-      (if (not show-dock?)
-          nil
-          (do
-            (local builders [(FlexChild (build-feature-rail) 0)])
-            (local left-dock-builder (current-left-dock-builder))
-            (when left-dock-builder
-              (set active-dock-entity (left-dock-builder ctx))
-              (when active-dock-entity
-                (table.insert builders
-                              (FlexChild
-                                (fn [_inner-ctx]
-                                  active-dock-entity)
-                                0))))
-            ((Flex {:axis 1
-                    :spacing 0
-                    :yalign :stretch
-                    :children builders})
-             ctx))))
+      (when show-activity-panel?
+        (local left-dock-builder (current-left-dock-builder))
+        (when left-dock-builder
+          (set active-dock-entity (left-dock-builder ctx))
+          (when active-dock-entity
+            (table.insert builders
+                          (FlexChild
+                            (fn [_inner-ctx]
+                              active-dock-entity)
+                            0)))))
+      ((Flex {:axis 1
+              :spacing 0
+              :yalign :stretch
+              :children builders})
+       ctx))
 
     (fn rebuild-children! []
       (drop-content!)

--- a/assets/lua/tests/test-drawing-sidebar.fnl
+++ b/assets/lua/tests/test-drawing-sidebar.fnl
@@ -712,6 +712,64 @@
       (set app.activity-registry original-registry)
       (set app.activities-changed original-signal))))
 
+(fn activity-dock-always-shows-feature-rail-in-scene-mode []
+  (with-sidebar-env
+    (fn []
+      (with-controller
+        (fn [controller]
+          (local original-controller app.drawing-controller)
+          (set app.drawing-controller controller)
+
+          ;; Activate drawing activity to ensure left-dock-builder is available
+          (set-activity-id "drawing")
+
+          ;; Switch to scene mode before creating dock
+          (set app.active-interaction-surface :scene)
+          (set app.canvas-visible? false)
+
+          ;; Create dock - should still show feature rail
+          (local dock ((ActivityDockView {}) (make-ctx)))
+          (dock.layout:measurer)
+
+          ;; Feature rail should still be visible (> 0 measurement)
+          (local scene-width (. dock.layout.measure 1))
+          (assert (> scene-width 0)
+                  "activity dock should show feature rail even in scene mode")
+
+          ;; Content should exist (not nil)
+          (local content-layout (. dock.layout.children 1))
+          (assert content-layout "activity dock should have content layout even in scene mode")
+
+          ;; Feature rail (FlexChild) should be present as first child
+          (local rail-flex-child (. content-layout.children 1))
+          (assert rail-flex-child "feature rail FlexChild should be present in scene mode")
+
+          ;; Activity-specific panel should NOT be present
+          (local activity-panel-child (. content-layout.children 2))
+          (assert (not activity-panel-child)
+                  "activity-specific panel should not be present in scene mode")
+
+          ;; Switch back to canvas mode
+          (set-interaction-surface :canvas)
+          (dock:update)
+          (dock.layout:measurer)
+
+          ;; Width should increase (activity panel added)
+          (local canvas-width (. dock.layout.measure 1))
+          (assert (> canvas-width scene-width)
+                  "activity dock should widen when switching to canvas")
+
+          ;; Activity panel should now be present
+          (local updated-content (. dock.layout.children 1))
+          (local updated-activity-panel (. updated-content.children 2))
+          (assert updated-activity-panel
+                  "activity-specific panel should be present after switching to canvas")
+
+          (dock:drop)
+          (set app.drawing-controller original-controller))))))
+
+(table.insert tests {:name "Activity dock always shows feature rail in scene mode"
+                     :fn activity-dock-always-shows-feature-rail-in-scene-mode})
 (table.insert tests {:name "Drawing sidebar expands in drawing activity"
                      :fn sidebar-width-reflects-active-activity-id})
 (table.insert tests {:name "Drawing sidebar width follows panel measure"


### PR DESCRIPTION
## Summary
- keep the permanent activity selector rail visible even when the active activity switches to scene mode and hides the canvas
- keep activity-specific left dock panels gated to canvas-visible/canvas surface
- add regression coverage for scene-mode rail visibility and canvas-mode panel restoration

## Testing
- SPACE_DISABLE_AUDIO=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_ASSETS_PATH=/home/ubuntu/space/molly/assets ./build/space -m tests.test-drawing-sidebar:main
- SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=/home/ubuntu/space/molly/assets make test