### PR TITLE
fix(skills): route red finishing validation through debugging

### DIFF
--- a/.opencode/agents/supervisor.md
+++ b/.opencode/agents/supervisor.md
@@ -242,8 +242,10 @@ When the human asks to debug something, invoke **systematic-debugging**.
 - Do not report completion until all reviewed changes are committed, the
   worktree is clean, and any verification or finishing checks required by
   the active skill or plan (e.g., tests, finishing-a-development-branch
-  validation) have passed. Report BLOCKED with the exact reason if any of
-  these cannot be satisfied.
+  validation) have passed. If required validation fails, follow the
+  Completion discipline contract (`systematic-debugging`, `implementer` →
+  `reviewer` → pass, rerun validation); report BLOCKED only when systematic
+  debugging establishes an unresolved blocker.
 - Never fix code yourself. That's what `implementer` is for.
 
 User instructions (AGENTS.md, direct requests) take precedence over skills,

--- a/.opencode/agents/supervisor.md
+++ b/.opencode/agents/supervisor.md
@@ -150,9 +150,13 @@ ready-to-merge, you must also complete any verification or finishing checks
 required by the active skill or plan (e.g., running tests, validating with
 finishing-a-development-branch). Only report completion / ready-to-merge
 when the tree is clean, changes are committed, and all required checks have
-passed. If you cannot commit, the tree is not clean, or required checks fail,
-report BLOCKED with the exact reason. Never report DONE with uncommitted,
-staged changes, or unsatisfied verification requirements.
+passed. If required validation fails, do not report completion and do not stop
+at the failure summary. Invoke `systematic-debugging`, identify the root cause,
+route any fix through `implementer` → `reviewer` → pass, commit reviewed fixes,
+rerun the failed validation, and restart finishing checks from the top. Report
+BLOCKED only when systematic debugging establishes that the failure cannot be
+resolved without human input, is external/environmental, is unreproducible with
+available evidence, or requires a product/API/data/architecture decision.
 
 ## Your Subagents
 
@@ -221,9 +225,10 @@ When the human asks to build something:
    dispatch `implementer` per task, `reviewer` after each task, `adjudicator`
    at the fix-loop breaker. Maintain the ledger, manage the workspace.
 
-4. Invoke **finishing-a-development-branch** — verify tests, consult project
-   policy, execute the integration action (or present options if no policy),
-   clean up.
+4. Invoke **finishing-a-development-branch** — verify clean tree and required
+   validation, use `systematic-debugging` plus `implementer` → `reviewer` for
+   any validation failure, then consult project policy and execute the
+   integration action only when green.
 
 When the human asks to debug something, invoke **systematic-debugging**.
 

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -46,7 +46,10 @@ Do all of the following:
    current `git status --porcelain`.
 2. Invoke `systematic-debugging` before proposing any fix.
 3. Identify and document the root cause. If root cause cannot be established,
-   continue gathering evidence or report BLOCKED with the missing evidence.
+   continue gathering evidence and debugging. Do not BLOCKED here on unknown
+   root cause alone; only report BLOCKED/HUMAN_DECISION_REQUIRED when
+   systematic debugging establishes one of the enumerated blocker conditions
+   below.
 4. Route any fix through `implementer` → `reviewer` → pass. The supervisor must
    not edit code, tests, `.opencode/**`, workflow files, or other non-allowlisted
    files directly.

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -54,11 +54,12 @@ Do all of the following:
    skill from Step 0.
 6. Only continue to Step 2 when the required validation suite passes.
 
-If systematic debugging establishes that the failure is external, environmental,
-unrelated to this branch, unreproducible with available evidence, or requires a
-human product/API/data/architecture decision, report BLOCKED or
-HUMAN_DECISION_REQUIRED with the evidence. Do not push, PR, merge, or clean up
-while required validation is red.
+If systematic debugging establishes that the failure is external/environmental,
+unreproducible with available evidence, or requires a human product/API/data/
+architecture decision, report BLOCKED or HUMAN_DECISION_REQUIRED with the
+evidence. A failure that is merely unrelated to this branch but does not meet
+one of these BLOCKED criteria still requires the standard debug/fix/rerun loop.
+Do not push, PR, merge, or clean up while required validation is red.
 
 **If tests pass:** continue to Step 2.
 
@@ -138,7 +139,7 @@ git pull
 git merge <feature-branch>
 ```
 
-If tests fail on the merged result: stop, leave everything in place, and investigate — nothing has been pushed, so the merge is local and recoverable.
+If tests fail on the merged result: follow the Step 1 validation-failure loop — invoke `systematic-debugging`, route any fix through `implementer` → `reviewer` → pass, do not push/PR/merge/clean up while red, and rerun from Step 0 after reviewed fixes. Nothing has been pushed, so the merge is local and recoverable.
 
 Once green: clean up the worktree (Step 7), then delete the branch:
 

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: finishing-a-development-branch
-description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work
+description: Use when implementation is complete and reviewed, to run final validation, recover from validation failures, and integrate only when green
 ---
 
 # Finishing a Development Branch
 
 ## Overview
 
-**Core principle:** Verify clean tree → Verify tests → Consult project policy → Detect environment → Execute action (or present options if no policy) → Clean up.
+**Core principle:** Verify clean tree → Verify required validation → If validation fails, debug root cause and route reviewed fixes → Rerun validation until green or blocked → Consult project policy → Detect environment → Execute action (or present options if no policy) → Clean up.
 
 **Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
 
@@ -39,7 +39,26 @@ Never auto-stage or auto-discard. Only allowlisted coordination-artifact files m
 
 Run the project's full test suite. Consult AGENTS.md for the correct test command.
 
-**If tests fail**, report the failures and stop — integration comes after a green suite.
+**If tests fail**, integration is forbidden but the branch is not finished.
+Do all of the following:
+
+1. Capture the exact failing command, failing tests, relevant error output, and
+   current `git status --porcelain`.
+2. Invoke `systematic-debugging` before proposing any fix.
+3. Identify and document the root cause. If root cause cannot be established,
+   continue gathering evidence or report BLOCKED with the missing evidence.
+4. Route any fix through `implementer` → `reviewer` → pass. The supervisor must
+   not edit code, tests, `.opencode/**`, workflow files, or other non-allowlisted
+   files directly.
+5. After reviewed fixes are committed and the tree is clean, rerun this finishing
+   skill from Step 0.
+6. Only continue to Step 2 when the required validation suite passes.
+
+If systematic debugging establishes that the failure is external, environmental,
+unrelated to this branch, unreproducible with available evidence, or requires a
+human product/API/data/architecture decision, report BLOCKED or
+HUMAN_DECISION_REQUIRED with the evidence. Do not push, PR, merge, or clean up
+while required validation is red.
 
 **If tests pass:** continue to Step 2.
 
@@ -164,3 +183,4 @@ git worktree prune
 | "They obviously want it merged" | Follow the project's integration policy, not assumptions. If AGENTS.md specifies an automatic action (push + create PR), execute it. Only present the menu when no policy exists or branch-unsafe conditions block the automatic action. |
 | "The base branch is obviously main" | Confirm the fork point or ask. Merging into the wrong base is expensive to undo. |
 | "The push was rejected — force-push will fix it" | A rejected push means the remote moved. Investigate; force-push only on your human partner's explicit request. |
+| "The final suite failed, so I'll just report it and stop" | A red final suite is a debugging task. Invoke `systematic-debugging`, route reviewed fixes through `implementer` → `reviewer`, rerun validation, and finish only when green or explicitly blocked. |

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -124,6 +124,10 @@ After all tasks, dispatch the **reviewer** in FULL REVIEW MODE with the complete
 ## Finish
 
 When final review is clean, use the finishing-a-development-branch skill.
+If finishing validation fails, stay in coordination mode: follow the finishing
+skill's validation-failure loop, invoke `systematic-debugging`, route fixes
+through `implementer` → `reviewer` → pass, rerun validation, and only finish or
+PR when the required suite is green.
 
 ## Common Rationalizations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,12 @@ explicitly requests a different integration action or when the branch state is
 unsafe (uncommitted changes, failing tests, unresolved merge conflicts with
 `main`).
 
+If required validation fails after implementation, review, or commit, do not
+finish, push, create a pull request, merge, or clean up the branch. Invoke the
+`systematic-debugging` skill, identify the root cause, route any fix through
+`implementer` → `reviewer` → pass, rerun validation, and only proceed with the
+default integration action when the required suite is green.
+
 ## Project Structure & Modules
 
 - `src/` holds the C++17 engine modules (rendering, physics, audio, bindings). Add new systems as matching `.cpp`/`.h` pairs. Engine Lua bindings live in `src/lua_engine.cpp`.

--- a/docs/dev/features/development-tooling.md
+++ b/docs/dev/features/development-tooling.md
@@ -33,6 +33,7 @@ A 3D spatial computing platform with C++ and Fennel components needs specialized
 - **Remote control** (`remote-control.fnl`): ZeroMQ-based live Fennel evaluation for debugging running apps.
 - **CLI tools** (`tools/`): Remote control client, MCP remote server, torrent download/upload scripts.
 - OpenCode project guidance uses `AGENTS.md` for always-on repository facts and `.opencode/skills/space-*` for triggerable Space domain guidance; users must restart OpenCode after `.opencode/**` changes.
+- After implementation/review/commit, failed required validation is handled as a debugging task: supervisors invoke `systematic-debugging`, route fixes through `implementer` → `reviewer`, rerun validation, and finish or PR only when green.
 
 - **DEB/RPM packaging**: Per-distro DEB (ubuntu-22.04/24.04, debian-12/13) and RPM (fedora, opensuse-tumbleweed) packages via CMake/CPack. CEF runtime bundling in full-profile packages; minimal-profile packages exclude it. Distro smoke tests via xvfb + headless engine. AppImage and tarball distribution formats. See [Building space](/dev/building).
 

--- a/docs/plans/2026-07-27-validation-failure-recovery.md
+++ b/docs/plans/2026-07-27-validation-failure-recovery.md
@@ -1,0 +1,297 @@
+# Validation Failure Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make failed required finishing validation trigger root-cause debugging and reviewed fixes instead of a terminal stop.
+
+**Architecture:** Keep repository policy concise in `AGENTS.md`, put operational details in the finishing skill, and align supervisor and SDD handoff wording so there is no contradictory “report failure and stop” path. This is instruction/documentation-only; no runtime behavior, product code, tests, or OpenCode schema changes are in scope.
+
+**Tech Stack:** Markdown repository instructions, OpenCode project agent prompts, OpenCode project skills, existing `systematic-debugging`, `implementer`, and `reviewer` workflows.
+
+## Global Constraints
+
+- Do not edit production code, runtime tests, build scripts, assets, or OpenCode JSON schema/config for this change.
+- Because `AGENTS.md` and `.opencode/**` are outside the supervisor edit allowlist, all instruction changes must be made by `implementer` and verified by `reviewer`.
+- OpenCode users must restart after `.opencode/**` changes.
+- Failed required validation after implementation/review/commit must not be treated as done, ready-to-merge, or ready-to-PR.
+- While required validation is red, agents must not push, create a PR, merge, or clean up the branch.
+- Any fix for a validation failure must be based on `systematic-debugging`, address root cause rather than symptoms, avoid silent failures and test weakening, and pass through `implementer` → `reviewer` → pass.
+- `BLOCKED` is allowed only when systematic debugging establishes an unresolved blocker: human decision required, external/environmental failure, unreproducible failure with available evidence, or unsafe scope/architecture uncertainty.
+
+---
+
+## File Structure
+
+- Modify `AGENTS.md`: repository-level policy for failed required validation after implementation/review/commit.
+- Modify `.opencode/agents/supervisor.md`: always-on routing rule so supervisors invoke debugging/fix coordination before reporting `BLOCKED` for red validation.
+- Modify `.opencode/skills/finishing-a-development-branch/SKILL.md`: canonical finishing-time validation-failure loop.
+- Modify `.opencode/skills/subagent-driven-development/SKILL.md`: final handoff reminder that finishing validation failures remain active coordination work.
+- Modify `docs/dev/features/development-tooling.md`: maintainer-facing documentation of the OpenCode workflow.
+
+## Baseline Evidence
+
+- Observed real failure: an agent stopped at finishing checks after the full suite failed and reported `BLOCKED` instead of diagnosing root cause.
+- Current finishing skill contains the direct stop instruction: `If tests fail, report the failures and stop — integration comes after a green suite.`
+- A read-only pressure check against current instructions found ambiguity: the finishing skill says stop, while `systematic-debugging` says test failures should be investigated. The implementation must remove that ambiguity by making “stop integration” distinct from “stop working.”
+
+---
+
+### Task 1: Repository and Supervisor Policy
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `.opencode/agents/supervisor.md`
+
+**Interfaces:**
+- Consumes: Existing branch convention, completion discipline, and subagent routing rules.
+- Produces: Always-on policy that red validation enters systematic debugging and reviewed fixes before finishing.
+
+- [ ] **Step 1: Inspect current wording**
+
+Read `AGENTS.md` and `.opencode/agents/supervisor.md`. Confirm the current automatic PR policy requires tests passing and that supervisor completion discipline currently allows reporting `BLOCKED` when required checks fail.
+
+- [ ] **Step 2: Add repository-level validation failure policy**
+
+In `AGENTS.md`, under `## Branch Convention` and after the existing automatic PR policy paragraph, add this paragraph exactly, wrapping only for Markdown line length:
+
+```markdown
+If required validation fails after implementation, review, or commit, do not
+finish, push, create a pull request, merge, or clean up the branch. Invoke the
+`systematic-debugging` skill, identify the root cause, route any fix through
+`implementer` → `reviewer` → pass, rerun validation, and only proceed with the
+default integration action when the required suite is green.
+```
+
+- [ ] **Step 3: Replace supervisor completion failure behavior**
+
+In `.opencode/agents/supervisor.md`, update the `Completion discipline` section so it keeps the clean-tree and required-checks gate, but replaces the unconditional “required checks fail → report BLOCKED” behavior with this contract:
+
+```markdown
+If required validation fails, do not report completion and do not stop at the
+failure summary. Invoke `systematic-debugging`, identify the root cause, route
+any fix through `implementer` → `reviewer` → pass, commit reviewed fixes, rerun
+the failed validation, and restart finishing checks from the top. Report BLOCKED
+only when systematic debugging establishes that the failure cannot be resolved
+without human input, is external/environmental, is unreproducible with available
+evidence, or requires a product/API/data/architecture decision.
+```
+
+- [ ] **Step 4: Align supervisor core workflow handoff**
+
+In `.opencode/agents/supervisor.md`, replace Core Workflow step 4 with:
+
+```markdown
+4. Invoke **finishing-a-development-branch** — verify clean tree and required
+   validation, use `systematic-debugging` plus `implementer` → `reviewer` for
+   any validation failure, then consult project policy and execute the
+   integration action only when green.
+```
+
+- [ ] **Step 5: Focused validation for Task 1**
+
+Run:
+
+```bash
+rg -n "required validation fails|do not stop at the|systematic-debugging|implementer.*reviewer|only proceed.*green" AGENTS.md .opencode/agents/supervisor.md
+git diff --check AGENTS.md .opencode/agents/supervisor.md
+```
+
+Expected: both files contain the validation-failure recovery policy; no whitespace errors.
+
+---
+
+### Task 2: Finishing and SDD Skill Contract
+
+**Files:**
+- Modify: `.opencode/skills/finishing-a-development-branch/SKILL.md`
+- Modify: `.opencode/skills/subagent-driven-development/SKILL.md`
+
+**Interfaces:**
+- Consumes: Existing finishing steps and SDD final-review handoff.
+- Produces: Concrete loop for failed finishing validation.
+
+- [ ] **Step 1: Inspect current skill wording**
+
+Read `.opencode/skills/finishing-a-development-branch/SKILL.md` and `.opencode/skills/subagent-driven-development/SKILL.md`. Confirm the finishing skill currently says tests failing should report and stop, and SDD currently only says to use the finishing skill after final review.
+
+- [ ] **Step 2: Update finishing skill trigger description**
+
+Change the frontmatter description in `.opencode/skills/finishing-a-development-branch/SKILL.md` to:
+
+```yaml
+description: Use when implementation is complete and reviewed, to run final validation, recover from validation failures, and integrate only when green
+```
+
+- [ ] **Step 3: Update finishing skill core principle**
+
+Replace the existing core principle sentence with:
+
+```markdown
+**Core principle:** Verify clean tree → Verify required validation → If validation fails, debug root cause and route reviewed fixes → Rerun validation until green or blocked → Consult project policy → Detect environment → Execute action (or present options if no policy) → Clean up.
+```
+
+- [ ] **Step 4: Replace finishing skill Step 1 failure behavior**
+
+Replace the current Step 1 failed-tests sentence with:
+
+```markdown
+**If tests fail**, integration is forbidden but the branch is not finished.
+Do all of the following:
+
+1. Capture the exact failing command, failing tests, relevant error output, and
+   current `git status --porcelain`.
+2. Invoke `systematic-debugging` before proposing any fix.
+3. Identify and document the root cause. If root cause cannot be established,
+   continue gathering evidence or report BLOCKED with the missing evidence.
+4. Route any fix through `implementer` → `reviewer` → pass. The supervisor must
+   not edit code, tests, `.opencode/**`, workflow files, or other non-allowlisted
+   files directly.
+5. After reviewed fixes are committed and the tree is clean, rerun this finishing
+   skill from Step 0.
+6. Only continue to Step 2 when the required validation suite passes.
+
+If systematic debugging establishes that the failure is external, environmental,
+unrelated to this branch, unreproducible with available evidence, or requires a
+human product/API/data/architecture decision, report BLOCKED or
+HUMAN_DECISION_REQUIRED with the evidence. Do not push, PR, merge, or clean up
+while required validation is red.
+```
+
+- [ ] **Step 5: Add finishing skill rationalization guard**
+
+Add this row to the `Common Rationalizations` table:
+
+```markdown
+| "The final suite failed, so I'll just report it and stop" | A red final suite is a debugging task. Invoke `systematic-debugging`, route reviewed fixes through `implementer` → `reviewer`, rerun validation, and finish only when green or explicitly blocked. |
+```
+
+- [ ] **Step 6: Update SDD finish handoff**
+
+Replace `.opencode/skills/subagent-driven-development/SKILL.md` `## Finish` section with:
+
+```markdown
+## Finish
+
+When final review is clean, use the finishing-a-development-branch skill.
+If finishing validation fails, stay in coordination mode: follow the finishing
+skill's validation-failure loop, invoke `systematic-debugging`, route fixes
+through `implementer` → `reviewer` → pass, rerun validation, and only finish or
+PR when the required suite is green.
+```
+
+- [ ] **Step 7: Focused validation for Task 2**
+
+Run:
+
+```bash
+rg -n "validation fails|systematic-debugging|implementer.*reviewer|only.*green|HUMAN_DECISION_REQUIRED|branch is not finished" .opencode/skills/finishing-a-development-branch/SKILL.md .opencode/skills/subagent-driven-development/SKILL.md
+git diff --check .opencode/skills/finishing-a-development-branch/SKILL.md .opencode/skills/subagent-driven-development/SKILL.md
+```
+
+Expected: finishing and SDD both contain the red-validation loop; no whitespace errors.
+
+---
+
+### Task 3: Developer Documentation
+
+**Files:**
+- Modify: `docs/dev/features/development-tooling.md`
+
+**Interfaces:**
+- Consumes: The policy and skill wording from Tasks 1 and 2.
+- Produces: Maintainer documentation explaining the OpenCode validation-failure workflow.
+
+- [ ] **Step 1: Inspect the OpenCode guidance section**
+
+Read `docs/dev/features/development-tooling.md` and find the existing OpenCode guidance mentioning `AGENTS.md` and `.opencode/skills/space-*`.
+
+- [ ] **Step 2: Extend the OpenCode guidance**
+
+Update that guidance so it includes this sentence:
+
+```markdown
+After implementation/review/commit, failed required validation is handled as a debugging task: supervisors invoke `systematic-debugging`, route fixes through `implementer` → `reviewer`, rerun validation, and finish or PR only when green.
+```
+
+- [ ] **Step 3: Focused validation for Task 3**
+
+Run:
+
+```bash
+rg -n "failed required validation|systematic-debugging|finish or PR only when green" docs/dev/features/development-tooling.md
+git diff --check docs/dev/features/development-tooling.md
+```
+
+Expected: the docs page contains the workflow summary; no whitespace errors.
+
+---
+
+### Task 4: Final Instruction Consistency Review
+
+**Files:**
+- Test: `AGENTS.md`
+- Test: `.opencode/agents/supervisor.md`
+- Test: `.opencode/skills/finishing-a-development-branch/SKILL.md`
+- Test: `.opencode/skills/subagent-driven-development/SKILL.md`
+- Test: `docs/dev/features/development-tooling.md`
+
+**Interfaces:**
+- Consumes: Completed instruction edits from Tasks 1 through 3.
+- Produces: Verified instruction contract ready for commit and restart notice.
+
+- [ ] **Step 1: Run cross-file consistency search**
+
+Run:
+
+```bash
+rg -n "do not.*push|do not.*pull request|do not.*PR|only.*green|systematic-debugging|implementer.*reviewer|branch is not finished" AGENTS.md .opencode/agents/supervisor.md .opencode/skills/finishing-a-development-branch/SKILL.md .opencode/skills/subagent-driven-development/SKILL.md docs/dev/features/development-tooling.md
+```
+
+Expected: each changed file has at least one relevant match, and the finishing skill has the most detailed loop.
+
+- [ ] **Step 2: Run whitespace validation**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace or formatting errors.
+
+- [ ] **Step 3: Inspect final diff and status**
+
+Run:
+
+```bash
+git status --short
+git diff -- AGENTS.md .opencode/agents/supervisor.md .opencode/skills/finishing-a-development-branch/SKILL.md .opencode/skills/subagent-driven-development/SKILL.md docs/dev/features/development-tooling.md
+```
+
+Expected: only the five intended files are modified for implementation. Plan/spec commits may already exist separately.
+
+- [ ] **Step 4: Include restart notice in implementation report**
+
+The implementer report must include this exact note:
+
+```markdown
+OpenCode must be restarted for `.opencode/**` agent and skill prompt changes to take effect.
+```
+
+## Acceptance Criteria
+
+- Future supervisors encountering failed required validation after implementation/review/commit invoke `systematic-debugging` instead of stopping at the failure summary.
+- No instruction permits finishing, pushing, PR creation, merging, or cleanup while required validation is red.
+- Any validation-failure fix is routed through `implementer` → `reviewer` → pass.
+- Finishing checks are rerun from Step 0 after reviewed fixes.
+- `AGENTS.md`, supervisor prompt, finishing skill, SDD handoff, and docs/dev tooling page agree without contradictory stop conditions.
+- The implementation report includes the OpenCode restart notice.
+
+## Out of Scope
+
+- Changing OpenCode schema/config files.
+- Changing production code, runtime tests, build scripts, or runtime assets.
+- Adding a new skill or agent.
+- Automating validation failure parsing.
+- Allowing PRs with known red required validation.
+- Weakening, skipping, or deleting failing tests as a default response.

--- a/docs/specs/2026-07-27-validation-failure-recovery-design.md
+++ b/docs/specs/2026-07-27-validation-failure-recovery-design.md
@@ -1,0 +1,75 @@
+# Validation Failure Recovery Design
+
+## Context
+
+A prior agent completed implementation and review, then stopped during finishing
+because the required full suite failed. The current `finishing-a-development-branch`
+skill explicitly says to report test failures and stop, while supervisor guidance
+says to report `BLOCKED` when required checks fail. That prevents the agent from
+owning the next necessary step: diagnosing the failed validation and routing a
+proper reviewed fix before integration.
+
+## Requirement
+
+After implementation, review, and commit, failed required validation is a gate
+and a debugging task. The agent must not finish, push, create a PR, merge, or
+clean up while required validation is red. It must invoke `systematic-debugging`,
+identify root cause with evidence, route any fix through `implementer` →
+`reviewer` → pass, commit reviewed fixes, rerun validation, and restart finishing
+checks from the top. If the failure cannot be resolved without human input or is
+external/environmental/unreproducible with available evidence, the agent reports
+`BLOCKED` or `HUMAN_DECISION_REQUIRED` with evidence instead of claiming done.
+
+## Approaches Considered
+
+1. **Only update `AGENTS.md`.** This creates project-wide policy, but it leaves
+   contradictory skill text telling agents to stop on failed tests.
+2. **Only update the finishing skill.** This fixes the immediate stop condition,
+   but always-on supervisor instructions would still say required checks failing
+   should be reported as `BLOCKED`.
+3. **Update the policy and the operational handoff points.** Put concise policy
+   in `AGENTS.md`, concrete loop mechanics in `finishing-a-development-branch`,
+   remove the contradictory supervisor stop rule, and clarify the SDD finish
+   handoff. This is the recommended approach because future agents see a
+   consistent contract at every decision point.
+
+## Design
+
+Update these instruction layers:
+
+- `AGENTS.md`: add a repository-level rule that required validation failures
+  trigger systematic debugging and reviewed fixes before integration.
+- `.opencode/agents/supervisor.md`: change completion discipline so failed
+  validation enters the debugging/fix loop before `BLOCKED`; `BLOCKED` is only
+  for evidence-backed unresolved, external, environmental, or human-decision
+  cases.
+- `.opencode/skills/finishing-a-development-branch/SKILL.md`: make failed tests
+  an explicit recovery loop: capture failure details, invoke
+  `systematic-debugging`, identify root cause, route fixes through
+  `implementer` → `reviewer`, rerun from Step 0, and forbid integration while
+  red.
+- `.opencode/skills/subagent-driven-development/SKILL.md`: clarify that final
+  review hands off to the finishing skill, and failed finishing validation stays
+  in coordination mode rather than stopping.
+- `docs/dev/features/development-tooling.md`: document the workflow for future
+  maintainers.
+
+No production code, runtime tests, or OpenCode schema/config changes are in
+scope.
+
+## Error Handling
+
+The recovery loop must preserve existing safety rules: no silent failures, no
+test weakening, no supervisor edits to non-allowlisted files, and no unreviewed
+patches. If systematic debugging establishes that the failure is unrelated but
+the required suite remains red, the branch is still not finished; the agent
+reports a blocker with evidence.
+
+## Testing
+
+This is an instruction/documentation change. Focused validation should check
+that all edited instruction files contain consistent wording for failed
+validation, `systematic-debugging`, `implementer` → `reviewer`, and green-suite
+integration. Run `git diff --check`. A full product test suite is not required
+unless implementation unexpectedly edits product code, tests, build files, or
+runtime assets.


### PR DESCRIPTION
## Summary
- Add repository and supervisor policy that failed required validation triggers systematic debugging and reviewed fixes before finishing.
- Update finishing and SDD skills so red validation stays in coordination mode and cannot push/PR/merge/cleanup while red.
- Document the workflow in development tooling docs and add spec/plan artifacts.

## Validation
- rg consistency checks across AGENTS.md, supervisor prompt, finishing skill, SDD skill, and development tooling docs.
- git diff --check.
- SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets make test — 100% tests passed, 0 failed out of 12.

## Note
- OpenCode must be restarted for .opencode/** agent and skill prompt changes to take effect.