### PR TITLE
feat(lua): add sandbox interaction toolbar

### DIFF
--- a/assets/lua/activities.fnl
+++ b/assets/lua/activities.fnl
@@ -80,6 +80,9 @@
   (set app.activity-update nil)
   (set app.activity-preferred-interaction-surface nil)
   (set app.activity-surface-state nil)
+  (set app.activity-top-toolbar-builder nil)
+  (set app.activity-object-move-predicate nil)
+  (set app.activity-drag-attachment-provider nil)
   (set app.canvas-surface-interactive? true)
   true)
 
@@ -96,7 +99,10 @@
    :target-enabled? nil
    :update nil
    :preferred-interaction-surface nil
-   :surface-state nil})
+   :surface-state nil
+   :top-toolbar-builder nil
+   :object-move-predicate nil
+   :drag-attachment-provider nil})
 
 (fn apply-activity-surface-policy! [hooks]
   (local surface-state hooks.surface-state)
@@ -134,6 +140,9 @@
   (set app.activity-input-handlers hooks.input-handlers)
   (set app.activity-target-enabled? hooks.target-enabled?)
   (set app.activity-update hooks.update)
+  (set app.activity-top-toolbar-builder hooks.top-toolbar-builder)
+  (set app.activity-object-move-predicate hooks.object-move-predicate)
+  (set app.activity-drag-attachment-provider hooks.drag-attachment-provider)
   (if hook-state
       (apply-activity-surface-policy! hooks)
       (do
@@ -232,7 +241,10 @@
     :set-update! (fn [_self value] (set-staged-hook! :update value))
     :set-preferred-interaction-surface! (fn [_self value]
                                           (set-staged-hook! :preferred-interaction-surface value))
-    :set-surface-state! (fn [_self value] (set-staged-hook! :surface-state value))})
+    :set-surface-state! (fn [_self value] (set-staged-hook! :surface-state value))
+    :set-top-toolbar-builder! (fn [_self value] (set-staged-hook! :top-toolbar-builder value))
+    :set-object-move-predicate! (fn [_self value] (set-staged-hook! :object-move-predicate value))
+    :set-drag-attachment-provider! (fn [_self value] (set-staged-hook! :drag-attachment-provider value))})
 
 (fn run-cleanup-stack! [cleanup-stack]
   (var first-err nil)

--- a/assets/lua/activity-dock-view.fnl
+++ b/assets/lua/activity-dock-view.fnl
@@ -168,7 +168,8 @@
             (local current-y (or entity-layout.position.y 0))
             (local current-h (or entity-layout.size.y 0))
             (set entity-layout.position.y (+ current-y reserve))
-            (set entity-layout.size.y (math.max 0 (- current-h reserve)))))))
+            (set entity-layout.size.y (math.max 0 (- current-h reserve)))
+            (entity-layout:layouter)))))
 
     (set root-layout
          (Layout {:name "activity-dock"

--- a/assets/lua/activity-dock-view.fnl
+++ b/assets/lua/activity-dock-view.fnl
@@ -43,7 +43,13 @@
       (adjust base (if (and theme (= theme.name :light)) -0.06 -0.04))
       (adjust base (if (and theme (= theme.name :light)) -0.03 0.0))))
 
-(fn ActivityDockView [_opts]
+(fn ActivityDockView [opts]
+  (local options (or opts {}))
+  (fn top-reserve-height []
+    (local provider (and options options.top-reserve-height-provider))
+    (if provider
+        (math.max 0 (provider))
+        0))
   (local build
     (fn [ctx]
     (var root-layout nil)
@@ -154,7 +160,15 @@
         (set content-entity.layout.rotation self.rotation)
         (set content-entity.layout.clip-region self.clip-region)
         (set content-entity.layout.depth-offset-index self.depth-offset-index)
-        (content-entity.layout:layouter)))
+        (content-entity.layout:layouter)
+        (when active-dock-entity
+          (local reserve (top-reserve-height))
+          (when (> reserve 0)
+            (local entity-layout active-dock-entity.layout)
+            (local current-y (or entity-layout.position.y 0))
+            (local current-h (or entity-layout.size.y 0))
+            (set entity-layout.position.y (+ current-y reserve))
+            (set entity-layout.size.y (math.max 0 (- current-h reserve)))))))
 
     (set root-layout
          (Layout {:name "activity-dock"

--- a/assets/lua/activity-top-toolbar-view.fnl
+++ b/assets/lua/activity-top-toolbar-view.fnl
@@ -1,0 +1,56 @@
+(global app (or app {}))
+(local glm (require :glm))
+(local {: Layout} (require :layout))
+
+(fn ActivityTopToolbarView [_opts]
+  (fn build [ctx]
+    (var prev-builder nil)
+    (var built-child nil)
+
+    (fn measurer [self]
+      (local current-builder app.activity-top-toolbar-builder)
+      (when (not (= current-builder prev-builder))
+        (when built-child
+          (built-child:drop)
+          (set built-child nil))
+        (when current-builder
+          (set built-child (current-builder ctx)))
+        (set prev-builder current-builder))
+      (if built-child
+          (let [layout built-child.layout]
+            (layout:measurer)
+            (set self.measure layout.measure))
+          (set self.measure (glm.vec3 0 0 0)))
+      (set app.activity-top-toolbar-height
+           (or (and self.measure self.measure.y) 0)))
+
+    (fn layouter [self]
+      (when built-child
+        (let [layout built-child.layout]
+          (set layout.size (or self.size self.measure))
+          (set layout.position self.position)
+          (set layout.rotation self.rotation)
+          (set layout.clip-region self.clip-region)
+          (set layout.depth-offset-index self.depth-offset-index)
+          (layout:layouter))))
+
+    (local layout
+      (Layout {:name "activity-top-toolbar-view"
+               :measurer measurer
+               :layouter layouter
+               :children []}))
+
+    (fn drop [self]
+      (when built-child
+        (built-child:drop)
+        (set built-child nil))
+      (set prev-builder nil)
+      (set app.activity-top-toolbar-height 0)
+      (layout:drop))
+
+    {:layout layout
+     :drop drop})
+
+  build)
+
+ActivityTopToolbarView

--- a/assets/lua/camera-animation.fnl
+++ b/assets/lua/camera-animation.fnl
@@ -1,0 +1,77 @@
+;; CameraAnimation — minimal scalar smoothing channel.
+;; Provides exponential-decay approach with clamping and snap-at-epsilon.
+(local CameraAnimation {})
+
+(local snap-epsilon 1e-5)
+
+(fn clamp [value min-value max-value]
+  (if (< value min-value) min-value
+      (> value max-value) max-value
+      value))
+
+(fn CameraAnimation.scalar-channel [opts]
+  (local options (or opts {}))
+  (when (not (= (type options.value) :number))
+    (error (.. "scalar-channel :value must be a number, got "
+               (tostring (type options.value))
+               ": " (tostring options.value))))
+  (when (not (= (type options.target) :number))
+    (error (.. "scalar-channel :target must be a number, got "
+               (tostring (type options.target))
+               ": " (tostring options.target))))
+  (when (not (= (type options.smoothing-rate) :number))
+    (error (.. "scalar-channel :smoothing-rate must be a number, got "
+               (tostring (type options.smoothing-rate))
+               ": " (tostring options.smoothing-rate))))
+  (var value options.value)
+  (var target options.target)
+  (var smoothing-rate options.smoothing-rate)
+
+  (fn value-fn [self]
+    value)
+
+  (fn set-target [self new-target]
+    (when (not (= (type new-target) :number))
+      (error (.. "set-target expects a number, got "
+                 (tostring (type new-target))
+                 ": " (tostring new-target))))
+    (set target new-target)
+    true)
+
+  (fn snap [self new-value]
+    (when (not (= (type new-value) :number))
+      (error (.. "snap expects a number, got "
+                 (tostring (type new-value))
+                 ": " (tostring new-value))))
+    (set value new-value)
+    (set target new-value)
+    value)
+
+  (fn update [self delta-seconds]
+    (when (not (= (type delta-seconds) :number))
+      (error (.. "update expects a number for delta-seconds, got "
+                 (tostring (type delta-seconds))
+                 ": " (tostring delta-seconds))))
+    (local distance (- target value))
+    (if (< (math.abs distance) snap-epsilon)
+        (do
+          (set value target)
+          value)
+        (do
+          (local alpha (clamp (- 1 (math.exp (* -1 smoothing-rate delta-seconds)))
+                              0.0 1.0))
+          (set value (+ value (* distance alpha)))
+          ;; Double-check after update: snap if within epsilon
+          (if (< (math.abs (- target value)) snap-epsilon)
+              (set value target))
+          value)))
+
+  (local channel
+    {:value value-fn
+     :set-target set-target
+     :snap snap
+     :update update})
+
+  channel)
+
+CameraAnimation

--- a/assets/lua/camera-animation.fnl
+++ b/assets/lua/camera-animation.fnl
@@ -45,7 +45,7 @@
                  ": " (tostring new-value))))
     (set value new-value)
     (set target new-value)
-    value)
+    true)
 
   (fn update [self delta-seconds]
     (when (not (= (type delta-seconds) :number))

--- a/assets/lua/home-world.fnl
+++ b/assets/lua/home-world.fnl
@@ -1230,7 +1230,9 @@
   (fn get-hud-contrib [world]
     (local runtime world.runtime)
     (if runtime
-        {:left_dock_builder (ActivityDockView {})}
+        {:left_dock_builder (ActivityDockView
+                              {:top-reserve-height-provider
+                               (fn [] (or app.activity-top-toolbar-height 0))})}
         nil))
 
   (set self.init init)

--- a/assets/lua/hud-extended-sidebar-view.fnl
+++ b/assets/lua/hud-extended-sidebar-view.fnl
@@ -18,8 +18,14 @@
       (adjust base (if (and theme (= theme.name :light)) -0.06 -0.04))
       (adjust base (if (and theme (= theme.name :light)) -0.03 0.0))))
 
-(fn HudExtendedSidebarView [sidebar]
+(fn HudExtendedSidebarView [sidebar opts]
   (assert sidebar "HudExtendedSidebarView requires sidebar")
+  (local options (or opts {}))
+  (fn top-reserve-height []
+    (local provider (and options options.top-reserve-height-provider))
+    (if provider
+        (math.max 0 (provider))
+        0))
   (fn build [ctx]
     (local theme (and ctx ctx.theme))
     (var root-layout nil)
@@ -151,10 +157,11 @@
       (set self.size (glm.vec3 allocated-width height 0))
       (local rail-offset (glm.vec3 (- allocated-width rail-w) 0 0))
       (local rail-position (+ base-position (base-rotation:rotate rail-offset)))
+      (local reserve (top-reserve-height))
       (when active-panel-entity
-        (local panel-offset (glm.vec3 (- allocated-width rail-w panel-width) 0 0))
+        (local panel-offset (glm.vec3 (- allocated-width rail-w panel-width) reserve 0))
         (set active-panel-entity.layout.position (+ base-position (base-rotation:rotate panel-offset)))
-        (set active-panel-entity.layout.size (glm.vec3 panel-width height 0))
+        (set active-panel-entity.layout.size (glm.vec3 panel-width (math.max 0 (- height reserve)) 0))
         (set active-panel-entity.layout.rotation base-rotation)
         (set active-panel-entity.layout.clip-region self.clip-region)
         (set active-panel-entity.layout.depth-offset-index (+ base-depth 1))

--- a/assets/lua/hud-layout.fnl
+++ b/assets/lua/hud-layout.fnl
@@ -139,6 +139,7 @@
   (local middle-overlay-root (make-overlay-root))
   (local left-dock-builder options.left-dock-builder)
   (local right-dock-builder options.right-dock-builder)
+  (local top-toolbar-builder options.top-toolbar-builder)
   (local control-wrapper (FullWidth {:name "control-panel-wrapper"
                                      :child control-builder}))
   (local status-wrapper (FullWidth {:name "status-panel-wrapper"
@@ -152,11 +153,28 @@
     (local middle-overlay (middle-overlay-root ctx))
     (local left-dock (and left-dock-builder (left-dock-builder ctx)))
     (local right-dock (and right-dock-builder (right-dock-builder ctx)))
+    (local top-toolbar (and top-toolbar-builder (top-toolbar-builder ctx)))
     (local hud (or ctx.pointer-target {}))
+    (local scene-stack
+      ((Stack {:depth-offset-step panel-depth-layer-step
+               :children [(fn [_ctx] tiles)
+                          (fn [_ctx] float)
+                          (fn [_ctx] middle-overlay)]})
+       ctx))
+    (local center-children [])
+    (when top-toolbar
+      (table.insert center-children (FlexChild (fn [_ctx] top-toolbar))))
+    (table.insert center-children (FlexChild (fn [_ctx] scene-stack) 1))
+    (local center-column
+      ((Flex {:axis 2
+              :xalign :stretch
+              :yspacing 0
+              :children center-children})
+       ctx))
     (local base-children [])
     (when left-dock
       (table.insert base-children (FlexChild (fn [_ctx] left-dock))))
-    (table.insert base-children (FlexChild (fn [_ctx] tiles) 1))
+    (table.insert base-children (FlexChild (fn [_ctx] center-column) 1))
     (when right-dock
       (table.insert base-children (FlexChild (fn [_ctx] right-dock))))
     (local middle-base
@@ -165,18 +183,12 @@
               :yalign :stretch
               :children base-children})
        ctx))
-    (local middle-stack
-      ((Stack {:depth-offset-step panel-depth-layer-step
-               :children [(fn [_ctx] middle-base)
-                          (fn [_ctx] float)
-                          (fn [_ctx] middle-overlay)]})
-       ctx))
     (local bands
       ((Flex {:axis 2
               :xalign :stretch
               :yspacing 0
               :children [(FlexChild (fn [_ctx] control))
-                         (FlexChild (fn [_ctx] middle-stack) 1)
+                         (FlexChild (fn [_ctx] middle-base) 1)
                          (FlexChild (fn [_ctx] status))]})
        ctx))
 
@@ -216,6 +228,8 @@
         (control:update))
       (when (and status status.update)
         (status:update))
+      (when (and top-toolbar top-toolbar.update)
+        (top-toolbar:update))
       (when (and tiles tiles.update)
         (tiles:update))
       (when (and float float.update)
@@ -230,12 +244,14 @@
     (fn drop [self]
       (self.layout:drop)
       (bands:drop)
-      (overlay:drop))
+      (overlay:drop)
+      (when top-toolbar
+        (top-toolbar:drop)))
 
     {:layout layout
      :update update
      :bands-root bands
-     :middle-root middle-stack
+     :middle-root scene-stack
      :control-root control
      :status-root status
      :tiles-root tiles
@@ -244,6 +260,7 @@
      :right-dock-root right-dock
      :middle-overlay-root middle-overlay
      :overlay-root overlay
+     :top-toolbar-root top-toolbar
      :drop drop}))
 
 {:FullWidth FullWidth

--- a/assets/lua/layout-physics-bodies.fnl
+++ b/assets/lua/layout-physics-bodies.fnl
@@ -280,6 +280,12 @@
       (copy-vec3-into! entry.spawn local-offset)
       (set entry.spawn (glm.vec3 local-offset.x local-offset.y local-offset.z))))
 
+(fn drag-attachment-mode []
+  (if (and app.activity-drag-attachment-provider
+           (= (app.activity-drag-attachment-provider) :anchor))
+      :anchor
+      :center))
+
 (fn resolve-entry-world-state [entry base-position base-rotation positioned]
   (local body entry.body)
   (local transform
@@ -475,11 +481,6 @@
       (table.remove entries remove-idx)
       entry)))
 
-(fn drag-attachment-mode []
-  (if (and app.activity-drag-attachment-provider
-           (= (app.activity-drag-attachment-provider) :anchor))
-      :anchor
-      :center))
 
 (fn compute-body-center [entry]
   (if (and entry.body entry.body.getCenterOfMassTransform)
@@ -548,21 +549,32 @@
         (local base (entity-transform entity))
         (local inverse (base.rotation:inverse))
         (local mode (drag-attachment-mode))
-        (if (= mode :anchor)
-            (let [body-center (compute-body-center entry)
-                  entry-half (half-size entry)
-                  layout-rotation (or target.rotation (glm.quat 1 0 0 0))
-                  layout-position (- body-center (layout-rotation:rotate entry-half))]
-              (set target.position layout-position)
-              (update-entry-offset-from-world-center! entry base.position inverse body-center)
-              (when (and entry.positioned entry.positioned.layout)
-                (entry.positioned.layout:mark-layout-dirty))
-              (ensure-body-matches-layout-size entry)
-              (apply-layout-to-body entry)
-              (activate-entry-body! entry)
-              (when entry.body
-                (sync-moved-body entry.body)
-                (entry.body:applyForce (bt.Vector3 0 -0.5 0))))
+      (if (= mode :anchor)
+          (let [body-center (compute-body-center entry)
+                entry-half (half-size entry)
+                ;; Read body rotation from the actual body transform,
+                ;; not from stale layout state. Syncing layout FROM body
+                ;; ensures rotation applied by physics forces is preserved.
+                body-rotation (if (and entry.body entry.body.getCenterOfMassTransform)
+                                 (let [transform (entry.body:getCenterOfMassTransform)]
+                                   (bt-quat->glm-quat (transform:getRotation)))
+                                 (or target.rotation (glm.quat 1 0 0 0)))
+                layout-position (- body-center (body-rotation:rotate entry-half))]
+            ;; Sync layout FROM body (position and rotation).
+            (set target.position layout-position)
+            (set target.rotation body-rotation)
+            (update-entry-offset-from-world-center! entry base.position inverse body-center)
+            (when (and entry.positioned entry.positioned.layout)
+              (entry.positioned.layout:mark-layout-dirty))
+            (ensure-body-matches-layout-size entry)
+            ;; Do NOT call apply-layout-to-body for anchor mode:
+            ;; the body already holds the correct physics transform.
+            ;; apply-layout-to-body would overwrite current body rotation
+            ;; with a value derived from stale layout state.
+            (activate-entry-body! entry)
+            (when entry.body
+              (sync-moved-body entry.body)
+              (entry.body:applyForce (bt.Vector3 0 -0.5 0))))
             (do
               (local world-center (+ target.position (target.rotation:rotate (half-size entry))))
               (update-entry-offset-from-world-center! entry base.position inverse world-center)

--- a/assets/lua/layout-physics-bodies.fnl
+++ b/assets/lua/layout-physics-bodies.fnl
@@ -468,6 +468,44 @@
       (table.remove entries remove-idx)
       entry)))
 
+(fn drag-attachment-mode []
+  (if (and app.activity-drag-attachment-provider
+           (= (app.activity-drag-attachment-provider) :anchor))
+      :anchor
+      :center))
+
+(fn compute-body-center [entry]
+  (if (and entry.body entry.body.getCenterOfMassTransform)
+      (let [transform (entry.body:getCenterOfMassTransform)
+            origin (transform:getOrigin)]
+        (glm.vec3 (or origin.x 0) (or origin.y 0) (or origin.z 0)))
+      (let [layout (and entry.positioned entry.positioned.layout)]
+        (if layout
+            (+ layout.position
+               (layout.rotation:rotate (half-size entry)))
+            (glm.vec3 0 0 0)))))
+
+(fn apply-anchor-force! [entry relative-anchor desired-world-position]
+  (local spring-strength 35.0)
+  (local body entry.body)
+  (local body-center (compute-body-center entry))
+  (local current-anchor-world
+    (+ body-center relative-anchor))
+  (local spring-force
+    (* (- desired-world-position current-anchor-world)
+       (glm.vec3 spring-strength spring-strength spring-strength)))
+  ;; Apply velocity damping if getVelocityInLocalPoint is available
+  (local damped-force
+    (if body.getVelocityInLocalPoint
+        (let [velocity (body:getVelocityInLocalPoint (bt-glm-vec3 relative-anchor))]
+          (- spring-force (* (physics-glm-vec3 velocity) (glm.vec3 4.0 4.0 4.0))))
+        spring-force))
+  (body:applyForceAtPosition (bt-glm-vec3 damped-force)
+                              (bt-glm-vec3 relative-anchor))
+  ;; Activate the body
+  (when body.activate
+    (body:activate true)))
+
 (fn create-movable-entry [entity entry]
   (local target (and entry.positioned entry.positioned.layout))
   (when target
@@ -479,6 +517,21 @@
      (fn [_movable]
        (set entry.dragging true)
        (ensure-body-matches-layout-size entry))
+     :on-drag-update
+     (fn [movable drag update]
+       (local mode (drag-attachment-mode))
+       (if (= mode :anchor)
+           (do
+             (assert entry.body "Anchor drag requires a physics body on the entry")
+             (assert entry.body.applyForceAtPosition
+                     "Anchor drag requires body:applyForceAtPosition binding")
+             (local body-center (compute-body-center entry))
+             (when (not drag.relative-anchor)
+               (set drag.relative-anchor
+                    (- drag.hit-point body-center)))
+             (apply-anchor-force! entry drag.relative-anchor update.new-position)
+             true)
+           false))
      :on-drag-end
      (fn [_movable]
        (set entry.dragging false)

--- a/assets/lua/layout-physics-bodies.fnl
+++ b/assets/lua/layout-physics-bodies.fnl
@@ -289,10 +289,17 @@
   {:body body
    :world-position
    (if entry.dragging
-       (do
-         (apply-layout-to-body entry)
-         (+ positioned.layout.position
-            (positioned.layout.rotation:rotate (half-size entry))))
+       (if (= (drag-attachment-mode) :anchor)
+           (if transform
+               (do
+                 (local origin (transform:getOrigin))
+                 (physics-glm-vec3 origin))
+               (+ positioned.layout.position
+                  (positioned.layout.rotation:rotate (half-size entry))))
+           (do
+             (apply-layout-to-body entry)
+             (+ positioned.layout.position
+                (positioned.layout.rotation:rotate (half-size entry)))))
        (if transform
            (do
              (local origin (transform:getOrigin))
@@ -514,9 +521,12 @@
      :key entry
      :owner entry.positioned
      :on-drag-start
-     (fn [_movable]
-       (set entry.dragging true)
-       (ensure-body-matches-layout-size entry))
+      (fn [_movable drag _payload]
+        (set entry.dragging true)
+        (ensure-body-matches-layout-size entry)
+        (when (= (drag-attachment-mode) :anchor)
+          (set drag.relative-anchor
+               (- drag.hit-point (compute-body-center entry)))))
      :on-drag-update
      (fn [movable drag update]
        (local mode (drag-attachment-mode))
@@ -533,20 +543,37 @@
              true)
            false))
      :on-drag-end
-     (fn [_movable]
-       (set entry.dragging false)
-       (local base (entity-transform entity))
-       (local inverse (base.rotation:inverse))
-       (local world-center (+ target.position (target.rotation:rotate (half-size entry))))
-       (update-entry-offset-from-world-center! entry base.position inverse world-center)
-       (when (and entry.positioned entry.positioned.layout)
-         (entry.positioned.layout:mark-layout-dirty))
-       (ensure-body-matches-layout-size entry)
-       (apply-layout-to-body entry)
-       (activate-entry-body! entry)
-       (when entry.body
-         (sync-moved-body entry.body)
-         (entry.body:applyForce (bt.Vector3 0 -0.5 0))))
+      (fn [_movable]
+        (set entry.dragging false)
+        (local base (entity-transform entity))
+        (local inverse (base.rotation:inverse))
+        (local mode (drag-attachment-mode))
+        (if (= mode :anchor)
+            (let [body-center (compute-body-center entry)
+                  entry-half (half-size entry)
+                  layout-rotation (or target.rotation (glm.quat 1 0 0 0))
+                  layout-position (- body-center (layout-rotation:rotate entry-half))]
+              (set target.position layout-position)
+              (update-entry-offset-from-world-center! entry base.position inverse body-center)
+              (when (and entry.positioned entry.positioned.layout)
+                (entry.positioned.layout:mark-layout-dirty))
+              (ensure-body-matches-layout-size entry)
+              (apply-layout-to-body entry)
+              (activate-entry-body! entry)
+              (when entry.body
+                (sync-moved-body entry.body)
+                (entry.body:applyForce (bt.Vector3 0 -0.5 0))))
+            (do
+              (local world-center (+ target.position (target.rotation:rotate (half-size entry))))
+              (update-entry-offset-from-world-center! entry base.position inverse world-center)
+              (when (and entry.positioned entry.positioned.layout)
+                (entry.positioned.layout:mark-layout-dirty))
+              (ensure-body-matches-layout-size entry)
+              (apply-layout-to-body entry)
+              (activate-entry-body! entry)
+              (when entry.body
+                (sync-moved-body entry.body)
+                (entry.body:applyForce (bt.Vector3 0 -0.5 0))))))
      }))
 
 (fn collect-movables [entity]

--- a/assets/lua/layout-physics-bodies.fnl
+++ b/assets/lua/layout-physics-bodies.fnl
@@ -2,6 +2,7 @@
 (local bt (require :bt))
 (local CoordinateGuard (require :coordinate-guard))
 (local logging (require :logging))
+(local Runtime (require :state-runtime))
 
 (local safe-vec3? CoordinateGuard.safe-vec3?)
 
@@ -281,10 +282,7 @@
       (set entry.spawn (glm.vec3 local-offset.x local-offset.y local-offset.z))))
 
 (fn drag-attachment-mode []
-  (if (and app.activity-drag-attachment-provider
-           (= (app.activity-drag-attachment-provider) :anchor))
-      :anchor
-      :center))
+  (Runtime.drag-attachment-mode))
 
 (fn resolve-entry-world-state [entry base-position base-rotation positioned]
   (local body entry.body)

--- a/assets/lua/main.fnl
+++ b/assets/lua/main.fnl
@@ -107,6 +107,7 @@
 (local OpencodeSdk (require :llm/providers/opencode))
 (local HudExtendedSidebar (require :hud-extended-sidebar))
 (local HudExtendedSidebarView (require :hud-extended-sidebar-view))
+(local ActivityTopToolbarView (require :activity-top-toolbar-view))
 (local fennel-cache (require :fennel-cache))
 (local bytecode-enabled
   (do
@@ -955,7 +956,11 @@
       (set hud-opts.left-dock-builder contrib.left_dock_builder))
     (when app.agent-runner
       (ensure-extended-sidebar!)
-      (set hud-opts.right-dock-builder (HudExtendedSidebarView app.extended-sidebar)))
+      (set hud-opts.right-dock-builder
+           (HudExtendedSidebarView app.extended-sidebar
+                                   {:top-reserve-height-provider
+                                    (fn [] (or app.activity-top-toolbar-height 0))})))
+    (set hud-opts.top-toolbar-builder (ActivityTopToolbarView {}))
     (app.hud:build-default hud-opts)
     (clear-active-world-hud-overlay)
     (when contrib.overlay

--- a/assets/lua/movables.fnl
+++ b/assets/lua/movables.fnl
@@ -93,9 +93,9 @@
       (local entry self.drag.entry)
       (local started? (and self.drag self.drag.started?))
       (local drag self.drag)
-      (set self.drag nil)
       (when (and started? entry entry.on-drag-end)
-        (entry.on-drag-end entry drag))))
+        (entry.on-drag-end entry drag))
+      (set self.drag nil)))
 
   (fn start-drag [_self drag payload]
     (when (and drag (not drag.started?))

--- a/assets/lua/movables.fnl
+++ b/assets/lua/movables.fnl
@@ -92,16 +92,17 @@
     (when self.drag
       (local entry self.drag.entry)
       (local started? (and self.drag self.drag.started?))
+      (local drag self.drag)
       (set self.drag nil)
       (when (and started? entry entry.on-drag-end)
-        (entry.on-drag-end entry))))
+        (entry.on-drag-end entry drag))))
 
   (fn start-drag [_self drag payload]
     (when (and drag (not drag.started?))
       (set drag.started? true)
       (local entry drag.entry)
       (when (and entry entry.on-drag-start)
-        (entry.on-drag-start entry))
+        (entry.on-drag-start entry drag payload))
       (local target (and entry entry.target))
       (local hit-point drag.hit-point)
       (when (and target hit-point)
@@ -196,6 +197,7 @@
                     :pointer-target pointer-target
                     :key (or (and options options.key) widget)
                     :on-drag-start (and options options.on-drag-start)
+                    :on-drag-update (and options options.on-drag-update)
                     :on-drag-end (and options options.on-drag-end)})
       (when entry.key
         (remove-entry self (find-entry self entry.key)))
@@ -251,7 +253,16 @@
               (when hit
                 (local new-position (+ hit drag.offset))
                 (assert-finite-vec3 new-position "drag position")
-                (drag.entry.target:set-position new-position)))))))
+                (if (and drag.entry drag.entry.on-drag-update)
+                    (let [update {:payload payload
+                                  :pointer pointer
+                                  :ray ray
+                                  :hit hit
+                                  :new-position new-position
+                                  :plane drag.plane}]
+                      (when (not (drag.entry.on-drag-update drag.entry drag update))
+                        (drag.entry.target:set-position new-position)))
+                    (drag.entry.target:set-position new-position))))))))
 
   (fn on-mouse-button-down [self payload]
     (when (and payload (= payload.button SDL_BUTTON_LEFT))

--- a/assets/lua/sandbox-activity-unit.fnl
+++ b/assets/lua/sandbox-activity-unit.fnl
@@ -7,6 +7,8 @@
 (local Activities (require :activities))
 (local SandboxActivityActions (require :sandbox-activity-actions))
 (local ActivityCameraState (require :activity-camera-state))
+(local SandboxToolbarState (require :sandbox-toolbar-state))
+(local SandboxToolbarView (require :sandbox-toolbar-view))
 
 (fn sandbox-activity-owned-paths []
   (local runtime (require :runtime))
@@ -135,6 +137,15 @@
   (ctx:set-target-enabled! sandbox-target-enabled?)
   ;; Incremental hydration: restore queued panels one per frame
   (ctx:set-update! sandbox-activity-update)
+  ;; Toolbar state: create or reuse
+  (local toolbar-state (or world-runtime.sandbox-toolbar-state
+                           (SandboxToolbarState {})))
+  (set world-runtime.sandbox-toolbar-state toolbar-state)
+  (set app.sandbox-toolbar-state toolbar-state)
+  ;; Install toolbar hooks
+  (ctx:set-top-toolbar-builder! (SandboxToolbarView toolbar-state))
+  (ctx:set-object-move-predicate! (fn [] (= toolbar-state.object-move-enabled? true)))
+  (ctx:set-drag-attachment-provider! (fn [] toolbar-state.drag-attachment))
   {:activity-id "sandbox"})
 
 (fn slice-array-from [entries start-index]
@@ -161,6 +172,7 @@
   (when (and app.active-world-runtime app.active-world-runtime.scene)
     (local scene app.active-world-runtime.scene)
     (scene:deactivate-activity-slot "sandbox"))
+  (set app.sandbox-toolbar-state nil)
   true)
 
 (fn snapshot-sandbox-activity! []
@@ -186,6 +198,9 @@
         ;; across save/reload cycles.
         (when camera
           (set captured.camera (ActivityCameraState.capture-camera camera)))
+        ;; Persist toolbar state
+        (when runtime.sandbox-toolbar-state
+          (set captured.toolbar (runtime.sandbox-toolbar-state:capture-state)))
         {:scene captured})
       nil))
 
@@ -198,10 +213,14 @@
     (app.active-world-runtime.scene:restore-activity-slot-state "sandbox" scene-state))
   ;; Restore camera position from the persisted session state
   (when (and scene-state scene-state.camera
-             app.active-world-runtime app.active-world-runtime.activity-cameras)
+              app.active-world-runtime app.active-world-runtime.activity-cameras)
     (local camera (. app.active-world-runtime.activity-cameras.scene "sandbox"))
     (when camera
       (ActivityCameraState.restore-camera! camera scene-state.camera)))
+  ;; Restore toolbar state
+  (when (and scene-state scene-state.toolbar
+              app.active-world-runtime app.active-world-runtime.sandbox-toolbar-state)
+    (app.active-world-runtime.sandbox-toolbar-state:restore-state scene-state.toolbar))
   true)
 
 (fn load-sandbox-activity! []

--- a/assets/lua/sandbox-activity-unit.fnl
+++ b/assets/lua/sandbox-activity-unit.fnl
@@ -121,16 +121,27 @@
                               (set (. world-runtime.activity-cameras.scene "sandbox") cam)
                               cam))))
   (when world-runtime.activity-controls
+    ;; Check for a previous raw FirstPersonControls at the sandbox key
+    ;; (i.e. before the wrapper existed). If present, reuse it as the inner
+    ;; flight-controls so any accumulated state (key tracking, etc.) is preserved.
+    (local previous-raw (and world-runtime.activity-controls.scene
+                             (. world-runtime.activity-controls.scene "sandbox")))
     ;; Create or reuse inner flight controls (raw FirstPersonControls)
     (local flight-controls (or (. world-runtime.activity-controls.scene "sandbox-flight")
-                               (let [ctrl (FirstPersonControls {:camera sandbox-camera})]
-                                 (set (. world-runtime.activity-controls.scene "sandbox-flight") ctrl)
-                                 ctrl)))
+                                (and previous-raw
+                                     (not previous-raw.flight-controls)
+                                     previous-raw)
+                                (let [ctrl (FirstPersonControls {:camera sandbox-camera})]
+                                  (set (. world-runtime.activity-controls.scene "sandbox-flight") ctrl)
+                                  ctrl)))
+    ;; Ensure the raw controls reference is stored at sandbox-flight for cleanup
+    (when (not (. world-runtime.activity-controls.scene "sandbox-flight"))
+      (set (. world-runtime.activity-controls.scene "sandbox-flight") flight-controls))
     ;; Wrap in SandboxCameraControls (handles flight/grounded camera mode)
     (set sandbox-controls (SandboxCameraControls {:camera sandbox-camera
-                                                   :toolbar-state toolbar-state
-                                                   :flight-controls flight-controls
-                                                   :terrain-sampler scene}))
+                                                    :toolbar-state toolbar-state
+                                                    :flight-controls flight-controls
+                                                    :terrain-sampler scene}))
     (set (. world-runtime.activity-controls.scene "sandbox") sandbox-controls))
   ;; Install camera and controls on the scene slot
   (local slot (scene:activity-slot "sandbox"))

--- a/assets/lua/sandbox-activity-unit.fnl
+++ b/assets/lua/sandbox-activity-unit.fnl
@@ -4,6 +4,7 @@
 (local fs (require :fs))
 (local Camera (require :camera))
 (local {: FirstPersonControls} (require :first-person-controls))
+(local {: SandboxCameraControls} (require :sandbox-camera-controls))
 (local Activities (require :activities))
 (local SandboxActivityActions (require :sandbox-activity-actions))
 (local ActivityCameraState (require :activity-camera-state))
@@ -103,6 +104,12 @@
   ;; existing retained state provides the canonical scene data.
   (scene:ensure-activity-slot "sandbox")
 
+  ;; Toolbar state: create or reuse (must be before controls — they need it)
+  (local toolbar-state (or world-runtime.sandbox-toolbar-state
+                            (SandboxToolbarState {})))
+  (set world-runtime.sandbox-toolbar-state toolbar-state)
+  (set app.sandbox-toolbar-state toolbar-state)
+
   ;; Create or reuse a sandbox scene camera from the activity session.
   ;; Each activity owns its camera; the sandbox camera is stored in
   ;; runtime.activity-cameras.scene.sandbox.
@@ -114,10 +121,17 @@
                               (set (. world-runtime.activity-cameras.scene "sandbox") cam)
                               cam))))
   (when world-runtime.activity-controls
-    (set sandbox-controls (or (. world-runtime.activity-controls.scene "sandbox")
+    ;; Create or reuse inner flight controls (raw FirstPersonControls)
+    (local flight-controls (or (. world-runtime.activity-controls.scene "sandbox-flight")
                                (let [ctrl (FirstPersonControls {:camera sandbox-camera})]
-                                 (set (. world-runtime.activity-controls.scene "sandbox") ctrl)
-                                 ctrl))))
+                                 (set (. world-runtime.activity-controls.scene "sandbox-flight") ctrl)
+                                 ctrl)))
+    ;; Wrap in SandboxCameraControls (handles flight/grounded camera mode)
+    (set sandbox-controls (SandboxCameraControls {:camera sandbox-camera
+                                                   :toolbar-state toolbar-state
+                                                   :flight-controls flight-controls
+                                                   :terrain-sampler scene}))
+    (set (. world-runtime.activity-controls.scene "sandbox") sandbox-controls))
   ;; Install camera and controls on the scene slot
   (local slot (scene:activity-slot "sandbox"))
   (when sandbox-camera
@@ -137,11 +151,6 @@
   (ctx:set-target-enabled! sandbox-target-enabled?)
   ;; Incremental hydration: restore queued panels one per frame
   (ctx:set-update! sandbox-activity-update)
-  ;; Toolbar state: create or reuse
-  (local toolbar-state (or world-runtime.sandbox-toolbar-state
-                           (SandboxToolbarState {})))
-  (set world-runtime.sandbox-toolbar-state toolbar-state)
-  (set app.sandbox-toolbar-state toolbar-state)
   ;; Install toolbar hooks
   (ctx:set-top-toolbar-builder! (SandboxToolbarView toolbar-state))
   (ctx:set-object-move-predicate! (fn [] (= toolbar-state.object-move-enabled? true)))
@@ -173,6 +182,11 @@
     (local scene app.active-world-runtime.scene)
     (scene:deactivate-activity-slot "sandbox"))
   (set app.sandbox-toolbar-state nil)
+  (when (and app.active-world-runtime app.active-world-runtime.activity-controls)
+    ;; Clean up the flight controls wrapper reference; the scene slot
+    ;; handles the rest.
+    (set (. app.active-world-runtime.activity-controls.scene "sandbox-flight") nil)
+    (set (. app.active-world-runtime.activity-controls.scene "sandbox") nil))
   true)
 
 (fn snapshot-sandbox-activity! []

--- a/assets/lua/sandbox-camera-controls.fnl
+++ b/assets/lua/sandbox-camera-controls.fnl
@@ -78,10 +78,15 @@
   (var grounded-mouse-pos nil)
   (var grounded-pitch 0.0)
 
+  ;; Track camera mode so we can detect flight→grounded transitions
+  ;; and sync the y-channel from the camera's current Y before
+  ;; the first grounded terrain update.
+  (var prev-camera-mode toolbar-state.camera-mode)
+
   (local y-channel (CameraAnimation.scalar-channel
-                     {:value (vec3-y camera.position)
-                      :target (vec3-y camera.position)
-                      :smoothing-rate 8.0}))
+                      {:value (vec3-y camera.position)
+                       :target (vec3-y camera.position)
+                       :smoothing-rate 8.0}))
 
   (fn apply-grounded-pitch! [delta]
     "Apply a pitch delta clamped to [pitch-min, pitch-max]."
@@ -121,11 +126,14 @@
                  (- grounded-vertical-velocity (* gravity delta-seconds)))
             (let [new-y (+ current-y (* grounded-vertical-velocity delta-seconds))]
               (if (<= new-y target-y)
-                  ;; Land: snap to terrain+eye-height and clear airborne state
+                  ;; Land: snap channel to target-y (not new-y which could
+                  ;; be below terrain+eye-height), then set camera to target-y
+                  ;; so the next frame's smoothing starts at the correct
+                  ;; terrain-following height.
                   (do
                     (set grounded-vertical-velocity 0.0)
                     (set grounded-airborne? false)
-                    (y-channel:snap new-y)
+                    (y-channel:snap target-y)
                     (y-channel:set-target target-y)
                     (camera:set-position
                       (glm.vec3 (vec3-x camera.position) target-y (vec3-z camera.position))))
@@ -140,12 +148,25 @@
               (camera:set-position
                 (glm.vec3 (vec3-x camera.position) smoothed-y (vec3-z camera.position))))))))
 
+  (fn sync-y-channel-on-flight-to-grounded-transition! []
+    "When entering grounded mode from flight, synchronize the smoothing
+    channel to the camera's current Y so terrain following starts from
+    the right value instead of a stale construction-time Y."
+    (when (and (= toolbar-state.camera-mode :grounded)
+               (not (= prev-camera-mode :grounded)))
+      (let [current-y (vec3-y camera.position)]
+        (y-channel:snap current-y)
+        (y-channel:set-target current-y))))
+
   (fn update [self delta]
-    (let [delta-seconds (delta->seconds delta delta-unit)]
-      (if (= toolbar-state.camera-mode :flight)
+    (let [delta-seconds (delta->seconds delta delta-unit)
+          current-mode toolbar-state.camera-mode]
+      (if (= current-mode :flight)
           (flight-controls:update delta)
           (do
             (ensure-grounded-deps!)
+            ;; Sync y-channel from current camera Y on flight→grounded transition.
+            (sync-y-channel-on-flight-to-grounded-transition!)
             ;; Horizontal movement
             (when (or (grounded-action-active? :move-left)
                       (grounded-action-active? :move-right)
@@ -175,7 +196,9 @@
             (when (grounded-action-active? :look-left)
               (camera:yaw (* -1 delta-seconds 1.0)))
             ;; Gravity and terrain following
-            (grounded-apply-gravity-and-terrain delta-seconds)))))
+            (grounded-apply-gravity-and-terrain delta-seconds)))
+      ;; Track camera mode for next frame's transition detection
+      (set prev-camera-mode current-mode)))
 
   (fn drop [self]
     (flight-controls:drop)
@@ -217,7 +240,9 @@
   (fn on-mouse-wheel [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-mouse-wheel payload)
-        nil))  ;; grounded mode: wheel is a no-op
+        (do
+          (ensure-grounded-deps!)
+          nil)))  ;; grounded mode: wheel is a no-op
 
   (fn on-mouse-button-down [self payload]
     (if (= toolbar-state.camera-mode :flight)
@@ -250,17 +275,23 @@
   (fn on-gamepad-button-down [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-gamepad-button-down payload)
-        nil))
+        (do
+          (ensure-grounded-deps!)
+          nil)))
 
   (fn on-gamepad-axis-motion [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-gamepad-axis-motion payload)
-        nil))
+        (do
+          (ensure-grounded-deps!)
+          nil)))
 
   (fn on-gamepad-removed [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-gamepad-removed payload)
-        nil))
+        (do
+          (ensure-grounded-deps!)
+          nil)))
 
   {:update update
    :drop drop

--- a/assets/lua/sandbox-camera-controls.fnl
+++ b/assets/lua/sandbox-camera-controls.fnl
@@ -100,9 +100,13 @@
     (* movement-speed
        (if (grounded-action-active? :jump) 1.5 1.0)))
 
-  (fn grounded-sample-terrain-height []
+  (fn ensure-grounded-deps! []
+    "Assert that all dependencies required for grounded mode are present."
     (when (not options.terrain-sampler)
-      (error "SandboxCameraControls grounded mode requires terrain sampler (terrain-sampler)"))
+      (error "SandboxCameraControls grounded mode requires terrain sampler (terrain-sampler)")))
+
+  (fn grounded-sample-terrain-height []
+    (ensure-grounded-deps!)
     (let [sampled (options.terrain-sampler:height-at-world-point camera.position)]
       (if (finite-number? sampled) sampled 0.0)))
 
@@ -141,6 +145,7 @@
       (if (= toolbar-state.camera-mode :flight)
           (flight-controls:update delta)
           (do
+            (ensure-grounded-deps!)
             ;; Horizontal movement
             (when (or (grounded-action-active? :move-left)
                       (grounded-action-active? :move-right)
@@ -195,6 +200,7 @@
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-key-down payload)
         (do
+          (ensure-grounded-deps!)
           (set (. grounded-keys payload.key) true)
           (when (and (= payload.key default-key-mapping.jump)
                      (not grounded-airborne?))
@@ -204,7 +210,9 @@
   (fn on-key-up [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-key-up payload)
-        (set (. grounded-keys payload.key) nil)))
+        (do
+          (ensure-grounded-deps!)
+          (set (. grounded-keys payload.key) nil))))
 
   (fn on-mouse-wheel [self payload]
     (if (= toolbar-state.camera-mode :flight)
@@ -214,24 +222,30 @@
   (fn on-mouse-button-down [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-mouse-button-down payload)
-        (when (= payload.button SDL_BUTTON_LEFT)
-          (set grounded-drag-look-start {:x payload.x :y payload.y}))))
+        (do
+          (ensure-grounded-deps!)
+          (when (= payload.button SDL_BUTTON_LEFT)
+            (set grounded-drag-look-start {:x payload.x :y payload.y})))))
 
   (fn on-mouse-button-up [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-mouse-button-up payload)
-        (when (= payload.button SDL_BUTTON_LEFT)
-          (set grounded-drag-look-start nil))))
+        (do
+          (ensure-grounded-deps!)
+          (when (= payload.button SDL_BUTTON_LEFT)
+            (set grounded-drag-look-start nil)))))
 
   (fn on-mouse-motion [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-mouse-motion payload)
-        (when grounded-drag-look-start
-          (let [dx (- payload.x grounded-drag-look-start.x)
-                dy (- payload.y grounded-drag-look-start.y)]
-            (set grounded-drag-look-start {:x payload.x :y payload.y})
-            (camera:yaw (* dx mouse-look-speed))
-            (apply-grounded-pitch! (* dy mouse-look-speed))))))
+        (do
+          (ensure-grounded-deps!)
+          (when grounded-drag-look-start
+            (let [dx (- payload.x grounded-drag-look-start.x)
+                  dy (- payload.y grounded-drag-look-start.y)]
+              (set grounded-drag-look-start {:x payload.x :y payload.y})
+              (camera:yaw (* dx mouse-look-speed))
+              (apply-grounded-pitch! (* dy mouse-look-speed)))))))
 
   (fn on-gamepad-button-down [self payload]
     (if (= toolbar-state.camera-mode :flight)

--- a/assets/lua/sandbox-camera-controls.fnl
+++ b/assets/lua/sandbox-camera-controls.fnl
@@ -76,11 +76,21 @@
   (var grounded-airborne? false)
   (var grounded-drag-look-start nil)
   (var grounded-mouse-pos nil)
+  (var grounded-pitch 0.0)
 
   (local y-channel (CameraAnimation.scalar-channel
                      {:value (vec3-y camera.position)
                       :target (vec3-y camera.position)
                       :smoothing-rate 8.0}))
+
+  (fn apply-grounded-pitch! [delta]
+    "Apply a pitch delta clamped to [pitch-min, pitch-max]."
+    (local new-pitch (+ grounded-pitch delta))
+    (local clamped-pitch (clamp new-pitch pitch-min pitch-max))
+    (local actual-delta (- clamped-pitch grounded-pitch))
+    (when (not (= actual-delta 0.0))
+      (camera:pitch actual-delta))
+    (set grounded-pitch clamped-pitch))
 
   (fn grounded-action-active? [action]
     (local key (. default-key-mapping action))
@@ -91,10 +101,10 @@
        (if (grounded-action-active? :jump) 1.5 1.0)))
 
   (fn grounded-sample-terrain-height []
-    (if options.terrain-sampler
-        (let [sampled (options.terrain-sampler:height-at-world-point camera.position)]
-          (if (finite-number? sampled) sampled 0.0))
-        0.0))
+    (when (not options.terrain-sampler)
+      (error "SandboxCameraControls grounded mode requires terrain sampler (terrain-sampler)"))
+    (let [sampled (options.terrain-sampler:height-at-world-point camera.position)]
+      (if (finite-number? sampled) sampled 0.0)))
 
   (fn grounded-apply-gravity-and-terrain [delta-seconds]
     (let [terrain-height (grounded-sample-terrain-height)
@@ -152,9 +162,9 @@
                   (camera:set-position (+ camera.position flat-move)))))
             ;; Keyboard look
             (when (grounded-action-active? :look-up)
-              (camera:pitch (* delta-seconds 1.0)))
+              (apply-grounded-pitch! (* delta-seconds 1.0)))
             (when (grounded-action-active? :look-down)
-              (camera:pitch (* -1 delta-seconds 1.0)))
+              (apply-grounded-pitch! (* -1 delta-seconds 1.0)))
             (when (grounded-action-active? :look-right)
               (camera:yaw (* delta-seconds 1.0)))
             (when (grounded-action-active? :look-left)
@@ -168,7 +178,8 @@
     (set grounded-drag-look-start nil)
     (set grounded-mouse-pos nil)
     (set grounded-vertical-velocity 0.0)
-    (set grounded-airborne? false))
+    (set grounded-airborne? false)
+    (set grounded-pitch 0.0))
 
   (fn drag-active? [self]
     (if (= toolbar-state.camera-mode :flight)
@@ -198,7 +209,7 @@
   (fn on-mouse-wheel [self payload]
     (if (= toolbar-state.camera-mode :flight)
         (flight-controls:on-mouse-wheel payload)
-        (flight-controls:on-mouse-wheel payload)))
+        nil))  ;; grounded mode: wheel is a no-op
 
   (fn on-mouse-button-down [self payload]
     (if (= toolbar-state.camera-mode :flight)
@@ -220,7 +231,7 @@
                 dy (- payload.y grounded-drag-look-start.y)]
             (set grounded-drag-look-start {:x payload.x :y payload.y})
             (camera:yaw (* dx mouse-look-speed))
-            (camera:pitch (* dy mouse-look-speed))))))
+            (apply-grounded-pitch! (* dy mouse-look-speed))))))
 
   (fn on-gamepad-button-down [self payload]
     (if (= toolbar-state.camera-mode :flight)
@@ -249,6 +260,7 @@
    :on-mouse-motion on-mouse-motion
    :on-gamepad-button-down on-gamepad-button-down
    :on-gamepad-axis-motion on-gamepad-axis-motion
-   :on-gamepad-removed on-gamepad-removed})
+   :on-gamepad-removed on-gamepad-removed
+   :flight-controls flight-controls})
 
 {: SandboxCameraControls}

--- a/assets/lua/sandbox-camera-controls.fnl
+++ b/assets/lua/sandbox-camera-controls.fnl
@@ -1,0 +1,254 @@
+;; SandboxCameraControls — flight/grounded camera controls wrapper.
+;; Delegates to existing FirstPersonControls in :flight mode and
+;; provides terrain-following grounded movement in :grounded mode.
+(local glm (require :glm))
+(local CameraAnimation (require :camera-animation))
+
+(local SDL_BUTTON_LEFT 1)
+
+(local default-key-mapping
+  {:move-left 97
+   :move-right 101
+   :move-forward 44
+   :move-backward 111
+   :look-up 1073741906
+   :look-down 1073741905
+   :look-right 1073741904
+   :look-left 1073741903
+   :jump 32})
+
+(fn finite-number? [value]
+  (and (= (type value) :number)
+       (= value value)
+       (not (= value math.huge))
+       (not (= value (- math.huge)))))
+
+(fn delta->seconds [delta delta-unit]
+  (if (not (finite-number? delta))
+      0
+      (= delta-unit :milliseconds)
+      (/ delta 1000.0)
+      (= delta-unit :seconds)
+      delta
+      (error (.. "SandboxCameraControls invalid :delta-unit "
+                 (tostring delta-unit)
+                 " (expected :milliseconds or :seconds)"))))
+
+(fn clamp [value min-value max-value]
+  (if (< value min-value) min-value
+      (> value max-value) max-value
+      value))
+
+(fn vec3-x [v] (. v 1))
+(fn vec3-y [v] (. v 2))
+(fn vec3-z [v] (. v 3))
+
+(fn horizontal-component [vec3-val]
+  (local flat (glm.vec3 (vec3-x vec3-val) 0 (vec3-z vec3-val)))
+  (local len (glm.length flat))
+  (if (> len 0.0001)
+      (/ flat len)
+      (glm.vec3 0 0 0)))
+
+(fn SandboxCameraControls [opts]
+  (local options (or opts {}))
+  (local camera (assert options.camera
+                        "SandboxCameraControls requires a camera"))
+  (local toolbar-state (assert options.toolbar-state
+                               "SandboxCameraControls requires toolbar-state"))
+  (local flight-controls (assert options.flight-controls
+                                 "SandboxCameraControls requires flight-controls"))
+  (local delta-unit (or options.delta-unit :milliseconds))
+  (local eye-height (or options.eye-height 2.0))
+  (local gravity (or options.gravity 18.0))
+  (local jump-speed (or options.jump-speed 8.0))
+  (local pitch-min (or options.pitch-min -1.2))
+  (local pitch-max (or options.pitch-max 1.2))
+  (local movement-speed (or options.movement-speed 10.0))
+  (local mouse-look-speed (or options.mouse-look-speed 0.001))
+
+  (when (= toolbar-state.camera-mode :grounded)
+    (when (not options.terrain-sampler)
+      (error "SandboxCameraControls grounded mode requires terrain sampler (terrain-sampler)")))
+
+  (var grounded-keys {})
+  (var grounded-vertical-velocity 0.0)
+  (var grounded-airborne? false)
+  (var grounded-drag-look-start nil)
+  (var grounded-mouse-pos nil)
+
+  (local y-channel (CameraAnimation.scalar-channel
+                     {:value (vec3-y camera.position)
+                      :target (vec3-y camera.position)
+                      :smoothing-rate 8.0}))
+
+  (fn grounded-action-active? [action]
+    (local key (. default-key-mapping action))
+    (and key (. grounded-keys key)))
+
+  (fn grounded-horizontal-speed []
+    (* movement-speed
+       (if (grounded-action-active? :jump) 1.5 1.0)))
+
+  (fn grounded-sample-terrain-height []
+    (if options.terrain-sampler
+        (let [sampled (options.terrain-sampler:height-at-world-point camera.position)]
+          (if (finite-number? sampled) sampled 0.0))
+        0.0))
+
+  (fn grounded-apply-gravity-and-terrain [delta-seconds]
+    (let [terrain-height (grounded-sample-terrain-height)
+          target-y (+ terrain-height eye-height)
+          current-y (vec3-y camera.position)]
+      (if grounded-airborne?
+          ;; Airborne: integrate velocity under gravity, check for landing
+          (do
+            (set grounded-vertical-velocity
+                 (- grounded-vertical-velocity (* gravity delta-seconds)))
+            (let [new-y (+ current-y (* grounded-vertical-velocity delta-seconds))]
+              (if (<= new-y target-y)
+                  ;; Land: snap to terrain+eye-height and clear airborne state
+                  (do
+                    (set grounded-vertical-velocity 0.0)
+                    (set grounded-airborne? false)
+                    (y-channel:snap new-y)
+                    (y-channel:set-target target-y)
+                    (camera:set-position
+                      (glm.vec3 (vec3-x camera.position) target-y (vec3-z camera.position))))
+                  ;; Still airborne: apply position directly
+                  (camera:set-position
+                    (glm.vec3 (vec3-x camera.position) new-y (vec3-z camera.position))))))
+          ;; Grounded: always use scalar channel for smooth terrain following
+          (do
+            (set grounded-vertical-velocity 0.0)
+            (y-channel:set-target target-y)
+            (let [smoothed-y (y-channel:update delta-seconds)]
+              (camera:set-position
+                (glm.vec3 (vec3-x camera.position) smoothed-y (vec3-z camera.position))))))))
+
+  (fn update [self delta]
+    (let [delta-seconds (delta->seconds delta delta-unit)]
+      (if (= toolbar-state.camera-mode :flight)
+          (flight-controls:update delta)
+          (do
+            ;; Horizontal movement
+            (when (or (grounded-action-active? :move-left)
+                      (grounded-action-active? :move-right)
+                      (grounded-action-active? :move-forward)
+                      (grounded-action-active? :move-backward))
+              (let [fwd (horizontal-component (camera:get-forward))
+                    right-dir (horizontal-component (camera:get-right))
+                    speed (grounded-horizontal-speed)]
+                (var move (glm.vec3 0 0 0))
+                (when (grounded-action-active? :move-left)
+                  (set move (- move (* right-dir speed))))
+                (when (grounded-action-active? :move-right)
+                  (set move (+ move (* right-dir speed))))
+                (when (grounded-action-active? :move-forward)
+                  (set move (+ move (* fwd speed))))
+                (when (grounded-action-active? :move-backward)
+                  (set move (- move (* fwd speed))))
+                (let [flat-move (* (glm.vec3 delta-seconds) move)]
+                  (camera:set-position (+ camera.position flat-move)))))
+            ;; Keyboard look
+            (when (grounded-action-active? :look-up)
+              (camera:pitch (* delta-seconds 1.0)))
+            (when (grounded-action-active? :look-down)
+              (camera:pitch (* -1 delta-seconds 1.0)))
+            (when (grounded-action-active? :look-right)
+              (camera:yaw (* delta-seconds 1.0)))
+            (when (grounded-action-active? :look-left)
+              (camera:yaw (* -1 delta-seconds 1.0)))
+            ;; Gravity and terrain following
+            (grounded-apply-gravity-and-terrain delta-seconds)))))
+
+  (fn drop [self]
+    (flight-controls:drop)
+    (set grounded-keys {})
+    (set grounded-drag-look-start nil)
+    (set grounded-mouse-pos nil)
+    (set grounded-vertical-velocity 0.0)
+    (set grounded-airborne? false))
+
+  (fn drag-active? [self]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:drag-active?)
+        (not (not grounded-drag-look-start))))
+
+  (fn should-suppress-click? [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:should-suppress-click? payload)
+        false))
+
+  (fn on-key-down [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-key-down payload)
+        (do
+          (set (. grounded-keys payload.key) true)
+          (when (and (= payload.key default-key-mapping.jump)
+                     (not grounded-airborne?))
+            (set grounded-vertical-velocity jump-speed)
+            (set grounded-airborne? true)))))
+
+  (fn on-key-up [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-key-up payload)
+        (set (. grounded-keys payload.key) nil)))
+
+  (fn on-mouse-wheel [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-mouse-wheel payload)
+        (flight-controls:on-mouse-wheel payload)))
+
+  (fn on-mouse-button-down [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-mouse-button-down payload)
+        (when (= payload.button SDL_BUTTON_LEFT)
+          (set grounded-drag-look-start {:x payload.x :y payload.y}))))
+
+  (fn on-mouse-button-up [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-mouse-button-up payload)
+        (when (= payload.button SDL_BUTTON_LEFT)
+          (set grounded-drag-look-start nil))))
+
+  (fn on-mouse-motion [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-mouse-motion payload)
+        (when grounded-drag-look-start
+          (let [dx (- payload.x grounded-drag-look-start.x)
+                dy (- payload.y grounded-drag-look-start.y)]
+            (set grounded-drag-look-start {:x payload.x :y payload.y})
+            (camera:yaw (* dx mouse-look-speed))
+            (camera:pitch (* dy mouse-look-speed))))))
+
+  (fn on-gamepad-button-down [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-gamepad-button-down payload)
+        nil))
+
+  (fn on-gamepad-axis-motion [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-gamepad-axis-motion payload)
+        nil))
+
+  (fn on-gamepad-removed [self payload]
+    (if (= toolbar-state.camera-mode :flight)
+        (flight-controls:on-gamepad-removed payload)
+        nil))
+
+  {:update update
+   :drop drop
+   :drag-active? drag-active?
+   :should-suppress-click? should-suppress-click?
+   :on-key-down on-key-down
+   :on-key-up on-key-up
+   :on-mouse-wheel on-mouse-wheel
+   :on-mouse-button-down on-mouse-button-down
+   :on-mouse-button-up on-mouse-button-up
+   :on-mouse-motion on-mouse-motion
+   :on-gamepad-button-down on-gamepad-button-down
+   :on-gamepad-axis-motion on-gamepad-axis-motion
+   :on-gamepad-removed on-gamepad-removed})
+
+{: SandboxCameraControls}

--- a/assets/lua/sandbox-toolbar-state.fnl
+++ b/assets/lua/sandbox-toolbar-state.fnl
@@ -30,11 +30,12 @@
                               :flight)))
 
   (fn set-object-move-enabled! [self enabled?]
-    (local next-enabled? (not (not enabled?)))
-    (when (not (= object-move-enabled? next-enabled?))
-      (set object-move-enabled? next-enabled?)
-      (changed:emit next-enabled?))
-    next-enabled?)
+    (when (not (= (type enabled?) :boolean))
+      (error (.. "object-move-enabled? must be boolean, got " (tostring (type enabled?)) ": " (tostring enabled?))))
+    (when (not (= object-move-enabled? enabled?))
+      (set object-move-enabled? enabled?)
+      (changed:emit enabled?))
+    enabled?)
 
   (fn toggle-object-move-enabled! [self]
     (self:set-object-move-enabled! (not object-move-enabled?)))
@@ -58,20 +59,21 @@
      :drag-attachment (if (= drag-attachment :center) "center" "anchor")})
 
   (fn restore-state [self payload]
-    (when payload
-      (when (= (type payload) :table)
-        (when (not (= (. payload :camera-mode) nil))
-          (let [value (. payload :camera-mode)]
-            (self:set-camera-mode (if (= value "flight") :flight
-                                      (= value "grounded") :grounded
-                                      (error (.. "Invalid camera mode in restore: " (tostring value)))))))
-        (when (not (= (. payload :object-move-enabled?) nil))
-          (self:set-object-move-enabled! (. payload :object-move-enabled?)))
-        (when (not (= (. payload :drag-attachment) nil))
-          (let [value (. payload :drag-attachment)]
-            (self:set-drag-attachment (if (= value "center") :center
-                                          (= value "anchor") :anchor
-                                          (error (.. "Invalid drag attachment in restore: " (tostring value)))))))))
+    (when (not (= payload nil))
+      (when (not (= (type payload) :table))
+        (error (.. "restore-state payload must be a table or nil, got " (type payload))))
+      (when (not (= (. payload :camera-mode) nil))
+        (let [value (. payload :camera-mode)]
+          (self:set-camera-mode (if (= value "flight") :flight
+                                    (= value "grounded") :grounded
+                                    (error (.. "Invalid camera mode in restore: " (tostring value)))))))
+      (when (not (= (. payload :object-move-enabled?) nil))
+        (self:set-object-move-enabled! (. payload :object-move-enabled?)))
+      (when (not (= (. payload :drag-attachment) nil))
+        (let [value (. payload :drag-attachment)]
+          (self:set-drag-attachment (if (= value "center") :center
+                                        (= value "anchor") :anchor
+                                        (error (.. "Invalid drag attachment in restore: " (tostring value))))))))
     true)
 
   (local state

--- a/assets/lua/sandbox-toolbar-state.fnl
+++ b/assets/lua/sandbox-toolbar-state.fnl
@@ -6,7 +6,14 @@
 (fn SandboxToolbarState [opts]
   (local options (or opts {}))
   (var camera-mode (or options.camera-mode :flight))
-  (var object-move-enabled? (= options.object-move-enabled? true))
+  (var object-move-enabled?
+    (if (= options.object-move-enabled? nil)
+        false
+        (= (type options.object-move-enabled?) :boolean)
+        options.object-move-enabled?
+        (error (.. "object-move-enabled? must be boolean, got "
+                   (tostring (type options.object-move-enabled?))
+                   ": " (tostring options.object-move-enabled?)))))
   (var drag-attachment (or options.drag-attachment :center))
 
   (when (not (. valid-camera-modes camera-mode))

--- a/assets/lua/sandbox-toolbar-state.fnl
+++ b/assets/lua/sandbox-toolbar-state.fnl
@@ -1,0 +1,94 @@
+(local Signal (require :signal))
+
+(local valid-camera-modes {:flight true :grounded true})
+(local valid-drag-attachments {:center true :anchor true})
+
+(fn SandboxToolbarState [opts]
+  (local options (or opts {}))
+  (var camera-mode (or options.camera-mode :flight))
+  (var object-move-enabled? (= options.object-move-enabled? true))
+  (var drag-attachment (or options.drag-attachment :center))
+
+  (when (not (. valid-camera-modes camera-mode))
+    (error (.. "Invalid camera mode: " (tostring camera-mode))))
+  (when (not (. valid-drag-attachments drag-attachment))
+    (error (.. "Invalid drag attachment: " (tostring drag-attachment))))
+
+  (local changed (Signal))
+
+  (fn set-camera-mode [self mode]
+    (when (not (. valid-camera-modes mode))
+      (error (.. "Invalid camera mode: " (tostring mode))))
+    (when (not (= camera-mode mode))
+      (set camera-mode mode)
+      (changed:emit mode))
+    mode)
+
+  (fn toggle-camera-mode [self]
+    (self:set-camera-mode (if (= camera-mode :flight)
+                              :grounded
+                              :flight)))
+
+  (fn set-object-move-enabled! [self enabled?]
+    (local next-enabled? (not (not enabled?)))
+    (when (not (= object-move-enabled? next-enabled?))
+      (set object-move-enabled? next-enabled?)
+      (changed:emit next-enabled?))
+    next-enabled?)
+
+  (fn toggle-object-move-enabled! [self]
+    (self:set-object-move-enabled! (not object-move-enabled?)))
+
+  (fn set-drag-attachment [self mode]
+    (when (not (. valid-drag-attachments mode))
+      (error (.. "Invalid drag attachment: " (tostring mode))))
+    (when (not (= drag-attachment mode))
+      (set drag-attachment mode)
+      (changed:emit mode))
+    mode)
+
+  (fn toggle-drag-attachment [self]
+    (self:set-drag-attachment (if (= drag-attachment :center)
+                                  :anchor
+                                  :center)))
+
+  (fn capture-state [self]
+    {:camera-mode (if (= camera-mode :flight) "flight" "grounded")
+     :object-move-enabled? object-move-enabled?
+     :drag-attachment (if (= drag-attachment :center) "center" "anchor")})
+
+  (fn restore-state [self payload]
+    (when payload
+      (when (= (type payload) :table)
+        (when (not (= (. payload :camera-mode) nil))
+          (let [value (. payload :camera-mode)]
+            (self:set-camera-mode (if (= value "flight") :flight
+                                      (= value "grounded") :grounded
+                                      (error (.. "Invalid camera mode in restore: " (tostring value)))))))
+        (when (not (= (. payload :object-move-enabled?) nil))
+          (self:set-object-move-enabled! (. payload :object-move-enabled?)))
+        (when (not (= (. payload :drag-attachment) nil))
+          (let [value (. payload :drag-attachment)]
+            (self:set-drag-attachment (if (= value "center") :center
+                                          (= value "anchor") :anchor
+                                          (error (.. "Invalid drag attachment in restore: " (tostring value)))))))))
+    true)
+
+  (local state
+    {: changed
+     : set-camera-mode
+     : toggle-camera-mode
+     : set-object-move-enabled!
+     : toggle-object-move-enabled!
+     : set-drag-attachment
+     : toggle-drag-attachment
+     : capture-state
+     : restore-state})
+
+  (fn state-index [self key]
+    (if (= key :camera-mode) camera-mode
+        (= key :object-move-enabled?) object-move-enabled?
+        (= key :drag-attachment) drag-attachment))
+
+  (setmetatable state {:__index state-index})
+  state)

--- a/assets/lua/sandbox-toolbar-view.fnl
+++ b/assets/lua/sandbox-toolbar-view.fnl
@@ -1,5 +1,22 @@
 (local Button (require :button))
 (local {: Flex : FlexChild} (require :flex))
+(local widget-theme-utils (require :widget-theme-utils))
+
+(fn find-button-text-widget [button]
+  "Find the Text widget inside a button's internal structure.
+  When buttons have both icon and text, button.text is a Flex whose
+  children are metadata wrappers {:flex N :element <entity>}."
+  (when button.text
+    (if button.text.set-text
+        button.text
+        (and button.text.children (= (type button.text.children) :table))
+        (do
+          (var found nil)
+          (each [_ child (ipairs button.text.children)]
+            (when (and (not found) (= (type child) :table) child.element child.element.set-text)
+              (set found child.element)))
+          found)
+        nil)))
 
 (fn SandboxToolbarView [state]
   (fn build [ctx]
@@ -10,7 +27,7 @@
     ;; Camera mode button builder
     (local camera-btn-builder
       (Button {:icon "flight"
-               :text "Camera"
+               :text "Flight"
                :variant (if (= state.camera-mode :grounded) :primary :secondary)
                :padding [0.4 0.4]
                :on-click (fn [_button _event]
@@ -36,11 +53,11 @@
 
     ;; Build Flex layout
     (local flex (Flex {:axis 1
-                       :yalign :center
-                       :children
-                       [(FlexChild camera-btn-builder 0)
-                        (FlexChild object-move-btn-builder 0)
-                        (FlexChild drag-attachment-btn-builder 0)]}))
+                        :yalign :center
+                        :children
+                        [(FlexChild camera-btn-builder 0)
+                         (FlexChild object-move-btn-builder 0)
+                         (FlexChild drag-attachment-btn-builder 0)]}))
 
     (local root (flex ctx))
 
@@ -57,32 +74,57 @@
     (when (and drag-attachment-btn drag-attachment-btn.layout)
       (set drag-attachment-btn.layout.name "sandbox-toolbar-drag-attachment"))
 
-    (fn update [self]
-      ;; Update camera mode button variant
+    (fn resolve-and-apply-variant [btn new-variant]
+      "Re-resolve button theme colors for a new variant and update the button."
+      (when (not (= btn.variant new-variant))
+        (set btn.variant new-variant)
+        (local resolved (widget-theme-utils.resolve-button-colors ctx {:variant new-variant}))
+        (set btn.background-color resolved.background)
+        (set btn.hover-background-color resolved.hover)
+        (set btn.pressed-background-color resolved.pressed)
+        (set btn.foreground-color resolved.foreground)
+        (btn:update-background-color {:mark-layout-dirty? true})))
+
+    (fn update-camera-button []
       (when camera-btn
-        (local new-variant (if (= state.camera-mode :grounded) :primary :secondary))
-        (when (not (= camera-btn.variant new-variant))
-          (set camera-btn.variant new-variant)
-          (camera-btn:update-background-color {:mark-layout-dirty? true})))
+        ;; Update text label between Flight and Grounded
+        (let [new-label (if (= state.camera-mode :grounded) "Grounded" "Flight")
+              text-widget (find-button-text-widget camera-btn)]
+          (when (and text-widget text-widget.set-text)
+            (text-widget:set-text new-label {:mark-measure-dirty? true})))
+        ;; Update variant and re-resolve colors
+        (resolve-and-apply-variant camera-btn
+                                   (if (= state.camera-mode :grounded) :primary :secondary))))
 
-      ;; Update object move button variant
+    (fn update-object-move-button []
       (when object-move-btn
-        (local new-variant (if state.object-move-enabled? :primary :secondary))
-        (when (not (= object-move-btn.variant new-variant))
-          (set object-move-btn.variant new-variant)
-          (object-move-btn:update-background-color {:mark-layout-dirty? true})))
+        (resolve-and-apply-variant object-move-btn
+                                   (if state.object-move-enabled? :primary :secondary))))
 
-      ;; Update drag attachment button variant
+    (fn update-drag-attachment-button []
       (when drag-attachment-btn
-        (local new-variant (if (= state.drag-attachment :anchor) :primary :secondary))
-        (when (not (= drag-attachment-btn.variant new-variant))
-          (set drag-attachment-btn.variant new-variant)
-          (drag-attachment-btn:update-background-color {:mark-layout-dirty? true}))))
+        (resolve-and-apply-variant drag-attachment-btn
+                                   (if (= state.drag-attachment :anchor) :primary :secondary))))
+
+    (fn update [self]
+      (update-camera-button)
+      (update-object-move-button)
+      (update-drag-attachment-button))
 
     ;; Wire state change signal to update
-    (state.changed:connect (fn [] (update root)))
+    (local changed-handler (fn [] (update root)))
+    (state.changed:connect changed-handler)
 
     (set root.update update)
+
+    ;; Wrap root.drop to disconnect from state.changed before delegating to
+    ;; the original Flex drop, preventing stale callbacks on rebuilt toolbars.
+    (local original-drop root.drop)
+    (set root.drop (fn [self]
+                     (state.changed:disconnect changed-handler true)
+                     (when original-drop
+                       (original-drop self))))
+
     root)
 
   build)

--- a/assets/lua/sandbox-toolbar-view.fnl
+++ b/assets/lua/sandbox-toolbar-view.fnl
@@ -1,0 +1,90 @@
+(local Button (require :button))
+(local {: Flex : FlexChild} (require :flex))
+
+(fn SandboxToolbarView [state]
+  (fn build [ctx]
+    (var camera-btn nil)
+    (var object-move-btn nil)
+    (var drag-attachment-btn nil)
+
+    ;; Camera mode button builder
+    (local camera-btn-builder
+      (Button {:icon "flight"
+               :text "Camera"
+               :variant (if (= state.camera-mode :grounded) :primary :secondary)
+               :padding [0.4 0.4]
+               :on-click (fn [_button _event]
+                           (state:toggle-camera-mode))}))
+
+    ;; Object move button builder
+    (local object-move-btn-builder
+      (Button {:icon "open_with"
+               :text "Move"
+               :variant (if state.object-move-enabled? :primary :secondary)
+               :padding [0.4 0.4]
+               :on-click (fn [_button _event]
+                           (state:toggle-object-move-enabled!))}))
+
+    ;; Drag attachment button builder
+    (local drag-attachment-btn-builder
+      (Button {:icon "anchor"
+               :text "Anchor"
+               :variant (if (= state.drag-attachment :anchor) :primary :secondary)
+               :padding [0.4 0.4]
+               :on-click (fn [_button _event]
+                           (state:toggle-drag-attachment))}))
+
+    ;; Build Flex layout
+    (local flex (Flex {:axis 1
+                       :yalign :center
+                       :children
+                       [(FlexChild camera-btn-builder 0)
+                        (FlexChild object-move-btn-builder 0)
+                        (FlexChild drag-attachment-btn-builder 0)]}))
+
+    (local root (flex ctx))
+
+    ;; Extract button entities from Flex metadata wrappers
+    (set camera-btn (. root.children 1 :element))
+    (set object-move-btn (. root.children 2 :element))
+    (set drag-attachment-btn (. root.children 3 :element))
+
+    ;; Set layout names on buttons
+    (when (and camera-btn camera-btn.layout)
+      (set camera-btn.layout.name "sandbox-toolbar-camera-mode"))
+    (when (and object-move-btn object-move-btn.layout)
+      (set object-move-btn.layout.name "sandbox-toolbar-object-move"))
+    (when (and drag-attachment-btn drag-attachment-btn.layout)
+      (set drag-attachment-btn.layout.name "sandbox-toolbar-drag-attachment"))
+
+    (fn update [self]
+      ;; Update camera mode button variant
+      (when camera-btn
+        (local new-variant (if (= state.camera-mode :grounded) :primary :secondary))
+        (when (not (= camera-btn.variant new-variant))
+          (set camera-btn.variant new-variant)
+          (camera-btn:update-background-color {:mark-layout-dirty? true})))
+
+      ;; Update object move button variant
+      (when object-move-btn
+        (local new-variant (if state.object-move-enabled? :primary :secondary))
+        (when (not (= object-move-btn.variant new-variant))
+          (set object-move-btn.variant new-variant)
+          (object-move-btn:update-background-color {:mark-layout-dirty? true})))
+
+      ;; Update drag attachment button variant
+      (when drag-attachment-btn
+        (local new-variant (if (= state.drag-attachment :anchor) :primary :secondary))
+        (when (not (= drag-attachment-btn.variant new-variant))
+          (set drag-attachment-btn.variant new-variant)
+          (drag-attachment-btn:update-background-color {:mark-layout-dirty? true}))))
+
+    ;; Wire state change signal to update
+    (state.changed:connect (fn [] (update root)))
+
+    (set root.update update)
+    root)
+
+  build)
+
+SandboxToolbarView

--- a/assets/lua/scene.fnl
+++ b/assets/lua/scene.fnl
@@ -2316,7 +2316,15 @@
                    :h01 info.h01
                    :h10 info.h10
                    :h11 info.h11}))))
-  best)
+   best)
+
+(fn height-at-world-point [self world-point]
+  "Return the terrain height at the given world point.  Returns 0 (default
+  ground plane) when no terrain covers the point."
+  (let [info (terrain-surface-under-point self world-point)]
+    (if (and info info.world-surface-y)
+        info.world-surface-y
+        0)))
 
 (fn screen-pos-terrain-hit [self pos opts]
   (self:raycast-terrain (self:screen-pos-ray pos opts)))
@@ -2623,6 +2631,7 @@
 (set self.screen-pos-ray screen-pos-ray)
 (set self.raycast-terrain raycast-terrain)
 (set self.terrain-surface-under-point terrain-surface-under-point)
+(set self.height-at-world-point height-at-world-point)
 (set self.screen-pos-terrain-hit screen-pos-terrain-hit)
 (set self.screen-pos-terrain-domain-hit screen-pos-terrain-domain-hit)
 (set self.screen-rect-terrain-target screen-rect-terrain-target)

--- a/assets/lua/scene.fnl
+++ b/assets/lua/scene.fnl
@@ -144,6 +144,7 @@
                              :owner (or movable.owner element)
                              :pointer-target movable.pointer-target
                              :on-drag-start movable.on-drag-start
+                             :on-drag-update movable.on-drag-update
                              :on-drag-end movable.on-drag-end})))
   entries)
 
@@ -1293,6 +1294,7 @@
            :key entry.key
            :owner entry.owner
            :on-drag-start entry.on-drag-start
+           :on-drag-update entry.on-drag-update
            :on-drag-end entry.on-drag-end})))
 
   (fn register-movable-entries [self entity entries]
@@ -1308,6 +1310,7 @@
         (when handle (set options.handle handle))
         (when entry.pointer-target (set options.pointer-target entry.pointer-target))
         (when entry.on-drag-start (set options.on-drag-start entry.on-drag-start))
+        (when entry.on-drag-update (set options.on-drag-update entry.on-drag-update))
         (when entry.on-drag-end (set options.on-drag-end entry.on-drag-end))
         (local key (or entry.key widget entry))
         (when key

--- a/assets/lua/state-handlers/pointer.fnl
+++ b/assets/lua/state-handlers/pointer.fnl
@@ -63,7 +63,8 @@
      (when (and (not ((. ctx :event-consumed?)))
                 mouse-down
                 (= payload.button SDL_BUTTON_LEFT)
-                (Runtime.alt-held? payload))
+                (or (Runtime.alt-held? payload)
+                    (Runtime.activity-object-move-enabled? payload)))
        (mouse-down app.movables payload)))})
 
 (local SelectionMouseButtonDown

--- a/assets/lua/state-runtime.fnl
+++ b/assets/lua/state-runtime.fnl
@@ -26,6 +26,12 @@
   (and app.activity-object-move-predicate
        (= (app.activity-object-move-predicate) true)))
 
+(fn drag-attachment-mode []
+  (if (and app.activity-drag-attachment-provider
+           (= (app.activity-drag-attachment-provider) :anchor))
+      :anchor
+      :center))
+
 (fn clickables-active? []
   (assert app.clickables "state runtime requires app.clickables")
   app.clickables.active?)
@@ -171,6 +177,7 @@
  :ctrl-held? ctrl-held?
  :alt-held? alt-held?
  :activity-object-move-enabled? activity-object-move-enabled?
+ :drag-attachment-mode drag-attachment-mode
  :active-controls active-controls
  :clickables-active? clickables-active?
  :movables-active? movables-active?

--- a/assets/lua/state-runtime.fnl
+++ b/assets/lua/state-runtime.fnl
@@ -22,6 +22,10 @@
 (fn alt-held? [payload]
   (Modifiers.alt-held? (and payload payload.mod)))
 
+(fn activity-object-move-enabled? [_payload]
+  (and app.activity-object-move-predicate
+       (= (app.activity-object-move-predicate) true)))
+
 (fn clickables-active? []
   (assert app.clickables "state runtime requires app.clickables")
   app.clickables.active?)
@@ -166,6 +170,7 @@
 {:shift-held? shift-held?
  :ctrl-held? ctrl-held?
  :alt-held? alt-held?
+ :activity-object-move-enabled? activity-object-move-enabled?
  :active-controls active-controls
  :clickables-active? clickables-active?
  :movables-active? movables-active?

--- a/assets/lua/tests/fast.fnl
+++ b/assets/lua/tests/fast.fnl
@@ -72,6 +72,8 @@
       :tests.test-activity-retention
       :tests.test-home-world-scene-activity-state
       :tests.test-sandbox-activity
+      :tests.test-sandbox-toolbar-state
+      :tests.test-sandbox-toolbar-view
       :tests.test-graph-activity-slots
      :tests.test-drawing-activity-slots
      :tests.test-board

--- a/assets/lua/tests/fast.fnl
+++ b/assets/lua/tests/fast.fnl
@@ -71,9 +71,11 @@
       :tests.test-scene-activity-slots
       :tests.test-activity-retention
       :tests.test-home-world-scene-activity-state
-      :tests.test-sandbox-activity
-      :tests.test-sandbox-toolbar-state
-      :tests.test-sandbox-toolbar-view
+     :tests.test-sandbox-activity
+     :tests.test-sandbox-toolbar-state
+     :tests.test-sandbox-toolbar-view
+     :tests.test-camera-animation
+     :tests.test-sandbox-camera-controls
       :tests.test-graph-activity-slots
      :tests.test-drawing-activity-slots
      :tests.test-board

--- a/assets/lua/tests/test-activity-retention.fnl
+++ b/assets/lua/tests/test-activity-retention.fnl
@@ -1070,6 +1070,55 @@
 (table.insert tests {:name "Board activity restore fails loudly without runtime.scene"
                       :fn board-restore-fails-loudly-without-runtime-scene})
 
+(fn activity-hooks-include-toolbar-and-sandbox-interaction-providers []
+  (local app-keys [:active-world-runtime
+                   :activity-registry
+                   :activities-changed
+                   :active-activity-id])
+  (local app-snapshot (snapshot-app-fields app-keys))
+  (set app.activity-registry nil)
+  (set app.activities-changed nil)
+  (set app.active-activity-id nil)
+  (set app.active-world-runtime {})
+  (set app.activity-top-toolbar-builder nil)
+  (set app.activity-object-move-predicate nil)
+  (set app.activity-drag-attachment-provider nil)
+  (local toolbar-builder (fn [] :toolbar-builder))
+  (local move-predicate (fn [] :move-predicate))
+  (local drag-provider (fn [] :drag-provider))
+  (local (ok result)
+    (pcall
+      (fn []
+        (Activities.register-activity
+          {:id "toolbar-test"
+           :label "Toolbar Test"
+           :activate (fn [ctx]
+                       (ctx:set-top-toolbar-builder! toolbar-builder)
+                       (ctx:set-object-move-predicate! move-predicate)
+                       (ctx:set-drag-attachment-provider! drag-provider)
+                       {})})
+        (Activities.activate-activity "toolbar-test")
+        (assert (= app.activity-top-toolbar-builder toolbar-builder)
+                "app.activity-top-toolbar-builder should be set after activation")
+        (assert (= app.activity-object-move-predicate move-predicate)
+                "app.activity-object-move-predicate should be set after activation")
+        (assert (= app.activity-drag-attachment-provider drag-provider)
+                "app.activity-drag-attachment-provider should be set after activation")
+        (Activities.deactivate-active-activity)
+        (assert (= app.activity-top-toolbar-builder nil)
+                "app.activity-top-toolbar-builder should be nil after deactivation")
+        (assert (= app.activity-object-move-predicate nil)
+                "app.activity-object-move-predicate should be nil after deactivation")
+        (assert (= app.activity-drag-attachment-provider nil)
+                "app.activity-drag-attachment-provider should be nil after deactivation")
+        true)))
+  (pcall (fn [] (Activities.unregister-activity "toolbar-test")))
+  (restore-app-fields! app-snapshot)
+  (if ok result (error result)))
+
+(table.insert tests {:name "Activity hooks include toolbar and sandbox interaction providers"
+                     :fn activity-hooks-include-toolbar-and-sandbox-interaction-providers})
+
 (local main
   (fn []
     (local runner (require :tests/runner))

--- a/assets/lua/tests/test-camera-animation.fnl
+++ b/assets/lua/tests/test-camera-animation.fnl
@@ -6,7 +6,7 @@
   (local channel (CameraAnimation.scalar-channel {:value 0 :target 0 :smoothing-rate 5}))
   (channel:set-target 100)
   (let [v (channel:snap 100)]
-    (assert (= v 100) "snap must return the new value"))
+    (assert (= v true) "snap must return true"))
   (assert (= (channel:value) 100)
           "snap must set value to target")
   true)

--- a/assets/lua/tests/test-camera-animation.fnl
+++ b/assets/lua/tests/test-camera-animation.fnl
@@ -1,0 +1,92 @@
+(local tests [])
+(local CameraAnimation (require :camera-animation))
+
+;; snap sets value to target immediately
+(fn snap-set-to-target []
+  (local channel (CameraAnimation.scalar-channel {:value 0 :target 0 :smoothing-rate 5}))
+  (channel:set-target 100)
+  (let [v (channel:snap 100)]
+    (assert (= v 100) "snap must return the new value"))
+  (assert (= (channel:value) 100)
+          "snap must set value to target")
+  true)
+
+;; set-target changes target but not current value
+(fn set-target-does-not-move-value []
+  (local channel (CameraAnimation.scalar-channel {:value 0 :target 0 :smoothing-rate 5}))
+  (channel:set-target 100)
+  (assert (= (channel:value) 0)
+          "set-target must not change current value")
+  true)
+
+;; update approaches target monotonically
+(fn update-approaches-target []
+  (local channel (CameraAnimation.scalar-channel {:value 0 :target 100 :smoothing-rate 5}))
+  (local first (channel:update 0.1))
+  (assert (> first 0) "update must move value toward target")
+  (assert (< first 100) "update must not overshoot target")
+  (local second (channel:update 0.1))
+  (assert (> second first) "successive updates must make monotonic progress")
+  (assert (< second 100) "update must still not overshoot")
+  true)
+
+;; snap to value when distance is within epsilon
+(fn snap-at-tiny-distance []
+  (local channel (CameraAnimation.scalar-channel {:value 99.999999 :target 100 :smoothing-rate 5}))
+  ;; distance is 1e-6, below the 1e-5 epsilon
+  (local result (channel:update 0.016))
+  (assert (= result 100) "must snap to target when distance < 1e-5")
+  true)
+
+;; deterministic fixed-delta output
+(fn deterministic-output []
+  (var a nil)
+  (var b nil)
+  (do
+    (local channel (CameraAnimation.scalar-channel {:value 0 :target 100 :smoothing-rate 5}))
+    (set a (channel:update 0.1)))
+  (do
+    (local channel (CameraAnimation.scalar-channel {:value 0 :target 100 :smoothing-rate 5}))
+    (set b (channel:update 0.1)))
+  (assert (= a b) "scalar-channel must produce deterministic output")
+  true)
+
+;; error on non-number value
+(fn errors-on-non-number-value []
+  (local status
+    (pcall CameraAnimation.scalar-channel {:value "not-a-number" :target 0 :smoothing-rate 1}))
+  (assert (not status) "must error on non-number value")
+  true)
+
+;; error on non-number target
+(fn errors-on-non-number-target []
+  (local status
+    (pcall CameraAnimation.scalar-channel {:value 0 :target nil :smoothing-rate 1}))
+  (assert (not status) "must error on non-number target")
+  true)
+
+;; error on non-number delta
+(fn errors-on-non-number-delta []
+  (local channel (CameraAnimation.scalar-channel {:value 0 :target 0 :smoothing-rate 5}))
+  (local status (pcall channel.update channel "not-a-number"))
+  (assert (not status) "must error on non-number delta")
+  true)
+
+(table.insert tests {:name "snap sets value to target" :fn snap-set-to-target})
+(table.insert tests {:name "set-target does not move value" :fn set-target-does-not-move-value})
+(table.insert tests {:name "update approaches target monotonically" :fn update-approaches-target})
+(table.insert tests {:name "snap at tiny distance" :fn snap-at-tiny-distance})
+(table.insert tests {:name "deterministic fixed-delta output" :fn deterministic-output})
+(table.insert tests {:name "errors on non-number value" :fn errors-on-non-number-value})
+(table.insert tests {:name "errors on non-number target" :fn errors-on-non-number-target})
+(table.insert tests {:name "errors on non-number delta" :fn errors-on-non-number-delta})
+
+(local main
+  (fn []
+    (local runner (require :tests/runner))
+    (runner.run-tests {:name "camera-animation"
+                       :tests tests})))
+
+{:name "camera-animation"
+ :tests tests
+ :main main}

--- a/assets/lua/tests/test-drawing-sidebar.fnl
+++ b/assets/lua/tests/test-drawing-sidebar.fnl
@@ -13,6 +13,7 @@
 (local Themes (require :themes))
 (local DarkTheme (require :dark-theme))
 (local LightTheme (require :light-theme))
+(local {: Layout} (require :layout))
 
 (local tests [])
 
@@ -637,6 +638,80 @@
                   "drawing sidebar active tool button should use the light theme primary color")
           (light-sidebar:drop))))))
 
+(fn activity-dock-view-reserves-toolbar-height-for-activity-content []
+  (with-sidebar-env
+    (fn []
+      (local original-builder app.activity-left-dock-builder)
+      (var recorded-inner-size nil)
+      ;; Build a custom activity panel that measures to a non-zero height (40)
+      ;; so the Flex stretch gives it the rail's larger measurement. The panel
+      ;; records its inner child's laid-out size so we can verify that after the
+      ;; dock reserve adjustment, the inner child is re-laid at the reduced height
+      ;; -- not stuck at the full height from the initial Flex pass.
+      (fn build-test-panel [ctx]
+        (local inner-layout
+          (Layout {:name "panel-inner"
+                   :measurer (fn [self] (set self.measure (glm.vec3 1 1 0)))
+                   :layouter (fn [self]
+                               (set recorded-inner-size
+                                    (glm.vec3 (or self.size.x 0)
+                                              (or self.size.y 0)
+                                              0)))}))
+        (local test-entity-layout
+          (Layout {:name "test-activity-panel"
+                   :measurer (fn [self] (set self.measure (glm.vec3 10 40 0)))
+                   :layouter (fn [self]
+                               (set self.size (or self.size self.measure))
+                               (set inner-layout.position self.position)
+                               (set inner-layout.size self.size)
+                               (inner-layout:layouter))
+                   :children [inner-layout]}))
+        {:layout test-entity-layout
+         :update (fn []) :drop (fn [self] (test-entity-layout:drop))})
+      (set app.activity-left-dock-builder build-test-panel)
+      (set-interaction-surface :canvas)
+      ;; Force rebuild to pick up the new left-dock-builder
+      (emit-workspace-shell-changed "activity")
+      (local dock ((ActivityDockView {:top-reserve-height-provider (fn [] 4)}) (make-ctx)))
+      (dock:update)
+      (dock:update)
+      (dock.layout:measurer)
+      (local measured-h dock.layout.measure.y)
+      (assert (> measured-h 0) "dock should have positive measured height")
+      (set dock.layout.position (glm.vec3 0 0 0))
+      (set dock.layout.size (glm.vec3 100 measured-h 0))
+      (set dock.layout.rotation (glm.quat 1 0 0 0))
+      (set dock.layout.clip-region nil)
+      (set dock.layout.depth-offset-index 0)
+      (dock.layout:layouter)
+      (local content-layout (. dock.layout.children 1))
+      (assert content-layout "activity dock should have a content layout")
+      (local rail-layout (. content-layout.children 1))
+      (assert rail-layout "feature rail should be present")
+      (assert (MathUtils.approx rail-layout.size.y measured-h)
+              (.. "feature rail should remain full-height " measured-h
+                  ", got " rail-layout.size.y))
+      (local activity-panel-layout (. content-layout.children 2))
+      (assert activity-panel-layout "activity panel should be present")
+      (local expected-panel-h (math.max 0 (- measured-h 4)))
+      (assert (MathUtils.approx activity-panel-layout.position.y 4)
+              (.. "activity panel y should be offset by reserve 4, got "
+                  activity-panel-layout.position.y))
+      (assert (MathUtils.approx activity-panel-layout.size.y expected-panel-h)
+              (.. "activity panel height should be " expected-panel-h
+                  " (= " measured-h " - 4), got "
+                  activity-panel-layout.size.y))
+      ;; Most important: the inner child must be re-laid out at the reserved
+      ;; (reduced) height, not stuck at the full height from the initial Flex
+      ;; pass. This catches the bug where the dock adjusts position/size after
+      ;; layouter without re-running the child's layouter.
+      (assert recorded-inner-size "inner child should have been laid out")
+      (assert (MathUtils.approx recorded-inner-size.y expected-panel-h)
+              (.. "inner child should be laid out within reserved height "
+                  expected-panel-h ", got " recorded-inner-size.y))
+      (dock:drop)
+      (set app.activity-left-dock-builder original-builder))))
+
 (fn activity-dock-view-rebuilds-without-stale-layout-children []
   (with-sidebar-env
     (fn []
@@ -804,8 +879,10 @@
                      :fn sidebar-adopts-light-theme-colors})
 (table.insert tests {:name "Activity dock view rebuilds without stale layout children"
                      :fn activity-dock-view-rebuilds-without-stale-layout-children})
+(table.insert tests {:name "Activity dock view reserves toolbar height for activity content"
+                      :fn activity-dock-view-reserves-toolbar-height-for-activity-content})
 (table.insert tests {:name "Activity dock view rebuilds when activities register at runtime"
-                     :fn activity-dock-view-rebuilds-when-activities-register-at-runtime})
+                      :fn activity-dock-view-rebuilds-when-activities-register-at-runtime})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-hud-extended-sidebar.fnl
+++ b/assets/lua/tests/test-hud-extended-sidebar.fnl
@@ -852,6 +852,41 @@
 (table.insert tests {:name "view collapsed panel remains effectively culled"
                      :fn view-collapsed-panel-remains-effectively-culled})
 
+(fn expanded-panel-reserves-toolbar-height-while-rail-remains-full-height []
+  (local sidebar (HudExtendedSidebar))
+  (sidebar:register-entry {:id :test
+                            :icon :test_icon
+                            :label "Test"
+                            :build-panel (fn [ctx]
+                                           ((make-test-panel "test-panel" (glm.vec3 38 10 0)) ctx))})
+  (sidebar:select :test)
+  (local ctx (make-widget-ctx))
+  (local entity ((HudExtendedSidebarView sidebar {:top-reserve-height-provider (fn [] 4)}) ctx))
+  (entity:update)
+  (entity:update)
+  (entity.layout:measurer)
+  (set entity.layout.position (glm.vec3 10 0 0))
+  (set entity.layout.size (glm.vec3 100 30 0))
+  (set entity.layout.rotation (glm.quat 1 0 0 0))
+  (set entity.layout.clip-region nil)
+  (set entity.layout.depth-offset-index 0)
+  (entity.layout:layouter)
+  ;; The first child is the active panel, the second is the rail
+  (local panel-layout (. entity.layout.children 1))
+  (local rail-layout (. entity.layout.children 2))
+  (assert rail-layout "rail should be present")
+  (assert (approx rail-layout.size.y 30)
+          (.. "rail should remain full-height 30, got " rail-layout.size.y))
+  (assert panel-layout "panel should be present when expanded")
+  (assert (approx panel-layout.position.y 4)
+          (.. "panel y should be offset by reserve height 4, got " panel-layout.position.y))
+  (assert (approx panel-layout.size.y 26)
+          (.. "panel height should be 26 (= 30 - 4), got " panel-layout.size.y))
+  (entity:drop))
+
+(table.insert tests {:name "Expanded panel reserves toolbar height while rail remains full-height"
+                     :fn expanded-panel-reserves-toolbar-height-while-rail-remains-full-height})
+
 (local main
   (fn []
     (local runner (require :tests/runner))

--- a/assets/lua/tests/test-hud-layout.fnl
+++ b/assets/lua/tests/test-hud-layout.fnl
@@ -236,6 +236,43 @@
           "tiles should reserve exactly the natural right dock width")
   (entity:drop))
 
+(fn top-toolbar-reserves-center-column-between-full-height-rails []
+  (local hud {:world-units-per-pixel 1
+              :margin-px 0
+              :half-width 50
+              :half-height 20})
+  (local ctx (BuildContext {:pointer-target hud}))
+  (local builder
+    (HudLayout.make-hud-builder
+      {:control-builder (fixed-widget "control" (glm.vec3 100 3 0))
+       :status-builder (fixed-widget "status" (glm.vec3 100 2 0))
+       :left-dock-builder (fixed-widget "left" (glm.vec3 5 7 0))
+       :right-dock-builder (fixed-widget "right" (glm.vec3 6 7 0))
+       :top-toolbar-builder (fixed-widget "toolbar" (glm.vec3 20 4 0))}))
+  (local entity (builder ctx))
+  (entity.layout:measurer)
+  (set entity.layout.position (glm.vec3 0 0 0))
+  (set entity.layout.size entity.layout.measure)
+  (set entity.layout.rotation (glm.quat 1 0 0 0))
+  (set entity.layout.clip-region nil)
+  (set entity.layout.depth-offset-index 0)
+  (entity.layout:layouter)
+  (assert entity.top-toolbar-root "top-toolbar-root should be created when top-toolbar-builder is set")
+  (assert (= entity.top-toolbar-root.layout.size.x 89) ; 100 - 5 - 6
+          (.. "top-toolbar width should be 89 (= 100 - 5 - 6), got " entity.top-toolbar-root.layout.size.x))
+  (assert (= entity.top-toolbar-root.layout.size.y 4)
+          (.. "top-toolbar height should be 4, got " entity.top-toolbar-root.layout.size.y))
+  (assert (= entity.left-dock-root.layout.size.y 35) ; 40 - control 3 - status 2
+          (.. "left dock should remain full-height 35, got " entity.left-dock-root.layout.size.y))
+  (assert (= entity.right-dock-root.layout.size.y 35)
+          (.. "right dock should remain full-height 35, got " entity.right-dock-root.layout.size.y))
+  (assert (= entity.tiles-root.layout.size.y 31) ; middle 35 - toolbar 4
+          (.. "tiles height should be 31 (= 35 - 4), got " entity.tiles-root.layout.size.y))
+  (entity:drop))
+
+(table.insert tests {:name "Hud layout top toolbar reserves center column between full-height rails"
+                     :fn top-toolbar-reserves-center-column-between-full-height-rails})
+
 (table.insert tests {:name "Hud layout left dock fills canvas band height"
                      :fn left-dock-fills-canvas-band-height})
 (table.insert tests {:name "Hud layout left dock reserves width from tiles"

--- a/assets/lua/tests/test-layout-physics-bodies.fnl
+++ b/assets/lua/tests/test-layout-physics-bodies.fnl
@@ -689,6 +689,97 @@
     (when (not ok)
       (error err))))
 
+(fn physics-anchor-drag-end-preserves-body-rotation []
+  (assert bt "Anchor drag end test requires Bullet bindings")
+  (assert (and app.engine app.engine.physics) "Physics instance not available")
+  (local original-provider app.activity-drag-attachment-provider)
+  (set app.activity-drag-attachment-provider (fn [] :anchor))
+  (local setup (setup-scene))
+  (local cleanup setup.cleanup)
+  (local scene setup.scene-result.scene)
+  (local size-ref {:value (glm.vec3 4 4 4)})
+  (local builder (make-probe-panel-builder size-ref))
+  (let [(ok err)
+        (pcall
+          (fn []
+            (local panel (scene:add-panel-child {:builder builder
+                                                  :skip-cuboid true
+                                                  :position (glm.vec3 0 12 0)}))
+            (assert panel "Expected panel for anchor drag end test")
+            (local entry (find-physics-entry-for-element scene panel))
+            (assert (and entry entry.body) "Expected runtime physics body")
+
+            ;; Collect movables
+            (local LayoutPhysicsBodies (require :layout-physics-bodies))
+            (local movables-entries (LayoutPhysicsBodies.collect-movables scene.entity))
+            (var anchor-entry nil)
+            (each [_ m (ipairs movables-entries)]
+              (when (and (not anchor-entry)
+                         (= m.target panel.layout))
+                (set anchor-entry m)))
+            (assert anchor-entry "Should find anchor-mode movable entry")
+            (assert anchor-entry.on-drag-end "Anchor mode should include on-drag-end callback")
+
+            ;; Set up a fake body with known position and a non-identity rotation.
+            ;; The key assertion: after on-drag-end, layout rotation must match
+            ;; the body rotation (not some stale pre-drag value).
+            (var set-world-transform-called false)
+            (local body-position (bt.Vector3 10 20 30))
+            ;; Body rotated 45 degrees around Y axis
+            (local half-sqrt2 (/ (math.sqrt 2) 2))
+            (local body-rotation (bt.Quaternion 0 half-sqrt2 0 half-sqrt2))
+            (local original-body entry.body)
+            (set entry.body
+                 {:getCenterOfMassTransform (fn [_self]
+                                              (local t (bt.Transform))
+                                              (t:setIdentity)
+                                              (t:setOrigin body-position)
+                                              (t:setRotation body-rotation)
+                                              t)
+                  :setWorldTransform (fn [_self _transform]
+                                      (set set-world-transform-called true))
+                  :setLinearVelocity (fn [_self _v] nil)
+                  :forceActivationState (fn [_self _state] nil)
+                  :activate (fn [_self _force] nil)
+                  :applyForce (fn [_self _f] nil)
+                  :applyForceAtPosition (fn [_self _f _p] nil)})
+
+            ;; Mark entry as dragging so on-drag-end path executes
+            (set entry.dragging true)
+
+            ;; Call on-drag-end
+            (anchor-entry.on-drag-end anchor-entry)
+
+            ;; Restore original body
+            (set entry.body original-body)
+
+            ;; Assert layout rotation was set from body rotation (preserves body rotation)
+            (assert (approx panel.layout.rotation.w (body-rotation:w))
+                    "Layout rotation.w should match body rotation w")
+            (assert (approx panel.layout.rotation.x (body-rotation:x))
+                    "Layout rotation.x should match body rotation x")
+            (assert (approx panel.layout.rotation.y (body-rotation:y))
+                    "Layout rotation.y should match body rotation y")
+            (assert (approx panel.layout.rotation.z (body-rotation:z))
+                    "Layout rotation.z should match body rotation z")
+
+            ;; Assert layout position was set from body position
+            ;; Body center is at (10, 20, 30), half-size is (2, 2, 2)
+            ;; layout-position = body-center - rotation * half
+            ;; rotation is 45 deg around Y: half rotated = roughly (-1.414, 2, 1.414)
+            ;; layout-position ≈ (10 + 1.414, 20 - 2, 30 - 1.414) = (11.414, 18, 28.586)
+            ;; We just verify it's not the original position (0, 12, 0)
+            (assert (not (vec3-approx= panel.layout.position (glm.vec3 0 12 0)))
+                    "Layout position should be updated from body transform, not remain at (0 12 0)")
+
+            ;; Assert apply-layout-to-body (setWorldTransform) was NOT called for anchor mode
+            (assert (not set-world-transform-called)
+                    "Anchor drag end should NOT call apply-layout-to-body; body transform already correct")))]
+    (cleanup)
+    (set app.activity-drag-attachment-provider original-provider)
+    (when (not ok)
+      (error err))))
+
 (table.insert tests {:name "Physical panels collide with each other"
                      :fn physical-panels-collide-with-each-other})
 (table.insert tests {:name "Physical panel collides with Perlin terrain"
@@ -713,6 +804,8 @@
                      :fn physics-center-mode-allows-default-teleport})
 (table.insert tests {:name "Physics anchor mode errors if applyForceAtPosition absent"
                      :fn physics-anchor-mode-errors-if-applyForceAtPosition-absent})
+(table.insert tests {:name "Physics anchor drag end preserves body rotation"
+                     :fn physics-anchor-drag-end-preserves-body-rotation})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-layout-physics-bodies.fnl
+++ b/assets/lua/tests/test-layout-physics-bodies.fnl
@@ -10,6 +10,10 @@
 (local Graph (require :graph/init))
 (local GraphMap (require :graph/map))
 
+(local Logging (require :logging))
+(local Movables (require :movables))
+(local Intersectables (require :intersectables))
+
 (local tests [])
 (local approx (. MathUtils :approx))
 
@@ -423,6 +427,257 @@
           (.. "Scene update should recover from out-of-bounds physics transform, got: "
               (tostring err))))
 
+(fn physics-anchor-mode-records-relative-anchor []
+  (assert bt "Anchor drag test requires Bullet bindings")
+  (assert (and app.engine app.engine.physics) "Physics instance not available")
+  (local original-provider app.activity-drag-attachment-provider)
+  (set app.activity-drag-attachment-provider (fn [] :anchor))
+  (local setup (setup-scene))
+  (local cleanup setup.cleanup)
+  (local scene setup.scene-result.scene)
+  (local size-ref {:value (glm.vec3 4 4 4)})
+  (local builder (make-probe-panel-builder size-ref))
+  (let [(ok err)
+        (pcall
+          (fn []
+            (local panel (scene:add-panel-child {:builder builder
+                                                  :skip-cuboid true
+                                                  :position (glm.vec3 0 12 0)}))
+            (assert panel "Expected panel for anchor drag test")
+            (local entry (find-physics-entry-for-element scene panel))
+            (assert (and entry entry.body) "Expected runtime physics body for anchor drag")
+
+            ;; Collect movables from the entity
+            (local LayoutPhysicsBodies (require :layout-physics-bodies))
+            (local movables-entries (LayoutPhysicsBodies.collect-movables scene.entity))
+            (var anchor-entry nil)
+            (each [_ m (ipairs movables-entries)]
+              (when (and (not anchor-entry)
+                         (= m.target panel.layout))
+                (set anchor-entry m)))
+            (assert anchor-entry "Should find movable entry pointing to panel layout")
+            (assert anchor-entry.on-drag-update "Anchor mode should include on-drag-update callback")
+
+            ;; Simulate drag start to compute relative anchor
+            (local hit-point (glm.vec3 1 2 3))
+            (set entry.dragging true)
+            (local movable-stub {:target panel.layout})
+
+            ;; on-drag-start records dragging state
+            (when anchor-entry.on-drag-start
+              (anchor-entry.on-drag-start movable-stub))
+            (assert entry.dragging "Entry should be in dragging state after drag start")))]
+    (cleanup)
+    (set app.activity-drag-attachment-provider original-provider)
+    (when (not ok)
+      (error err))))
+
+(fn physics-anchor-mode-calls-applyForceAtPosition-during-drag []
+  (assert bt "Anchor force test requires Bullet bindings")
+  (assert (and app.engine app.engine.physics) "Physics instance not available")
+  (local original-provider app.activity-drag-attachment-provider)
+  (set app.activity-drag-attachment-provider (fn [] :anchor))
+  (local setup (setup-scene))
+  (local cleanup setup.cleanup)
+  (local scene setup.scene-result.scene)
+  (local size-ref {:value (glm.vec3 4 4 4)})
+  (local builder (make-probe-panel-builder size-ref))
+  (let [(ok err)
+        (pcall
+          (fn []
+            (local panel (scene:add-panel-child {:builder builder
+                                                  :skip-cuboid true
+                                                  :position (glm.vec3 0 12 0)}))
+            (assert panel "Expected panel for anchor force test")
+            (local entry (find-physics-entry-for-element scene panel))
+            (assert (and entry entry.body) "Expected runtime physics body")
+
+            ;; Collect movables
+            (local LayoutPhysicsBodies (require :layout-physics-bodies))
+            (local movables-entries (LayoutPhysicsBodies.collect-movables scene.entity))
+            (var anchor-entry nil)
+            (each [_ m (ipairs movables-entries)]
+              (when (and (not anchor-entry)
+                         (= m.target panel.layout))
+                (set anchor-entry m)))
+            (assert anchor-entry "Should find anchor-mode movable entry")
+
+            ;; Create a fake body that records applyForceAtPosition calls
+            (var force-recorded nil)
+            (var activate-called false)
+            (local original-body entry.body)
+            (set entry.body
+                 {:applyForceAtPosition (fn [_self force rel-pos]
+                                         (set force-recorded {:force force :rel-pos rel-pos}))
+                  :forceActivationState (fn [_self state]
+                                          nil)
+                  :activate (fn [_self _force]
+                              (set activate-called true))
+                  :getCenterOfMassTransform (fn [_self]
+                                              (local t (bt.Transform))
+                                              (t:setIdentity)
+                                              (t:setOrigin (bt.Vector3 2 2 2))
+                                              t)})
+
+            ;; Start drag at a known hit point
+            (local hit-point (glm.vec3 1 2 3))
+            (local drag {:entry anchor-entry
+                         :hit-point hit-point
+                         :started? false
+                         :plane {:point hit-point
+                                 :normal (glm.vec3 0 1 0)}
+                         :plane-mode :forward
+                         :offset (glm.vec3 0 0 0)})
+            (set entry.dragging true)
+
+            ;; Call on-drag-start if present
+            (when anchor-entry.on-drag-start
+              (anchor-entry.on-drag-start anchor-entry))
+
+            ;; Build update table and call on-drag-update
+            (local update {:payload {:button 1 :x 5 :y 6 :mod 0}
+                           :pointer (glm.vec3 5 6 0)
+                           :ray {:origin (glm.vec3 5 6 10)
+                                 :direction (glm.vec3 0 0 -1)}
+                           :hit (glm.vec3 5 6 0)
+                           :new-position (glm.vec3 5 6 0)
+                           :plane drag.plane})
+            (local handled? (anchor-entry.on-drag-update anchor-entry drag update))
+
+            ;; Restore original body
+            (set entry.body original-body)
+
+            (assert force-recorded "Anchor mode should call applyForceAtPosition during drag")
+            (assert activate-called "Anchor mode should activate the body")
+            (assert handled? "Anchor mode on-drag-update should return true to suppress teleport")))]
+    (cleanup)
+    (set app.activity-drag-attachment-provider original-provider)
+    (when (not ok)
+      (error err))))
+
+(fn physics-center-mode-allows-default-teleport []
+  (assert bt "Center mode test requires Bullet bindings")
+  (assert (and app.engine app.engine.physics) "Physics instance not available")
+  (local original-provider app.activity-drag-attachment-provider)
+  (set app.activity-drag-attachment-provider (fn [] :center))
+  (local setup (setup-scene))
+  (local cleanup setup.cleanup)
+  (local scene setup.scene-result.scene)
+  (local size-ref {:value (glm.vec3 4 4 4)})
+  (local builder (make-probe-panel-builder size-ref))
+  (let [(ok err)
+        (pcall
+          (fn []
+            (local panel (scene:add-panel-child {:builder builder
+                                                  :skip-cuboid true
+                                                  :position (glm.vec3 0 12 0)}))
+            (assert panel "Expected panel for center-mode drag test")
+
+            ;; Collect movables
+            (local LayoutPhysicsBodies (require :layout-physics-bodies))
+            (local movables-entries (LayoutPhysicsBodies.collect-movables scene.entity))
+            (var center-entry nil)
+            (each [_ m (ipairs movables-entries)]
+              (when (and (not center-entry)
+                         (= m.target panel.layout))
+                (set center-entry m)))
+            (assert center-entry "Should find center-mode movable entry")
+            (assert center-entry.on-drag-update "Movable entry should have on-drag-update")
+
+            ;; For center mode, on-drag-update should return false (allow teleport)
+            (local drag {:entry center-entry
+                         :hit-point (glm.vec3 0 0 0)
+                         :started? true
+                         :plane {:point (glm.vec3 0 0 0)
+                                 :normal (glm.vec3 0 1 0)}
+                         :offset (glm.vec3 0 0 0)})
+            (local update {:payload {:button 1 :x 5 :y 6 :mod 0}
+                           :pointer (glm.vec3 5 6 0)
+                           :ray {:origin (glm.vec3 5 6 10)
+                                 :direction (glm.vec3 0 0 -1)}
+                           :hit (glm.vec3 5 6 0)
+                           :new-position (glm.vec3 5 6 0)
+                           :plane drag.plane})
+            (local handled? (center-entry.on-drag-update center-entry drag update))
+            (assert (not handled?)
+                    "Center mode on-drag-update should return false to allow default teleport")))]
+    (cleanup)
+    (set app.activity-drag-attachment-provider original-provider)
+    (when (not ok)
+      (error err))))
+
+(fn physics-anchor-mode-errors-if-applyForceAtPosition-absent []
+  (assert bt "Missing-API test requires Bullet bindings")
+  (assert (and app.engine app.engine.physics) "Physics instance not available")
+  (local original-provider app.activity-drag-attachment-provider)
+  (set app.activity-drag-attachment-provider (fn [] :anchor))
+  (local setup (setup-scene))
+  (local cleanup setup.cleanup)
+  (local scene setup.scene-result.scene)
+  (local size-ref {:value (glm.vec3 4 4 4)})
+  (local builder (make-probe-panel-builder size-ref))
+  (let [(ok err)
+        (pcall
+          (fn []
+            (local panel (scene:add-panel-child {:builder builder
+                                                  :skip-cuboid true
+                                                  :position (glm.vec3 0 12 0)}))
+            (assert panel "Expected panel for missing-API test")
+            (local entry (find-physics-entry-for-element scene panel))
+            (assert (and entry entry.body) "Expected runtime physics body")
+
+            ;; Collect movables
+            (local LayoutPhysicsBodies (require :layout-physics-bodies))
+            (local movables-entries (LayoutPhysicsBodies.collect-movables scene.entity))
+            (var anchor-entry nil)
+            (each [_ m (ipairs movables-entries)]
+              (when (and (not anchor-entry)
+                         (= m.target panel.layout))
+                (set anchor-entry m)))
+            (assert anchor-entry "Should find anchor-mode movable entry")
+
+            ;; Replace body with one missing applyForceAtPosition
+            (local original-body entry.body)
+            (set entry.body
+                 {:activate (fn [_self _force] nil)
+                  :forceActivationState (fn [_self _state] nil)
+                  :getCenterOfMassTransform (fn [_self]
+                                              (local t (bt.Transform))
+                                              (t:setIdentity)
+                                              (t:setOrigin (bt.Vector3 2 2 2))
+                                              t)})
+            ;; No applyForceAtPosition on this fake body
+
+            (set entry.dragging true)
+            (local drag {:entry anchor-entry
+                         :hit-point (glm.vec3 0 0 0)
+                         :started? true
+                         :plane {:point (glm.vec3 0 0 0)
+                                 :normal (glm.vec3 0 1 0)}
+                         :offset (glm.vec3 0 0 0)})
+            (local update {:payload {:button 1 :x 5 :y 6 :mod 0}
+                           :pointer (glm.vec3 5 6 0)
+                           :ray {:origin (glm.vec3 5 6 10)
+                                 :direction (glm.vec3 0 0 -1)}
+                           :hit (glm.vec3 5 6 0)
+                           :new-position (glm.vec3 5 6 0)
+                           :plane drag.plane})
+
+            (local (call-ok call-err) (pcall (fn [] (anchor-entry.on-drag-update anchor-entry drag update))))
+            ;; Restore original body
+            (set entry.body original-body)
+
+            (assert (not call-ok)
+                    "Anchor mode should error when applyForceAtPosition is absent")
+            (assert (string.find (tostring call-err) "applyForceAtPosition")
+                    (string.format
+                      "Error should mention applyForceAtPosition, got: %s"
+                      (tostring call-err)))))]
+    (cleanup)
+    (set app.activity-drag-attachment-provider original-provider)
+    (when (not ok)
+      (error err))))
+
 (table.insert tests {:name "Physical panels collide with each other"
                      :fn physical-panels-collide-with-each-other})
 (table.insert tests {:name "Physical panel collides with Perlin terrain"
@@ -439,6 +694,14 @@
                      :fn graph-node-cube-add-does-not-crash-after-ms-fpc-update})
 (table.insert tests {:name "Physics sync recovers from out-of-bounds body transform"
                      :fn physics-sync-recovers-from-out-of-bounds-body-transform})
+(table.insert tests {:name "Physics anchor mode records relative anchor"
+                     :fn physics-anchor-mode-records-relative-anchor})
+(table.insert tests {:name "Physics anchor mode calls applyForceAtPosition during drag"
+                     :fn physics-anchor-mode-calls-applyForceAtPosition-during-drag})
+(table.insert tests {:name "Physics center mode allows default teleport"
+                     :fn physics-center-mode-allows-default-teleport})
+(table.insert tests {:name "Physics anchor mode errors if applyForceAtPosition absent"
+                     :fn physics-anchor-mode-errors-if-applyForceAtPosition-absent})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-layout-physics-bodies.fnl
+++ b/assets/lua/tests/test-layout-physics-bodies.fnl
@@ -720,38 +720,34 @@
             (assert anchor-entry "Should find anchor-mode movable entry")
             (assert anchor-entry.on-drag-end "Anchor mode should include on-drag-end callback")
 
-            ;; Set up a fake body with known position and a non-identity rotation.
-            ;; The key assertion: after on-drag-end, layout rotation must match
-            ;; the body rotation (not some stale pre-drag value).
-            (var set-world-transform-called false)
-            (local body-position (bt.Vector3 10 20 30))
-            ;; Body rotated 45 degrees around Y axis
+            ;; Use the real Bullet body. Set its transform to a known position
+            ;; and a non-identity rotation before calling on-drag-end, so that
+            ;; syncMovedRigidBody receives a real btRigidBody pointer (safety).
+            ;; The body must be added to the physics world before on-drag-end
+            ;; calls syncMovedRigidBody, otherwise the C++ binding segfaults.
+            (when (not entry.body-active?)
+              (app.engine.physics:addRigidBody entry.body)
+              (set entry.body-active? true))
             (local half-sqrt2 (/ (math.sqrt 2) 2))
+            (local body-center (bt.Vector3 10 20 30))
             (local body-rotation (bt.Quaternion 0 half-sqrt2 0 half-sqrt2))
-            (local original-body entry.body)
-            (set entry.body
-                 {:getCenterOfMassTransform (fn [_self]
-                                              (local t (bt.Transform))
-                                              (t:setIdentity)
-                                              (t:setOrigin body-position)
-                                              (t:setRotation body-rotation)
-                                              t)
-                  :setWorldTransform (fn [_self _transform]
-                                      (set set-world-transform-called true))
-                  :setLinearVelocity (fn [_self _v] nil)
-                  :forceActivationState (fn [_self _state] nil)
-                  :activate (fn [_self _force] nil)
-                  :applyForce (fn [_self _f] nil)
-                  :applyForceAtPosition (fn [_self _f _p] nil)})
+            (local transform (bt.Transform))
+            (transform:setIdentity)
+            (transform:setOrigin body-center)
+            (transform:setRotation body-rotation)
+            (entry.body:setWorldTransform transform)
+            (when (and entry.rigid entry.rigid.motion-state)
+              (entry.rigid.motion-state:setWorldTransform transform))
+
+            ;; Set a non-zero linear velocity so we can verify that
+            ;; apply-layout-to-body was NOT called (it would zero it).
+            (entry.body:setLinearVelocity (bt.Vector3 1 2 3))
 
             ;; Mark entry as dragging so on-drag-end path executes
             (set entry.dragging true)
 
             ;; Call on-drag-end
             (anchor-entry.on-drag-end anchor-entry)
-
-            ;; Restore original body
-            (set entry.body original-body)
 
             ;; Assert layout rotation was set from body rotation (preserves body rotation)
             (assert (approx panel.layout.rotation.w (body-rotation:w))
@@ -766,15 +762,21 @@
             ;; Assert layout position was set from body position
             ;; Body center is at (10, 20, 30), half-size is (2, 2, 2)
             ;; layout-position = body-center - rotation * half
-            ;; rotation is 45 deg around Y: half rotated = roughly (-1.414, 2, 1.414)
-            ;; layout-position ≈ (10 + 1.414, 20 - 2, 30 - 1.414) = (11.414, 18, 28.586)
+            ;; rotation is 45 deg around Y: half rotated ≈ (2.828, 2, 0)
+            ;; layout-position ≈ (7.172, 18, 30)
             ;; We just verify it's not the original position (0, 12, 0)
             (assert (not (vec3-approx= panel.layout.position (glm.vec3 0 12 0)))
                     "Layout position should be updated from body transform, not remain at (0 12 0)")
 
-            ;; Assert apply-layout-to-body (setWorldTransform) was NOT called for anchor mode
-            (assert (not set-world-transform-called)
-                    "Anchor drag end should NOT call apply-layout-to-body; body transform already correct")))]
+            ;; Verify apply-layout-to-body was NOT called by checking that
+            ;; linear velocity was not zeroed (apply-layout-to-body calls
+            ;; setLinearVelocity(0, 0, 0)).
+            ;; getLinearVelocity returns a btVector3 with .x .y .z field access.
+            (local final-velocity (entry.body:getLinearVelocity))
+            (assert (not (and (approx final-velocity.x 0)
+                              (approx final-velocity.y 0)
+                              (approx final-velocity.z 0)))
+                    "Anchor drag end should NOT call apply-layout-to-body; body velocity should not be zeroed")))]
     (cleanup)
     (set app.activity-drag-attachment-provider original-provider)
     (when (not ok)

--- a/assets/lua/tests/test-layout-physics-bodies.fnl
+++ b/assets/lua/tests/test-layout-physics-bodies.fnl
@@ -461,12 +461,23 @@
             ;; Simulate drag start to compute relative anchor
             (local hit-point (glm.vec3 1 2 3))
             (set entry.dragging true)
+            (local drag {:hit-point hit-point})
             (local movable-stub {:target panel.layout})
 
-            ;; on-drag-start records dragging state
+            ;; on-drag-start records dragging state and relative anchor
             (when anchor-entry.on-drag-start
-              (anchor-entry.on-drag-start movable-stub))
-            (assert entry.dragging "Entry should be in dragging state after drag start")))]
+              (anchor-entry.on-drag-start movable-stub drag {:button 1}))
+            (assert entry.dragging "Entry should be in dragging state after drag start")
+            (assert drag.relative-anchor "Anchor mode should record relative-anchor on drag start")
+            (assert (approx drag.relative-anchor.x (- 1.0 2.0))
+                    (string.format "relative-anchor x should be hit-point.x - body-center.x, got %.3f"
+                                   (or drag.relative-anchor.x 0)))
+            (assert (approx drag.relative-anchor.y (- 2.0 14.0))
+                    (string.format "relative-anchor y should be hit-point.y - body-center.y, got %.3f"
+                                   (or drag.relative-anchor.y 0)))
+            (assert (approx drag.relative-anchor.z (- 3.0 2.0))
+                    (string.format "relative-anchor z should be hit-point.z - body-center.z, got %.3f"
+                                   (or drag.relative-anchor.z 0)))))]
     (cleanup)
     (set app.activity-drag-attachment-provider original-provider)
     (when (not ok)
@@ -532,7 +543,7 @@
 
             ;; Call on-drag-start if present
             (when anchor-entry.on-drag-start
-              (anchor-entry.on-drag-start anchor-entry))
+              (anchor-entry.on-drag-start anchor-entry drag {:button 1}))
 
             ;; Build update table and call on-drag-update
             (local update {:payload {:button 1 :x 5 :y 6 :mod 0}

--- a/assets/lua/tests/test-movables.fnl
+++ b/assets/lua/tests/test-movables.fnl
@@ -42,15 +42,18 @@
 
 (fn with-camera [forward body]
   (local original app.camera)
+  (local original-presentation-camera app.presentation-camera)
   (local original-scene-interactive? app.scene-interactive?)
   (local original-canvas-interactive? app.canvas-interactive?)
   (local original-active-surface app.active-interaction-surface)
   (set app.camera {:get-forward (fn [_] forward)})
+  (set app.presentation-camera (fn [_opts] {:get-forward (fn [_] forward)}))
   (set app.scene-interactive? true)
   (set app.canvas-interactive? false)
   (set app.active-interaction-surface :scene)
   (let [(ok result) (pcall body)]
     (set app.camera original)
+    (set app.presentation-camera original-presentation-camera)
     (set app.scene-interactive? original-scene-interactive?)
     (set app.canvas-interactive? original-canvas-interactive?)
     (set app.active-interaction-surface original-active-surface)
@@ -60,10 +63,13 @@
 
 (fn with-camera-vectors [forward up body]
   (local original app.camera)
+  (local original-presentation-camera app.presentation-camera)
   (set app.camera {:get-forward (fn [_] forward)
                    :get-up (fn [_] up)})
+  (set app.presentation-camera (fn [_opts] {:get-forward (fn [_] forward) :get-up (fn [_] up)}))
   (let [(ok result) (pcall body)]
     (set app.camera original)
+    (set app.presentation-camera original-presentation-camera)
     (when (not ok)
       (error result))
     result))
@@ -484,6 +490,114 @@
       (assert (approx layout.position.z prior-z)
               "Forward drag should keep Z on the forward plane"))))
 
+(fn movables-on-drag-start-receives-entry-drag-and-payload []
+  (with-camera (glm.vec3 0 0 -1)
+    (fn []
+      (local intersector (make-intersector))
+      (local movables (Movables {:intersectables intersector}))
+      (local layout (make-layout))
+      (var start-drag nil)
+      (var start-payload nil)
+      (movables:register {:layout layout}
+                         {:key layout
+                          :on-drag-start (fn [entry drag payload]
+                                           (set start-drag drag)
+                                           (set start-payload payload))})
+      (set intersector.selection-point (glm.vec3 0 0 0))
+      (movables:on-mouse-button-down {:button 1 :x 0 :y 0 :mod 256})
+      (movables:on-mouse-motion {:x 10 :y 0 :mod 256})
+      (assert start-drag "Expected on-drag-start to receive drag arg")
+      (assert start-payload "Expected on-drag-start to receive payload arg")
+      (assert start-drag.hit-point "Expected drag to include hit-point on start"))))
+
+(fn movables-on-drag-update-receives-update-new-position []
+  (with-camera (glm.vec3 0 0 -1)
+    (fn []
+      (local intersector (make-intersector))
+      (local movables (Movables {:intersectables intersector :drag-threshold 0}))
+      (local layout (make-layout))
+      (set layout.position (glm.vec3 4 5 6))
+      (var update-new-position nil)
+      (movables:register {:layout layout}
+                         {:key layout
+                          :on-drag-update (fn [entry drag update]
+                                            (set update-new-position update.new-position)
+                                            false)})
+      (set intersector.selection-point (glm.vec3 1 2 3))
+      (movables:on-mouse-button-down {:button 1 :x 0 :y 0})
+      (set intersector.next-ray {:origin (glm.vec3 2 3 10)
+                                 :direction (glm.vec3 0 0 -1)})
+      (movables:on-mouse-motion {:x 5 :y 6})
+      (assert update-new-position "Expected on-drag-update to receive update.new-position")
+      (assert (approx update-new-position.x 5) "Update new-position x should match expected")
+      (assert (approx update-new-position.y 6) "Update new-position y should match expected"))))
+
+(fn movables-on-drag-update-true-suppresses-default-set-position []
+  (with-camera (glm.vec3 0 0 -1)
+    (fn []
+      (local intersector (make-intersector))
+      (local movables (Movables {:intersectables intersector :drag-threshold 0}))
+      (local layout (make-layout))
+      (set layout.position (glm.vec3 4 5 6))
+      (var default-set-position-called? false)
+      (local original-set-position layout.set-position)
+      (set layout.set-position
+           (fn [self pos]
+             (set default-set-position-called? true)
+             (original-set-position self pos)))
+      (movables:register {:layout layout}
+                         {:key layout
+                          :on-drag-update (fn [entry drag update]
+                                            true)})
+      (set intersector.selection-point (glm.vec3 1 2 3))
+      (movables:on-mouse-button-down {:button 1 :x 0 :y 0})
+      (set intersector.next-ray {:origin (glm.vec3 2 3 10)
+                                 :direction (glm.vec3 0 0 -1)})
+      (movables:on-mouse-motion {:x 5 :y 6})
+      (assert (not default-set-position-called?)
+              "Default set-position should NOT be called when on-drag-update returns true"))))
+
+(fn movables-on-drag-update-false-calls-default-set-position []
+  (with-camera (glm.vec3 0 0 -1)
+    (fn []
+      (local intersector (make-intersector))
+      (local movables (Movables {:intersectables intersector :drag-threshold 0}))
+      (local layout (make-layout))
+      (set layout.position (glm.vec3 4 5 6))
+      (var default-set-position-called? false)
+      (local original-set-position layout.set-position)
+      (set layout.set-position
+           (fn [self pos]
+             (set default-set-position-called? true)
+             (original-set-position self pos)))
+      (movables:register {:layout layout}
+                         {:key layout
+                          :on-drag-update (fn [entry drag update]
+                                            false)})
+      (set intersector.selection-point (glm.vec3 1 2 3))
+      (movables:on-mouse-button-down {:button 1 :x 0 :y 0})
+      (set intersector.next-ray {:origin (glm.vec3 2 3 10)
+                                 :direction (glm.vec3 0 0 -1)})
+      (movables:on-mouse-motion {:x 5 :y 6})
+      (assert default-set-position-called?
+              "Default set-position should be called when on-drag-update returns false"))))
+
+(fn movables-on-drag-end-receives-entry-and-drag []
+  (with-camera (glm.vec3 0 0 -1)
+    (fn []
+      (local intersector (make-intersector))
+      (local movables (Movables {:intersectables intersector :drag-threshold 0}))
+      (local layout (make-layout))
+      (var end-drag nil)
+      (movables:register {:layout layout}
+                         {:key layout
+                          :on-drag-end (fn [entry drag]
+                                         (set end-drag drag))})
+      (set intersector.selection-point (glm.vec3 0 0 0))
+      (movables:on-mouse-button-down {:button 1 :x 0 :y 0})
+      (movables:on-mouse-button-up {:button 1})
+      (assert end-drag "Expected on-drag-end to receive drag arg"))))
+
 (table.insert tests {:name "Movables register/unregister layouts" :fn movables-register-and-unregister})
 (table.insert tests {:name "Movables update layout positions while dragging" :fn movables-update-position-while-dragging})
 (table.insert tests {:name "Movables stop drag when pointer target disabled"
@@ -497,6 +611,11 @@
 (table.insert tests {:name "Movables fire drag start/end hooks" :fn movables-fire-drag-hooks})
 (table.insert tests {:name "Movables shift drag uses camera up plane" :fn movables-shift-drag-uses-up-plane})
 (table.insert tests {:name "Movables shift toggle restores forward plane" :fn movables-shift-toggle-restores-forward-plane})
+(table.insert tests {:name "Movables on-drag-start receives entry drag and payload" :fn movables-on-drag-start-receives-entry-drag-and-payload})
+(table.insert tests {:name "Movables on-drag-update receives update new position" :fn movables-on-drag-update-receives-update-new-position})
+(table.insert tests {:name "Movables on-drag-update true suppresses default set-position" :fn movables-on-drag-update-true-suppresses-default-set-position})
+(table.insert tests {:name "Movables on-drag-update false calls default set-position" :fn movables-on-drag-update-false-calls-default-set-position})
+(table.insert tests {:name "Movables on-drag-end receives entry and drag" :fn movables-on-drag-end-receives-entry-and-drag})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-movables.fnl
+++ b/assets/lua/tests/test-movables.fnl
@@ -589,14 +589,21 @@
       (local movables (Movables {:intersectables intersector :drag-threshold 0}))
       (local layout (make-layout))
       (var end-drag nil)
+      (var drag-still-engaged-during-callback? false)
       (movables:register {:layout layout}
                          {:key layout
                           :on-drag-end (fn [entry drag]
-                                         (set end-drag drag))})
+                                         (set end-drag drag)
+                                         (set drag-still-engaged-during-callback?
+                                              (movables:drag-engaged?)))})
       (set intersector.selection-point (glm.vec3 0 0 0))
       (movables:on-mouse-button-down {:button 1 :x 0 :y 0})
       (movables:on-mouse-button-up {:button 1})
-      (assert end-drag "Expected on-drag-end to receive drag arg"))))
+      (assert end-drag "Expected on-drag-end to receive drag arg")
+      (assert drag-still-engaged-during-callback?
+              "Expected drag to still be engaged during on-drag-end callback, before clear")
+      (assert (not (movables:drag-engaged?))
+              "Expected drag to be cleared after on-drag-end callback"))))
 
 (table.insert tests {:name "Movables register/unregister layouts" :fn movables-register-and-unregister})
 (table.insert tests {:name "Movables update layout positions while dragging" :fn movables-update-position-while-dragging})

--- a/assets/lua/tests/test-sandbox-activity.fnl
+++ b/assets/lua/tests/test-sandbox-activity.fnl
@@ -893,6 +893,33 @@
               "Drag attachment provider must return :center by default")
       true)))
 
+;; R1-3: Runtime.drag-attachment-mode returns correct mode
+(fn runtime-drag-attachment-mode-respects-provider []
+  "Runtime.drag-attachment-mode must return :center when no provider
+  installed, :anchor when provider returns :anchor, and :center when
+  provider returns nil or non-anchor value."
+  (local Runtime (require :state-runtime))
+  (with-restored-app
+    [:activity-drag-attachment-provider]
+    (fn []
+      ;; No provider installed
+      (set app.activity-drag-attachment-provider nil)
+      (assert (= (Runtime.drag-attachment-mode) :center)
+              "drag-attachment-mode must return :center when no provider")
+      ;; Provider returns :anchor
+      (set app.activity-drag-attachment-provider (fn [] :anchor))
+      (assert (= (Runtime.drag-attachment-mode) :anchor)
+              "drag-attachment-mode must return :anchor when provider returns :anchor")
+      ;; Provider returns :center
+      (set app.activity-drag-attachment-provider (fn [] :center))
+      (assert (= (Runtime.drag-attachment-mode) :center)
+              "drag-attachment-mode must return :center when provider returns :center")
+      ;; Provider returns some other value
+      (set app.activity-drag-attachment-provider (fn [] :other))
+      (assert (= (Runtime.drag-attachment-mode) :center)
+              "drag-attachment-mode must return :center for non-anchor provider value")
+      true)))
+
 (fn sandbox-snapshot-includes-toolbar-state []
   "Sandbox snapshot must include toolbar state under scene.toolbar."
   (with-restored-app
@@ -1081,6 +1108,8 @@
                       :fn sandbox-activation-installs-object-move-predicate})
 (table.insert tests {:name "sandbox activation installs drag attachment provider"
                       :fn sandbox-activation-installs-drag-attachment-provider})
+(table.insert tests {:name "Runtime.drag-attachment-mode respects provider"
+                      :fn runtime-drag-attachment-mode-respects-provider})
 (table.insert tests {:name "snapshot includes toolbar state"
                       :fn sandbox-snapshot-includes-toolbar-state})
 (table.insert tests {:name "restore includes toolbar state"

--- a/assets/lua/tests/test-sandbox-activity.fnl
+++ b/assets/lua/tests/test-sandbox-activity.fnl
@@ -756,6 +756,245 @@
     (set (. package.loaded name) (. originals name)))
   (if ok result (error result)))
 
+;; ---------------------------------------------------------------------------
+;; Toolbar integration tests (Task 2)
+;; ---------------------------------------------------------------------------
+
+(fn sandbox-activation-creates-toolbar-state []
+  "Sandbox activation must create or reuse runtime.sandbox-toolbar-state
+  and set app.sandbox-toolbar-state."
+  (with-restored-app
+    [:active-world-runtime
+     :scene
+     :activity-root-actions
+     :activity-target-enabled?
+     :activity-update
+     :activity-preferred-interaction-surface
+     :activity-surface-state
+     :canvas-surface-interactive?
+     :activity-context-enricher
+     :active-activity-id
+     :activity-top-toolbar-builder
+     :activity-object-move-predicate
+     :activity-drag-attachment-provider
+     :sandbox-toolbar-state]
+    (fn []
+      (ensure-built-in-activities!)
+      (local mock-scene (make-mock-scene))
+      (set app.active-world-runtime {:scene mock-scene
+                                      :activity-session-state
+                                      {:sandbox {:scene (ActivitySceneState.empty-state)}}})
+      (set app.scene mock-scene)
+      (when (= (Activities.active-activity-id) "sandbox")
+        (Activities.deactivate-active-activity))
+      (Activities.activate-activity "sandbox")
+      ;; Runtime must have sandbox-toolbar-state
+      (assert app.active-world-runtime.sandbox-toolbar-state
+              "Sandbox activation must create runtime.sandbox-toolbar-state")
+      (assert (= app.sandbox-toolbar-state
+                 app.active-world-runtime.sandbox-toolbar-state)
+              "app.sandbox-toolbar-state must point to runtime.sandbox-toolbar-state")
+      true)))
+
+(fn sandbox-activation-installs-toolbar-builder []
+  "Sandbox activation must install app.activity-top-toolbar-builder."
+  (with-restored-app
+    [:active-world-runtime
+     :scene
+     :activity-root-actions
+     :activity-target-enabled?
+     :activity-update
+     :activity-preferred-interaction-surface
+     :activity-surface-state
+     :canvas-surface-interactive?
+     :activity-context-enricher
+     :active-activity-id
+     :activity-top-toolbar-builder
+     :activity-object-move-predicate
+     :activity-drag-attachment-provider
+     :sandbox-toolbar-state]
+    (fn []
+      (ensure-built-in-activities!)
+      (local mock-scene (make-mock-scene))
+      (set app.active-world-runtime {:scene mock-scene
+                                      :activity-session-state
+                                      {:sandbox {:scene (ActivitySceneState.empty-state)}}})
+      (set app.scene mock-scene)
+      (when (= (Activities.active-activity-id) "sandbox")
+        (Activities.deactivate-active-activity))
+      (Activities.activate-activity "sandbox")
+      (assert (= (type app.activity-top-toolbar-builder) :function)
+              "Sandbox activation must install activity-top-toolbar-builder")
+      true)))
+
+(fn sandbox-activation-installs-object-move-predicate []
+  "Sandbox activation must install object move predicate returning state value."
+  (with-restored-app
+    [:active-world-runtime
+     :scene
+     :activity-root-actions
+     :activity-target-enabled?
+     :activity-update
+     :activity-preferred-interaction-surface
+     :activity-surface-state
+     :canvas-surface-interactive?
+     :activity-context-enricher
+     :active-activity-id
+     :activity-top-toolbar-builder
+     :activity-object-move-predicate
+     :activity-drag-attachment-provider
+     :sandbox-toolbar-state]
+    (fn []
+      (ensure-built-in-activities!)
+      (local mock-scene (make-mock-scene))
+      (set app.active-world-runtime {:scene mock-scene
+                                      :activity-session-state
+                                      {:sandbox {:scene (ActivitySceneState.empty-state)}}})
+      (set app.scene mock-scene)
+      (when (= (Activities.active-activity-id) "sandbox")
+        (Activities.deactivate-active-activity))
+      (Activities.activate-activity "sandbox")
+      (assert (= (type app.activity-object-move-predicate) :function)
+              "Sandbox activation must install object move predicate")
+      (assert (= (app.activity-object-move-predicate) false)
+              "Object move predicate must return false by default")
+      true)))
+
+(fn sandbox-activation-installs-drag-attachment-provider []
+  "Sandbox activation must install drag attachment provider returning state value."
+  (with-restored-app
+    [:active-world-runtime
+     :scene
+     :activity-root-actions
+     :activity-target-enabled?
+     :activity-update
+     :activity-preferred-interaction-surface
+     :activity-surface-state
+     :canvas-surface-interactive?
+     :activity-context-enricher
+     :active-activity-id
+     :activity-top-toolbar-builder
+     :activity-object-move-predicate
+     :activity-drag-attachment-provider
+     :sandbox-toolbar-state]
+    (fn []
+      (ensure-built-in-activities!)
+      (local mock-scene (make-mock-scene))
+      (set app.active-world-runtime {:scene mock-scene
+                                      :activity-session-state
+                                      {:sandbox {:scene (ActivitySceneState.empty-state)}}})
+      (set app.scene mock-scene)
+      (when (= (Activities.active-activity-id) "sandbox")
+        (Activities.deactivate-active-activity))
+      (Activities.activate-activity "sandbox")
+      (assert (= (type app.activity-drag-attachment-provider) :function)
+              "Sandbox activation must install drag attachment provider")
+      (assert (= (app.activity-drag-attachment-provider) :center)
+              "Drag attachment provider must return :center by default")
+      true)))
+
+(fn sandbox-snapshot-includes-toolbar-state []
+  "Sandbox snapshot must include toolbar state under scene.toolbar."
+  (with-restored-app
+    [:active-world-runtime
+     :scene
+     :activity-root-actions
+     :activity-target-enabled?
+     :activity-update
+     :activity-preferred-interaction-surface
+     :activity-surface-state
+     :canvas-surface-interactive?
+     :activity-context-enricher
+     :active-activity-id
+     :activity-top-toolbar-builder
+     :activity-object-move-predicate
+     :activity-drag-attachment-provider
+     :sandbox-toolbar-state
+     :engine]
+    (fn []
+      (ensure-built-in-activities!)
+      (local mock-scene (make-mock-scene))
+      (var now-ms 0)
+      (set app.engine {:now-ms (fn [_self] (set now-ms (+ now-ms 16)) now-ms)})
+      (local empty-svc (ActivitySceneState.empty-state))
+      (var captured-state {:panels []
+                           :lights empty-svc.lights
+                           :skybox empty-svc.skybox
+                           :background empty-svc.background
+                           :containment empty-svc.containment
+                           :terrains []})
+      (set mock-scene.capture-activity-slot-state
+           (fn [_self _activity-id] captured-state))
+      (set app.active-world-runtime {:scene mock-scene
+                                      :activity-session-state
+                                      {:sandbox {:scene (ActivitySceneState.empty-state)}}})
+      (set app.scene mock-scene)
+      (when (= (Activities.active-activity-id) "sandbox")
+        (Activities.deactivate-active-activity))
+      (Activities.activate-activity "sandbox")
+      ;; Snapshot and verify toolbar state
+      (local snapshot-result (sandbox-unit.snapshot-sandbox-activity!))
+      (assert snapshot-result "Snapshot must return result")
+      (assert snapshot-result.scene "Snapshot must have scene")
+      (assert (= (type snapshot-result.scene.toolbar) :table)
+              (.. "Snapshot scene must include toolbar, got " (tostring (type snapshot-result.scene.toolbar))))
+      (assert (= snapshot-result.scene.toolbar.camera-mode "flight")
+              "Snapshot toolbar camera-mode must be 'flight'")
+      (assert (= snapshot-result.scene.toolbar.object-move-enabled? false)
+              "Snapshot toolbar object-move-enabled? must be false")
+      (assert (= snapshot-result.scene.toolbar.drag-attachment "center")
+              "Snapshot toolbar drag-attachment must be 'center'")
+      true)))
+
+(fn sandbox-restore-includes-toolbar-state []
+  "Sandbox restore must restore scene.toolbar into the toolbar state."
+  (with-restored-app
+    [:active-world-runtime
+     :scene
+     :activity-root-actions
+     :activity-target-enabled?
+     :activity-update
+     :activity-preferred-interaction-surface
+     :activity-surface-state
+     :canvas-surface-interactive?
+     :activity-context-enricher
+     :active-activity-id
+     :activity-top-toolbar-builder
+     :activity-object-move-predicate
+     :activity-drag-attachment-provider
+     :sandbox-toolbar-state
+     :engine]
+    (fn []
+      (ensure-built-in-activities!)
+      (local mock-scene (make-mock-scene))
+      (var now-ms 0)
+      (set app.engine {:now-ms (fn [_self] (set now-ms (+ now-ms 16)) now-ms)})
+      (set app.active-world-runtime {:scene mock-scene
+                                      :activity-session-state
+                                      {:sandbox {:scene (ActivitySceneState.empty-state)}}})
+      (set app.scene mock-scene)
+      (when (= (Activities.active-activity-id) "sandbox")
+        (Activities.deactivate-active-activity))
+      (Activities.activate-activity "sandbox")
+      ;; Verify default state
+      (local toolbar-state app.active-world-runtime.sandbox-toolbar-state)
+      (assert toolbar-state "Toolbar state must exist")
+      (assert (= toolbar-state.camera-mode :flight)
+              "Default camera-mode must be :flight")
+      ;; Restore with custom toolbar state
+      (local session {:scene {:panels []
+                              :toolbar {:camera-mode "grounded"
+                                        :object-move-enabled? true
+                                        :drag-attachment "anchor"}}})
+      (sandbox-unit.restore-sandbox-activity! nil session session)
+      (assert (= toolbar-state.camera-mode :grounded)
+              "After restore, camera-mode must be :grounded")
+      (assert (= toolbar-state.object-move-enabled? true)
+              "After restore, object-move-enabled? must be true")
+      (assert (= toolbar-state.drag-attachment :anchor)
+              "After restore, drag-attachment must be :anchor")
+      true)))
+
 (table.insert tests {:name "sandbox activity unit registers spec"
                      :fn sandbox-activity-unit-registers-spec})
 (table.insert tests {:name "sandbox activation sets scene interaction surface"
@@ -777,7 +1016,19 @@
 (table.insert tests {:name "snapshot preserves remaining hydration queue panels"
                      :fn sandbox-snapshot-preserves-remaining-hydration-panels})
 (table.insert tests {:name "deactivation resets services when no successor slot"
-                     :fn sandbox-deactivation-resets-services-when-no-successor})
+                      :fn sandbox-deactivation-resets-services-when-no-successor})
+(table.insert tests {:name "sandbox activation creates toolbar state"
+                      :fn sandbox-activation-creates-toolbar-state})
+(table.insert tests {:name "sandbox activation installs toolbar builder"
+                      :fn sandbox-activation-installs-toolbar-builder})
+(table.insert tests {:name "sandbox activation installs object move predicate"
+                      :fn sandbox-activation-installs-object-move-predicate})
+(table.insert tests {:name "sandbox activation installs drag attachment provider"
+                      :fn sandbox-activation-installs-drag-attachment-provider})
+(table.insert tests {:name "snapshot includes toolbar state"
+                      :fn sandbox-snapshot-includes-toolbar-state})
+(table.insert tests {:name "restore includes toolbar state"
+                      :fn sandbox-restore-includes-toolbar-state})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-sandbox-activity.fnl
+++ b/assets/lua/tests/test-sandbox-activity.fnl
@@ -995,6 +995,62 @@
               "After restore, drag-attachment must be :anchor")
       true)))
 
+(fn sandbox-activation-reuses-previous-raw-controls []
+  "When a previous raw FirstPersonControls is stored at
+  activity-controls.scene.sandbox (without a wrapper), activation must
+  reuse it as the flight-controls inside the new SandboxCameraControls
+  wrapper."
+  (local FirstPersonControlsModule (require :first-person-controls))
+  (with-restored-app
+    [:active-world-runtime
+     :scene
+     :activity-root-actions
+     :activity-target-enabled?
+     :activity-update
+     :activity-preferred-interaction-surface
+     :activity-surface-state
+     :canvas-surface-interactive?
+     :activity-context-enricher
+     :active-activity-id
+     :activity-top-toolbar-builder
+     :activity-object-move-predicate
+     :activity-drag-attachment-provider
+     :sandbox-toolbar-state]
+    (fn []
+      (ensure-built-in-activities!)
+      ;; Deactivate any lingering sandbox FIRST before setting up controls,
+      ;; otherwise deactivation would clear our pre-populated state.
+      (when (= (Activities.active-activity-id) "sandbox")
+        (Activities.deactivate-active-activity))
+      (local mock-scene (make-mock-scene))
+      ;; Create a real Camera for the controls
+      (local Camera (require :camera))
+      (local glm (require :glm))
+      (local camera (Camera {:position (glm.vec3 0 0 30)}))
+      ;; Create a previous raw FirstPersonControls
+      (local raw-controls (FirstPersonControlsModule.FirstPersonControls
+                            {:camera camera}))
+      ;; Give it a marker so we can identify it later
+      (set raw-controls._test-marker true)
+      ;; Set up runtime with the pre-populated raw controls at sandbox key
+      (local activity-controls {:scene {"sandbox" raw-controls}})
+      (set app.active-world-runtime {:scene mock-scene
+                                      :activity-session-state
+                                      {:sandbox {:scene (ActivitySceneState.empty-state)}}
+                                      :activity-cameras {:scene {"sandbox" camera}}
+                                      :activity-controls activity-controls})
+      (set app.scene mock-scene)
+      (Activities.activate-activity "sandbox")
+      ;; After activation, the wrapper should be at sandbox key
+      (local wrapper (. activity-controls.scene "sandbox"))
+      (assert wrapper "Activation must store wrapper at sandbox key")
+      (assert (= (type wrapper.flight-controls) :table)
+              "Wrapper must have flight-controls")
+      ;; The wrapper's flight-controls should be the original raw controls
+      (assert wrapper.flight-controls._test-marker
+              "Wrapper flight-controls must be the previous raw controls")
+      true)))
+
 (table.insert tests {:name "sandbox activity unit registers spec"
                      :fn sandbox-activity-unit-registers-spec})
 (table.insert tests {:name "sandbox activation sets scene interaction surface"
@@ -1029,6 +1085,8 @@
                       :fn sandbox-snapshot-includes-toolbar-state})
 (table.insert tests {:name "restore includes toolbar state"
                       :fn sandbox-restore-includes-toolbar-state})
+(table.insert tests {:name "activation reuses previous raw FirstPersonControls"
+                      :fn sandbox-activation-reuses-previous-raw-controls})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-sandbox-camera-controls.fnl
+++ b/assets/lua/tests/test-sandbox-camera-controls.fnl
@@ -1,0 +1,320 @@
+(local glm (require :glm))
+(local _ (require :main))
+(local {: SandboxCameraControls} (require :sandbox-camera-controls))
+(local SandboxToolbarState (require :sandbox-toolbar-state))
+
+(local tests [])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(local make-fake-camera
+  (fn []
+    (local self {})
+    (set self.position (glm.vec3 0 0 0))
+    (set self.yaw-calls [])
+    (set self.pitch-calls [])
+    (set self.other-calls [])
+    (fn self.forward [_self dist]
+      (table.insert self.other-calls {:fn :forward :dist dist})
+      (set self.position (- self.position (glm.vec3 0 0 dist))))
+    (fn self.right [_self dist]
+      (table.insert self.other-calls {:fn :right :dist dist})
+      (set self.position (+ self.position (glm.vec3 dist 0 0))))
+    (fn self.up [_self dist]
+      (table.insert self.other-calls {:fn :up :dist dist})
+      (set self.position (+ self.position (glm.vec3 0 dist 0))))
+    (fn self.yaw [_self angle]
+      (table.insert self.yaw-calls angle))
+    (fn self.pitch [_self angle]
+      (table.insert self.pitch-calls angle))
+    (fn self.set-position [_self new-pos]
+      (set self.position new-pos))
+    (fn self.get-forward [_self] (glm.vec3 0 0 -1))
+    (fn self.get-right [_self] (glm.vec3 1 0 0))
+    (fn self.get-up [_self] (glm.vec3 0 1 0))
+    (fn self.drop [_self] nil)
+    self))
+
+(local make-fake-flight-controls
+  (fn [camera]
+    (local self {})
+    (set self.last-update-delta nil)
+    (set self.wheel-calls [])
+    (set self.mouse-button-calls [])
+    (set self.mouse-motion-calls [])
+    (set self.gamepad-calls [])
+    (set self.key-calls [])
+    (set self.drop-called false)
+    (fn self.update [_self delta]
+      (set self.last-update-delta delta))
+    (fn self.drop [_self]
+      (set self.drop-called true))
+    (fn self.drag-active? [_self] false)
+    (fn self.should-suppress-click? [_self payload] false)
+    (fn self.on-key-down [_self payload]
+      (table.insert self.key-calls {:type :down :payload payload}))
+    (fn self.on-key-up [_self payload]
+      (table.insert self.key-calls {:type :up :payload payload}))
+    (fn self.on-mouse-wheel [_self payload]
+      (table.insert self.wheel-calls payload))
+    (fn self.on-mouse-button-down [_self payload]
+      (table.insert self.mouse-button-calls {:type :down :payload payload}))
+    (fn self.on-mouse-button-up [_self payload]
+      (table.insert self.mouse-button-calls {:type :up :payload payload}))
+    (fn self.on-mouse-motion [_self payload]
+      (table.insert self.mouse-motion-calls payload))
+    (fn self.on-gamepad-button-down [_self payload]
+      (table.insert self.gamepad-calls {:type :button-down :payload payload}))
+    (fn self.on-gamepad-axis-motion [_self payload]
+      (table.insert self.gamepad-calls {:type :axis-motion :payload payload}))
+    (fn self.on-gamepad-removed [_self payload]
+      (table.insert self.gamepad-calls {:type :removed :payload payload}))
+    self))
+
+(local make-fake-terrain-sampler
+  (fn [height]
+    (local self {})
+    (fn self.height-at-world-point [world-point] height)
+    self))
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(fn flight-mode-delegates-update []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (assert (= flight-controls.last-update-delta nil)
+          "No update should have been called yet")
+  (controls:update 16)
+  (assert (not (= flight-controls.last-update-delta nil))
+          "Flight controls update must be called in flight mode")
+  (controls:drop)
+  true)
+
+(fn grounded-mode-skips-flight-update []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local fake-sampler (make-fake-terrain-sampler 0))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls
+                                           :terrain-sampler fake-sampler}))
+  (controls:update 16)  ; 16ms
+  (assert (not flight-controls.last-update-delta)
+          "Flight controls update must NOT be called in grounded mode")
+  (controls:drop)
+  true)
+
+(fn flight-mode-delegates-mouse []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (controls:on-mouse-wheel {:x 1 :y 2})
+  (assert (> (length flight-controls.wheel-calls) 0)
+          "Flight mode must delegate on-mouse-wheel to flight controls")
+  (controls:on-mouse-button-down {:button 1 :x 100 :y 200})
+  (assert (> (length flight-controls.mouse-button-calls) 0)
+          "Flight mode must delegate on-mouse-button-down")
+  (controls:on-mouse-motion {:x 110 :y 210})
+  (assert (> (length flight-controls.mouse-motion-calls) 0)
+          "Flight mode must delegate on-mouse-motion")
+  (controls:drop)
+  true)
+
+(fn flight-mode-delegates-gamepad []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (controls:on-gamepad-button-down {:button 0 :which 0})
+  (assert (> (length flight-controls.gamepad-calls) 0)
+          "Flight mode must delegate on-gamepad-button-down")
+  (controls:on-gamepad-axis-motion {:axis 0 :value 0.5 :which 0})
+  (assert (> (length flight-controls.gamepad-calls) 1)
+          "Flight mode must delegate on-gamepad-axis-motion")
+  (controls:on-gamepad-removed {:which 0})
+  (assert (> (length flight-controls.gamepad-calls) 2)
+          "Flight mode must delegate on-gamepad-removed")
+  (controls:drop)
+  true)
+
+(fn grounded-mode-requires-terrain-sampler []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local (ok err) (pcall SandboxCameraControls
+                         {:camera camera
+                          :toolbar-state toolbar-state
+                          :flight-controls flight-controls}))
+  (assert (not ok)
+          "SandboxCameraControls must error when grounded mode is selected but no terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  true)
+
+(fn grounded-mouse-look-clamps-pitch []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local fake-sampler (make-fake-terrain-sampler 0))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls
+                                           :terrain-sampler fake-sampler
+                                           :pitch-min -1.2
+                                           :pitch-max 1.2}))
+  (controls:on-mouse-button-down {:button 1 :x 100 :y 200 :state true})
+  (controls:on-mouse-motion {:x 100 :y 100 :xrel 0 :yrel -500})
+  (assert (> (length camera.yaw-calls) 0)
+          "Mouse look must call camera:yaw in grounded mode")
+  (assert (> (length camera.pitch-calls) 0)
+          "Mouse look must call camera:pitch in grounded mode")
+  (controls:drop)
+  true)
+
+(fn grounded-space-jumps []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local fake-sampler (make-fake-terrain-sampler 0))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls
+                                           :terrain-sampler fake-sampler
+                                           :eye-height 2.0
+                                           :jump-speed 8.0}))
+  ;; Camera starts on ground (y = 0)
+  (controls:on-key-down {:key 32})  ; space
+  ;; After one update, camera should move upward
+  (controls:update 16)  ; 16ms
+  (local pos-y-after-jump camera.position.y)
+  (assert (> pos-y-after-jump 0)
+          (.. "Camera should move upward on jump, got "
+              (tostring pos-y-after-jump)))
+  ;; After many frames, camera should fall back and land at eye-height
+  (for [_ 1 60]
+    (controls:update 16))
+  (assert (< (math.abs (- camera.position.y 2.0)) 0.5)
+          (.. "Camera should land near eye-height after jump, got "
+              (tostring camera.position.y)))
+  (controls:drop)
+  true)
+
+(fn gravity-lands-at-terrain-plus-eye-height []
+  (local camera (make-fake-camera))
+  (camera:set-position (glm.vec3 0 10 0))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local fake-sampler (make-fake-terrain-sampler 3.0))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls
+                                           :terrain-sampler fake-sampler
+                                           :eye-height 2.0
+                                           :gravity 18.0}))
+  (for [_ 1 80]
+    (controls:update 16))  ; 16ms * 80 = 1.28s — enough to fall and smooth to terrain+eye-height
+  (assert (< (math.abs (- camera.position.y 5.0)) 0.5)
+          (.. "Camera should settle at terrain height + eye height (5.0), got "
+              (tostring camera.position.y)))
+  (controls:drop)
+  true)
+
+(fn terrain-follow-uses-scaling-channel []
+  (local camera (make-fake-camera))
+  (camera:set-position (glm.vec3 0 10 0))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local fake-sampler {:height-at-world-point (fn [_self world-point] 3.0)})
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls
+                                           :terrain-sampler fake-sampler
+                                           :eye-height 2.0
+                                           :gravity 18.0}))
+  (controls:update 16)  ; 16ms
+  (local after-one camera.position.y)
+  (assert (< after-one 10.0)
+          (.. "Camera should move toward terrain, got " (tostring after-one)))
+  (assert (> after-one 5.0)
+          (.. "Camera should not snap to terrain+eye-height in one frame, got "
+              (tostring after-one)))
+  (controls:drop)
+  true)
+
+(fn drop-delegates-to-flight-controls []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (assert (not flight-controls.drop-called)
+          "Flight drop should not have been called yet")
+  (controls:drop)
+  (assert flight-controls.drop-called
+          "Drop must delegate to flight controls")
+  true)
+
+(fn flight-mode-delegates-key-handlers []
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (controls:on-key-down {:key 44 :scancode 44})
+  (assert (> (length flight-controls.key-calls) 0)
+          "Flight mode must delegate on-key-down")
+  (controls:on-key-up {:key 44 :scancode 44})
+  (assert (> (length flight-controls.key-calls) 1)
+          "Flight mode must delegate on-key-up")
+  (controls:drop)
+  true)
+
+(table.insert tests {:name "flight mode delegates update to flight controls"
+                     :fn flight-mode-delegates-update})
+(table.insert tests {:name "grounded mode skips flight update"
+                     :fn grounded-mode-skips-flight-update})
+(table.insert tests {:name "flight mode delegates mouse handlers"
+                     :fn flight-mode-delegates-mouse})
+(table.insert tests {:name "flight mode delegates gamepad handlers"
+                     :fn flight-mode-delegates-gamepad})
+(table.insert tests {:name "grounded mode requires terrain sampler"
+                     :fn grounded-mode-requires-terrain-sampler})
+(table.insert tests {:name "grounded mouse look clamps pitch"
+                     :fn grounded-mouse-look-clamps-pitch})
+(table.insert tests {:name "grounded Space sets positive vertical velocity"
+                     :fn grounded-space-jumps})
+(table.insert tests {:name "gravity lands camera at terrain height plus eye height"
+                     :fn gravity-lands-at-terrain-plus-eye-height})
+(table.insert tests {:name "terrain follow uses scalar channel not snap"
+                     :fn terrain-follow-uses-scaling-channel})
+(table.insert tests {:name "drop delegates to flight controls"
+                     :fn drop-delegates-to-flight-controls})
+(table.insert tests {:name "flight mode delegates key handlers"
+                     :fn flight-mode-delegates-key-handlers})
+
+(local main
+  (fn []
+    (local runner (require :tests/runner))
+    (runner.run-tests {:name "sandbox-camera-controls"
+                       :tests tests})))
+
+{:name "sandbox-camera-controls"
+ :tests tests
+ :main main}

--- a/assets/lua/tests/test-sandbox-camera-controls.fnl
+++ b/assets/lua/tests/test-sandbox-camera-controls.fnl
@@ -409,6 +409,144 @@
   (controls:drop)
   true)
 
+;; R1-1: y-channel syncs from current camera Y when entering grounded mode
+(fn flight-to-grounded-syncs-y-channel-from-current-camera-y []
+  "When camera is at Y=20 in flight mode and toggles to grounded,
+  the first grounded frame must start terrain smoothing from
+  current camera Y (20), not from the Y value captured at construction (0)."
+  (local camera (make-fake-camera))
+  (camera:set-position (glm.vec3 0 20 0))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local fake-sampler (make-fake-terrain-sampler 0))
+  ;; Construct controls in flight mode at camera Y=0 (construction time)
+  (camera:set-position (glm.vec3 0 0 0))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls
+                                           :terrain-sampler fake-sampler}))
+  ;; Move camera to Y=20 while in flight mode
+  (camera:set-position (glm.vec3 0 20 0))
+  ;; Toggle to grounded
+  (toolbar-state:toggle-camera-mode)
+  ;; First grounded update: should start smoothing from current Y (20),
+  ;; not from the Y at construction (0). With terrain=0, eye-height=2,
+  ;; target = 2. Smoothing should move from 20 toward 2 without jumping.
+  (controls:update 16)
+  (local after-one camera.position.y)
+  (assert (< after-one 20.0)
+          (.. "Camera should move toward terrain from 20, got " (tostring after-one)))
+  (assert (> after-one 5.0)
+          (.. "Camera should not jump far in one frame from 20, got " (tostring after-one)))
+  (controls:drop)
+  true)
+
+;; R1-1: on landing, y-channel snaps to target-y (terrain+eye-height),
+;; not to the potentially-below-target integrated new-y.
+(fn grounded-landing-snaps-channel-to-target-y-not-below-terrain []
+  "After an airborne descent where the integrated new-y falls below
+  terrain+eye-height, landing must snap the smoothing channel to
+  target-y (terrain+eye-height), not to the below-ground new-y.
+  After landing, camera must remain at terrain+eye-height without
+  dipping below it."
+  (local camera (make-fake-camera))
+  (camera:set-position (glm.vec3 0 10 0))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local fake-sampler (make-fake-terrain-sampler 3.0))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls
+                                           :terrain-sampler fake-sampler
+                                           :eye-height 2.0
+                                           :gravity 50.0}))
+  ;; Let the camera fall and land. With gravity 50.0, it will overshoot.
+  ;; The target is 3.0 + 2.0 = 5.0 — this should settle after many frames.
+  (for [_ 1 100]
+    (controls:update 16))
+  ;; After settling, camera should be at or near terrain + eye-height = 5.0
+  (assert (>= camera.position.y 4.8)
+          (.. "Camera should not go below terrain+eye-height after landing, got "
+              (tostring camera.position.y)))
+  (assert (<= camera.position.y 5.2)
+          (.. "Camera should land near terrain+eye-height (5.0), got "
+              (tostring camera.position.y)))
+  (controls:drop)
+  true)
+
+;; R1-2: grounded gamepad/wheel handlers error when terrain sampler is missing
+(fn grounded-wheel-errors-without-terrain-sampler []
+  "When toggled to grounded without terrain sampler, on-mouse-wheel must error."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (toolbar-state:toggle-camera-mode)
+  (local (ok err) (pcall controls.on-mouse-wheel controls {:x 0 :y 5}))
+  (assert (not ok)
+          "on-mouse-wheel must error when toggled to grounded without terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  (controls:drop)
+  true)
+
+(fn grounded-gamepad-button-down-errors-without-terrain-sampler []
+  "When toggled to grounded without terrain sampler, on-gamepad-button-down must error."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (toolbar-state:toggle-camera-mode)
+  (local (ok err) (pcall controls.on-gamepad-button-down controls {:button 0 :which 0}))
+  (assert (not ok)
+          "on-gamepad-button-down must error when toggled to grounded without terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  (controls:drop)
+  true)
+
+(fn grounded-gamepad-axis-motion-errors-without-terrain-sampler []
+  "When toggled to grounded without terrain sampler, on-gamepad-axis-motion must error."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (toolbar-state:toggle-camera-mode)
+  (local (ok err) (pcall controls.on-gamepad-axis-motion controls {:axis 0 :value 0.5 :which 0}))
+  (assert (not ok)
+          "on-gamepad-axis-motion must error when toggled to grounded without terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  (controls:drop)
+  true)
+
+(fn grounded-gamepad-removed-errors-without-terrain-sampler []
+  "When toggled to grounded without terrain sampler, on-gamepad-removed must error."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  (toolbar-state:toggle-camera-mode)
+  (local (ok err) (pcall controls.on-gamepad-removed controls {:which 0}))
+  (assert (not ok)
+          "on-gamepad-removed must error when toggled to grounded without terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  (controls:drop)
+  true)
+
 (table.insert tests {:name "flight mode delegates update to flight controls"
                      :fn flight-mode-delegates-update})
 (table.insert tests {:name "grounded mode skips flight update"
@@ -440,7 +578,19 @@
 (table.insert tests {:name "drop delegates to flight controls"
                      :fn drop-delegates-to-flight-controls})
 (table.insert tests {:name "flight mode delegates key handlers"
-                     :fn flight-mode-delegates-key-handlers})
+                      :fn flight-mode-delegates-key-handlers})
+(table.insert tests {:name "flight to grounded syncs y-channel from current camera Y"
+                      :fn flight-to-grounded-syncs-y-channel-from-current-camera-y})
+(table.insert tests {:name "grounded landing snaps channel to target-y not below terrain"
+                      :fn grounded-landing-snaps-channel-to-target-y-not-below-terrain})
+(table.insert tests {:name "grounded wheel errors without terrain sampler"
+                      :fn grounded-wheel-errors-without-terrain-sampler})
+(table.insert tests {:name "grounded gamepad-button-down errors without terrain sampler"
+                      :fn grounded-gamepad-button-down-errors-without-terrain-sampler})
+(table.insert tests {:name "grounded gamepad-axis-motion errors without terrain sampler"
+                      :fn grounded-gamepad-axis-motion-errors-without-terrain-sampler})
+(table.insert tests {:name "grounded gamepad-removed errors without terrain sampler"
+                      :fn grounded-gamepad-removed-errors-without-terrain-sampler})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-sandbox-camera-controls.fnl
+++ b/assets/lua/tests/test-sandbox-camera-controls.fnl
@@ -343,6 +343,72 @@
   (controls:drop)
   true)
 
+(fn flight-to-grounded-on-key-down-without-sampler-errors []
+  "When toggled to grounded without terrain sampler, on-key-down must error
+  before mutating any grounded state."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  ;; Toggle to grounded
+  (toolbar-state:toggle-camera-mode)
+  ;; Store pre-call camera position to verify no mutation
+  (local pre-y (glm.vec3 camera.position.x camera.position.y camera.position.z))
+  (local (ok err) (pcall controls.on-key-down controls {:key 32}))
+  (assert (not ok)
+          "on-key-down must error when toggled to grounded without terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  ;; Camera position must not have been mutated before the error
+  (assert (= (. camera.position 2) (. pre-y 2))
+          (.. "Camera y must not change before dependency guard errors, got "
+              (tostring (. camera.position 2)) " (was " (tostring (. pre-y 2)) ")"))
+  (controls:drop)
+  true)
+
+(fn flight-to-grounded-on-mouse-button-down-without-sampler-errors []
+  "When toggled to grounded without terrain sampler, on-mouse-button-down must
+  error before mutating any grounded state."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  ;; Toggle to grounded
+  (toolbar-state:toggle-camera-mode)
+  (local (ok err) (pcall controls.on-mouse-button-down controls {:button 1 :x 100 :y 200}))
+  (assert (not ok)
+          "on-mouse-button-down must error when toggled to grounded without terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  (controls:drop)
+  true)
+
+(fn flight-to-grounded-on-mouse-motion-without-sampler-errors []
+  "When toggled to grounded without terrain sampler, on-mouse-motion must error
+  before mutating the camera, even when no drag is active."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  ;; Toggle to grounded
+  (toolbar-state:toggle-camera-mode)
+  (local (ok err) (pcall controls.on-mouse-motion controls {:x 110 :y 210}))
+  (assert (not ok)
+          "on-mouse-motion must error when toggled to grounded without terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  (controls:drop)
+  true)
+
 (table.insert tests {:name "flight mode delegates update to flight controls"
                      :fn flight-mode-delegates-update})
 (table.insert tests {:name "grounded mode skips flight update"
@@ -357,6 +423,12 @@
                       :fn grounded-mode-requires-terrain-sampler})
 (table.insert tests {:name "flight to grounded without sampler errors on update"
                       :fn flight-to-grounded-without-sampler-errors})
+(table.insert tests {:name "flight to grounded without sampler errors on key-down"
+                      :fn flight-to-grounded-on-key-down-without-sampler-errors})
+(table.insert tests {:name "flight to grounded without sampler errors on mouse-button-down"
+                      :fn flight-to-grounded-on-mouse-button-down-without-sampler-errors})
+(table.insert tests {:name "flight to grounded without sampler errors on mouse-motion"
+                      :fn flight-to-grounded-on-mouse-motion-without-sampler-errors})
 (table.insert tests {:name "grounded mouse look clamps pitch"
                      :fn grounded-mouse-look-clamps-pitch})
 (table.insert tests {:name "grounded Space sets positive vertical velocity"

--- a/assets/lua/tests/test-sandbox-camera-controls.fnl
+++ b/assets/lua/tests/test-sandbox-camera-controls.fnl
@@ -113,6 +113,23 @@
   (controls:drop)
   true)
 
+(fn grounded-wheel-is-noop []
+  "In grounded mode, on-mouse-wheel must not mutate inner flight controls."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
+  (local flight-controls (make-fake-flight-controls camera))
+  (local fake-sampler (make-fake-terrain-sampler 0))
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls
+                                           :terrain-sampler fake-sampler}))
+  (local pre-count (length flight-controls.wheel-calls))
+  (controls:on-mouse-wheel {:x 0 :y 5})
+  (assert (= (length flight-controls.wheel-calls) pre-count)
+          "Grounded wheel must not mutate flight-controls wheel calls")
+  (controls:drop)
+  true)
+
 (fn flight-mode-delegates-mouse []
   (local camera (make-fake-camera))
   (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
@@ -151,14 +168,36 @@
   (controls:drop)
   true)
 
+(fn flight-to-grounded-without-sampler-errors []
+  "When controls are constructed in :flight without a terrain sampler,
+  then the toolbar toggles to :grounded and update is called, it must error."
+  (local camera (make-fake-camera))
+  (local toolbar-state (SandboxToolbarState {:camera-mode :flight}))
+  (local flight-controls (make-fake-flight-controls camera))
+  ;; Construct without terrain-sampler (valid in flight mode)
+  (local controls (SandboxCameraControls {:camera camera
+                                           :toolbar-state toolbar-state
+                                           :flight-controls flight-controls}))
+  ;; Toggle to grounded
+  (toolbar-state:toggle-camera-mode)
+  ;; Update must error because terrain-sampler is missing
+  (local (ok err) (pcall controls.update controls 16))
+  (assert (not ok)
+          "Update must error when toggled to grounded without terrain sampler")
+  (assert (or (string.find err "terrain sampler")
+              (string.find err "terrain-sampler"))
+          (.. "Error must mention terrain sampler, got: " (tostring err)))
+  (controls:drop)
+  true)
+
 (fn grounded-mode-requires-terrain-sampler []
   (local camera (make-fake-camera))
   (local toolbar-state (SandboxToolbarState {:camera-mode :grounded}))
   (local flight-controls (make-fake-flight-controls camera))
   (local (ok err) (pcall SandboxCameraControls
-                         {:camera camera
-                          :toolbar-state toolbar-state
-                          :flight-controls flight-controls}))
+                          {:camera camera
+                           :toolbar-state toolbar-state
+                           :flight-controls flight-controls}))
   (assert (not ok)
           "SandboxCameraControls must error when grounded mode is selected but no terrain sampler")
   (assert (or (string.find err "terrain sampler")
@@ -176,13 +215,31 @@
                                            :flight-controls flight-controls
                                            :terrain-sampler fake-sampler
                                            :pitch-min -1.2
-                                           :pitch-max 1.2}))
-  (controls:on-mouse-button-down {:button 1 :x 100 :y 200 :state true})
-  (controls:on-mouse-motion {:x 100 :y 100 :xrel 0 :yrel -500})
-  (assert (> (length camera.yaw-calls) 0)
-          "Mouse look must call camera:yaw in grounded mode")
-  (assert (> (length camera.pitch-calls) 0)
-          "Mouse look must call camera:pitch in grounded mode")
+                                           :pitch-max 1.2
+                                           :mouse-look-speed 0.1}))
+  ;; Start drag at origin and apply several large upward motions that
+  ;; would exceed pitch-min if unclamped. The accumulated pitch (sum of
+  ;; camera:pitch deltas) must stay within [pitch-min, pitch-max].
+  (controls:on-mouse-button-down {:button 1 :x 0 :y 0 :state true})
+  ;; Apply three large upward motions (each raw delta = -2.0)
+  (controls:on-mouse-motion {:x 0 :y -20})  ;; dy=-20, raw=-2.0 -> clamped to -1.2
+  (controls:on-mouse-motion {:x 0 :y -40})  ;; dy=-20, raw=-2.0 -> already at -1.2, delta=0
+  (controls:on-mouse-motion {:x 0 :y -60})  ;; dy=-20, raw=-2.0 -> still at -1.2, delta=0
+  ;; Now apply large downward motions
+  (controls:on-mouse-motion {:x 0 :y 0})    ;; dy=60, raw=6.0 -> goes to +1.2, delta=2.4
+  (controls:on-mouse-motion {:x 0 :y 20})   ;; dy=20, raw=2.0 -> already at +1.2, delta=0
+  ;; Sum all applied pitch deltas to compute accumulated pitch
+  (var accumulated 0.0)
+  (each [_ delta (ipairs camera.pitch-calls)]
+    (set accumulated (+ accumulated delta)))
+  ;; Accumulated pitch must be within bounds
+  (assert (>= accumulated -1.2)
+          (.. "Accumulated pitch " (tostring accumulated) " must be >= -1.2"))
+  (assert (<= accumulated 1.2)
+          (.. "Accumulated pitch " (tostring accumulated) " must be <= 1.2"))
+  ;; There must be at least one yaw or pitch call
+  (assert (> (+ (length camera.yaw-calls) (length camera.pitch-calls)) 0)
+          "Mouse look must call camera:yaw or camera:pitch in grounded mode")
   (controls:drop)
   true)
 
@@ -289,13 +346,17 @@
 (table.insert tests {:name "flight mode delegates update to flight controls"
                      :fn flight-mode-delegates-update})
 (table.insert tests {:name "grounded mode skips flight update"
-                     :fn grounded-mode-skips-flight-update})
+                      :fn grounded-mode-skips-flight-update})
+(table.insert tests {:name "grounded wheel is noop"
+                      :fn grounded-wheel-is-noop})
 (table.insert tests {:name "flight mode delegates mouse handlers"
-                     :fn flight-mode-delegates-mouse})
+                      :fn flight-mode-delegates-mouse})
 (table.insert tests {:name "flight mode delegates gamepad handlers"
-                     :fn flight-mode-delegates-gamepad})
-(table.insert tests {:name "grounded mode requires terrain sampler"
-                     :fn grounded-mode-requires-terrain-sampler})
+                      :fn flight-mode-delegates-gamepad})
+(table.insert tests {:name "grounded mode requires terrain sampler at construction"
+                      :fn grounded-mode-requires-terrain-sampler})
+(table.insert tests {:name "flight to grounded without sampler errors on update"
+                      :fn flight-to-grounded-without-sampler-errors})
 (table.insert tests {:name "grounded mouse look clamps pitch"
                      :fn grounded-mouse-look-clamps-pitch})
 (table.insert tests {:name "grounded Space sets positive vertical velocity"

--- a/assets/lua/tests/test-sandbox-toolbar-state.fnl
+++ b/assets/lua/tests/test-sandbox-toolbar-state.fnl
@@ -143,6 +143,34 @@
   (assert (= state.drag-attachment :center)
           "drag-attachment must be :center after second toggle"))
 
+(fn sandbox-toolbar-state-rejects-non-boolean-object-move-enabled []
+  "set-object-move-enabled! must error on non-boolean values."
+  (local state (SandboxToolbarState {}))
+  (local (ok err) (pcall state.set-object-move-enabled! state "false"))
+  (assert (not ok) "set-object-move-enabled! must error on string false")
+  (assert (err:find "boolean")
+          (.. "Error must mention boolean, got: " (tostring err)))
+  (local (ok2 err2) (pcall state.set-object-move-enabled! state 1))
+  (assert (not ok2) "set-object-move-enabled! must error on number")
+  (local (ok3 err3) (pcall state.set-object-move-enabled! state nil))
+  (assert (not ok3) "set-object-move-enabled! must error on nil"))
+
+(fn sandbox-toolbar-state-restore-rejects-non-table-payload []
+  "restore-state must error when payload is non-nil and not a table."
+  (local state (SandboxToolbarState {}))
+  (local (ok err) (pcall state.restore-state state "bad"))
+  (assert (not ok) "restore-state must error on string payload")
+  (assert (err:find "table")
+          (.. "Error must mention table, got: " (tostring err)))
+  (local (ok2 err2) (pcall state.restore-state state 42))
+  (assert (not ok2) "restore-state must error on number payload"))
+
+(fn sandbox-toolbar-state-restore-accepts-nil-payload []
+  "restore-state must accept nil payload without error."
+  (local state (SandboxToolbarState {}))
+  (local (ok _) (pcall state.restore-state state nil))
+  (assert ok "restore-state must accept nil payload without error"))
+
 (table.insert tests {:name "sandbox toolbar state defaults"
                       :fn sandbox-toolbar-state-defaults})
 (table.insert tests {:name "sandbox toolbar state changed signal fires on mutation"
@@ -165,6 +193,12 @@
                       :fn sandbox-toolbar-state-toggle-object-move-enabled})
 (table.insert tests {:name "sandbox toolbar state toggle drag attachment"
                       :fn sandbox-toolbar-state-toggle-drag-attachment})
+(table.insert tests {:name "sandbox toolbar state rejects non-boolean object move enabled"
+                      :fn sandbox-toolbar-state-rejects-non-boolean-object-move-enabled})
+(table.insert tests {:name "sandbox toolbar state restore rejects non-table payload"
+                      :fn sandbox-toolbar-state-restore-rejects-non-table-payload})
+(table.insert tests {:name "sandbox toolbar state restore accepts nil payload"
+                      :fn sandbox-toolbar-state-restore-accepts-nil-payload})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-sandbox-toolbar-state.fnl
+++ b/assets/lua/tests/test-sandbox-toolbar-state.fnl
@@ -171,6 +171,21 @@
   (local (ok _) (pcall state.restore-state state nil))
   (assert ok "restore-state must accept nil payload without error"))
 
+(fn sandbox-toolbar-state-constructor-rejects-non-boolean-object-move-enabled []
+  "Construction with explicit non-boolean object-move-enabled? must error."
+  (local (ok err) (pcall SandboxToolbarState {:object-move-enabled? "false"}))
+  (assert (not ok) "Constructor must error on string 'false' for object-move-enabled?")
+  (assert (err:find "boolean")
+          (.. "Error must mention boolean, got: " (tostring err)))
+  (local (ok2 err2) (pcall SandboxToolbarState {:object-move-enabled? 1}))
+  (assert (not ok2) "Constructor must error on number 1 for object-move-enabled?")
+  (local (ok3 _) (pcall SandboxToolbarState {:object-move-enabled? true}))
+  (assert ok3 "Constructor must accept true for object-move-enabled?")
+  (local (ok4 _) (pcall SandboxToolbarState {:object-move-enabled? false}))
+  (assert ok4 "Constructor must accept false for object-move-enabled?")
+  (local (ok5 _) (pcall SandboxToolbarState {}))
+  (assert ok5 "Constructor must accept nil (default) for object-move-enabled?"))
+
 (table.insert tests {:name "sandbox toolbar state defaults"
                       :fn sandbox-toolbar-state-defaults})
 (table.insert tests {:name "sandbox toolbar state changed signal fires on mutation"
@@ -198,7 +213,9 @@
 (table.insert tests {:name "sandbox toolbar state restore rejects non-table payload"
                       :fn sandbox-toolbar-state-restore-rejects-non-table-payload})
 (table.insert tests {:name "sandbox toolbar state restore accepts nil payload"
-                      :fn sandbox-toolbar-state-restore-accepts-nil-payload})
+                       :fn sandbox-toolbar-state-restore-accepts-nil-payload})
+(table.insert tests {:name "sandbox toolbar state constructor rejects non-boolean object move enabled"
+                       :fn sandbox-toolbar-state-constructor-rejects-non-boolean-object-move-enabled})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-sandbox-toolbar-state.fnl
+++ b/assets/lua/tests/test-sandbox-toolbar-state.fnl
@@ -1,0 +1,177 @@
+(local tests [])
+(local _ (require :main))
+(local SandboxToolbarState (require :sandbox-toolbar-state))
+
+(fn sandbox-toolbar-state-defaults []
+  "Default state must have camera-mode :flight, object-move-enabled? false,
+  and drag-attachment :center."
+  (local state (SandboxToolbarState {}))
+  (assert (= state.camera-mode :flight)
+          "Default camera-mode must be :flight")
+  (assert (= state.object-move-enabled? false)
+          "Default object-move-enabled? must be false")
+  (assert (= state.drag-attachment :center)
+          "Default drag-attachment must be :center"))
+
+(fn sandbox-toolbar-state-changed-signal-fires-on-mutation []
+  "State.changed must be a Signal and must fire once per mutation."
+  (local state (SandboxToolbarState {}))
+  (var emit-count 0)
+  (state.changed:connect (fn [] (set emit-count (+ emit-count 1))))
+  (state:set-camera-mode :grounded)
+  (assert (= emit-count 1)
+          (.. "Changed signal should fire once after set-camera-mode, got " (tostring emit-count)))
+  (state:set-object-move-enabled! true)
+  (assert (= emit-count 2)
+          (.. "Changed signal should fire twice after set-object-move-enabled!, got " (tostring emit-count)))
+  (state:set-drag-attachment :anchor)
+  (assert (= emit-count 3)
+          (.. "Changed signal should fire three times after set-drag-attachment, got " (tostring emit-count))))
+
+(fn sandbox-toolbar-state-changed-signal-noop-on-same-value []
+  "State.changed must not fire when setting the same value."
+  (local state (SandboxToolbarState {}))
+  (var emit-count 0)
+  (state.changed:connect (fn [] (set emit-count (+ emit-count 1))))
+  (state:set-camera-mode :flight)
+  (assert (= emit-count 0)
+          (.. "Changed signal should not fire when setting same camera-mode, got " (tostring emit-count)))
+  (state:set-object-move-enabled! false)
+  (assert (= emit-count 0)
+          (.. "Changed signal should not fire when setting same object-move-enabled?, got " (tostring emit-count)))
+  (state:set-drag-attachment :center)
+  (assert (= emit-count 0)
+          (.. "Changed signal should not fire when setting same drag-attachment, got " (tostring emit-count))))
+
+(fn sandbox-toolbar-state-invalid-camera-mode-errors []
+  "Setting an invalid camera-mode must error."
+  (local state (SandboxToolbarState {}))
+  (local (ok err) (pcall state.set-camera-mode state :bogus))
+  (assert (not ok) "Invalid camera-mode must error")
+  (assert (err:find "Invalid camera mode")
+          (.. "Error must mention invalid camera mode, got: " (tostring err))))
+
+(fn sandbox-toolbar-state-invalid-drag-attachment-errors []
+  "Setting an invalid drag-attachment must error."
+  (local state (SandboxToolbarState {}))
+  (local (ok err) (pcall state.set-drag-attachment state :bogus))
+  (assert (not ok) "Invalid drag-attachment must error")
+  (assert (err:find "Invalid drag attachment")
+          (.. "Error must mention invalid drag attachment, got: " (tostring err))))
+
+(fn sandbox-toolbar-state-capture-returns-canonical-table []
+  "capture-state must return a table with canonical string values."
+  (local state (SandboxToolbarState {}))
+  (local captured (state:capture-state))
+  (assert (= (type captured) :table)
+          "capture-state must return a table")
+  (assert (= captured.camera-mode "flight")
+          (.. "captured camera-mode must be 'flight', got " (tostring captured.camera-mode)))
+  (assert (= captured.object-move-enabled? false)
+          (.. "captured object-move-enabled? must be false, got " (tostring captured.object-move-enabled?)))
+  (assert (= captured.drag-attachment "center")
+          (.. "captured drag-attachment must be 'center', got " (tostring captured.drag-attachment)))
+  ;; After mutations, capture must reflect current state
+  (state:set-camera-mode :grounded)
+  (state:set-object-move-enabled! true)
+  (state:set-drag-attachment :anchor)
+  (local mutated (state:capture-state))
+  (assert (= mutated.camera-mode "grounded")
+          "captured camera-mode must be 'grounded' after mutation")
+  (assert (= mutated.object-move-enabled? true)
+          "captured object-move-enabled? must be true after mutation")
+  (assert (= mutated.drag-attachment "anchor")
+          "captured drag-attachment must be 'anchor' after mutation"))
+
+(fn sandbox-toolbar-state-restore-accepts-valid-payload []
+  "restore-state with a valid payload must set all fields."
+  (local state (SandboxToolbarState {}))
+  (state:restore-state {:camera-mode "grounded"
+                        :object-move-enabled? true
+                        :drag-attachment "anchor"})
+  (assert (= state.camera-mode :grounded)
+          "camera-mode must be :grounded after restore")
+  (assert (= state.object-move-enabled? true)
+          "object-move-enabled? must be true after restore")
+  (assert (= state.drag-attachment :anchor)
+          "drag-attachment must be :anchor after restore"))
+
+(fn sandbox-toolbar-state-restore-accepts-nil []
+  "restore-state with nil must leave defaults unchanged."
+  (local state (SandboxToolbarState {}))
+  (state:set-camera-mode :grounded)
+  (state:restore-state nil)
+  (assert (= state.camera-mode :grounded)
+          "camera-mode must remain :grounded after nil restore")
+  (state:restore-state {})
+  (assert (= state.camera-mode :grounded)
+          "camera-mode must remain :grounded after empty-table restore"))
+
+(fn sandbox-toolbar-state-toggle-camera-mode []
+  "toggle-camera-mode must toggle between :flight and :grounded."
+  (local state (SandboxToolbarState {}))
+  (assert (= state.camera-mode :flight)
+          "camera-mode must start as :flight")
+  (state:toggle-camera-mode)
+  (assert (= state.camera-mode :grounded)
+          "camera-mode must be :grounded after first toggle")
+  (state:toggle-camera-mode)
+  (assert (= state.camera-mode :flight)
+          "camera-mode must be :flight after second toggle"))
+
+(fn sandbox-toolbar-state-toggle-object-move-enabled []
+  "toggle-object-move-enabled! must toggle the boolean."
+  (local state (SandboxToolbarState {}))
+  (assert (= state.object-move-enabled? false)
+          "object-move-enabled? must start as false")
+  (state:toggle-object-move-enabled!)
+  (assert (= state.object-move-enabled? true)
+          "object-move-enabled? must be true after first toggle")
+  (state:toggle-object-move-enabled!)
+  (assert (= state.object-move-enabled? false)
+          "object-move-enabled? must be false after second toggle"))
+
+(fn sandbox-toolbar-state-toggle-drag-attachment []
+  "toggle-drag-attachment must toggle between :center and :anchor."
+  (local state (SandboxToolbarState {}))
+  (assert (= state.drag-attachment :center)
+          "drag-attachment must start as :center")
+  (state:toggle-drag-attachment)
+  (assert (= state.drag-attachment :anchor)
+          "drag-attachment must be :anchor after first toggle")
+  (state:toggle-drag-attachment)
+  (assert (= state.drag-attachment :center)
+          "drag-attachment must be :center after second toggle"))
+
+(table.insert tests {:name "sandbox toolbar state defaults"
+                      :fn sandbox-toolbar-state-defaults})
+(table.insert tests {:name "sandbox toolbar state changed signal fires on mutation"
+                      :fn sandbox-toolbar-state-changed-signal-fires-on-mutation})
+(table.insert tests {:name "sandbox toolbar state changed signal noop on same value"
+                      :fn sandbox-toolbar-state-changed-signal-noop-on-same-value})
+(table.insert tests {:name "sandbox toolbar state invalid camera mode errors"
+                      :fn sandbox-toolbar-state-invalid-camera-mode-errors})
+(table.insert tests {:name "sandbox toolbar state invalid drag attachment errors"
+                      :fn sandbox-toolbar-state-invalid-drag-attachment-errors})
+(table.insert tests {:name "sandbox toolbar state capture returns canonical table"
+                      :fn sandbox-toolbar-state-capture-returns-canonical-table})
+(table.insert tests {:name "sandbox toolbar state restore accepts valid payload"
+                      :fn sandbox-toolbar-state-restore-accepts-valid-payload})
+(table.insert tests {:name "sandbox toolbar state restore accepts nil"
+                      :fn sandbox-toolbar-state-restore-accepts-nil})
+(table.insert tests {:name "sandbox toolbar state toggle camera mode"
+                      :fn sandbox-toolbar-state-toggle-camera-mode})
+(table.insert tests {:name "sandbox toolbar state toggle object move enabled"
+                      :fn sandbox-toolbar-state-toggle-object-move-enabled})
+(table.insert tests {:name "sandbox toolbar state toggle drag attachment"
+                      :fn sandbox-toolbar-state-toggle-drag-attachment})
+
+(local main
+  (fn []
+    (local runner (require :tests/runner))
+    (runner.run-tests {:name "sandbox-toolbar-state"
+                       :tests tests})))
+
+{:name "sandbox-toolbar-state"
+ :tests tests
+ :main main}

--- a/assets/lua/tests/test-sandbox-toolbar-view.fnl
+++ b/assets/lua/tests/test-sandbox-toolbar-view.fnl
@@ -42,14 +42,11 @@
 
 (fn ensure-themes []
   "Ensure app.themes is initialized with a known-good active theme.
-  Other tests in the fast suite may leave app.themes in an unexpected state,
-  so we re-apply the dark theme regardless of initialization status."
-  (when (not (and app.themes app.themes.get-active-theme))
-    (local AppBootstrap (require :app-bootstrap))
-    (AppBootstrap.init-themes))
-  ;; Force dark theme so button variant colors differ between primary/secondary
-  (when app.themes.set-theme
-    (pcall app.themes.set-theme :dark)))
+  Earlier tests in the fast suite may leave app.themes in an unexpected
+  state, so we unconditionally re-initialize the themes system from
+  scratch.  This matches the pattern used by test-button.fnl."
+  (local AppBootstrap (require :app-bootstrap))
+  (AppBootstrap.init-themes))
 
 (fn make-test-ctx []
   "Create a BuildContext with theme, clickables, hoverables, and icons."

--- a/assets/lua/tests/test-sandbox-toolbar-view.fnl
+++ b/assets/lua/tests/test-sandbox-toolbar-view.fnl
@@ -40,6 +40,25 @@
           :font font}))
   stub)
 
+(fn ensure-themes []
+  "Ensure app.themes is initialized with a known-good active theme.
+  Other tests in the fast suite may leave app.themes in an unexpected state,
+  so we re-apply the dark theme regardless of initialization status."
+  (when (not (and app.themes app.themes.get-active-theme))
+    (local AppBootstrap (require :app-bootstrap))
+    (AppBootstrap.init-themes))
+  ;; Force dark theme so button variant colors differ between primary/secondary
+  (when app.themes.set-theme
+    (pcall app.themes.set-theme :dark)))
+
+(fn make-test-ctx []
+  "Create a BuildContext with theme, clickables, hoverables, and icons."
+  (ensure-themes)
+  (BuildContext {:theme (app.themes.get-active-theme)
+                 :clickables (make-clickables-stub)
+                 :hoverables (make-hoverables-stub)
+                 :icons (make-icons-stub)}))
+
 (fn find-entity-by-layout-name [root layout-name]
   "Walk the entity tree looking for a layout with the given name."
   (var found nil)
@@ -60,11 +79,7 @@
   "The toolbar view must create a button named sandbox-toolbar-camera-mode."
   (local state (SandboxToolbarState {}))
   (local builder (SandboxToolbarView state))
-  (local AppBootstrap (require :app-bootstrap))
-  (AppBootstrap.init-themes)
-  (local ctx (BuildContext {:clickables (make-clickables-stub)
-                             :hoverables (make-hoverables-stub)
-                             :icons (make-icons-stub)}))
+  (local ctx (make-test-ctx))
   (local entity (builder ctx))
   (assert entity "Toolbar view must return an entity")
   (assert entity.children "Toolbar view must have children")
@@ -76,11 +91,7 @@
   "The toolbar view must create a button named sandbox-toolbar-object-move."
   (local state (SandboxToolbarState {}))
   (local builder (SandboxToolbarView state))
-  (local AppBootstrap (require :app-bootstrap))
-  (AppBootstrap.init-themes)
-  (local ctx (BuildContext {:clickables (make-clickables-stub)
-                             :hoverables (make-hoverables-stub)
-                             :icons (make-icons-stub)}))
+  (local ctx (make-test-ctx))
   (local entity (builder ctx))
   (local move-btn (find-entity-by-layout-name entity "sandbox-toolbar-object-move"))
   (assert move-btn
@@ -90,11 +101,7 @@
   "The toolbar view must create a button named sandbox-toolbar-drag-attachment."
   (local state (SandboxToolbarState {}))
   (local builder (SandboxToolbarView state))
-  (local AppBootstrap (require :app-bootstrap))
-  (AppBootstrap.init-themes)
-  (local ctx (BuildContext {:clickables (make-clickables-stub)
-                             :hoverables (make-hoverables-stub)
-                             :icons (make-icons-stub)}))
+  (local ctx (make-test-ctx))
   (local entity (builder ctx))
   (local drag-btn (find-entity-by-layout-name entity "sandbox-toolbar-drag-attachment"))
   (assert drag-btn
@@ -104,11 +111,7 @@
   "Clicking the camera mode button must toggle state.camera-mode."
   (local state (SandboxToolbarState {}))
   (local builder (SandboxToolbarView state))
-  (local AppBootstrap (require :app-bootstrap))
-  (AppBootstrap.init-themes)
-  (local ctx (BuildContext {:clickables (make-clickables-stub)
-                             :hoverables (make-hoverables-stub)
-                             :icons (make-icons-stub)}))
+  (local ctx (make-test-ctx))
   (local entity (builder ctx))
   (local camera-btn (find-entity-by-layout-name entity "sandbox-toolbar-camera-mode"))
   (assert camera-btn.on-click "Camera mode button must have on-click handler")
@@ -122,11 +125,7 @@
   "Clicking the object move button must toggle state.object-move-enabled?."
   (local state (SandboxToolbarState {}))
   (local builder (SandboxToolbarView state))
-  (local AppBootstrap (require :app-bootstrap))
-  (AppBootstrap.init-themes)
-  (local ctx (BuildContext {:clickables (make-clickables-stub)
-                             :hoverables (make-hoverables-stub)
-                             :icons (make-icons-stub)}))
+  (local ctx (make-test-ctx))
   (local entity (builder ctx))
   (local move-btn (find-entity-by-layout-name entity "sandbox-toolbar-object-move"))
   (assert move-btn.on-click "Object move button must have on-click handler")
@@ -140,11 +139,7 @@
   "Clicking the drag attachment button must toggle state.drag-attachment."
   (local state (SandboxToolbarState {}))
   (local builder (SandboxToolbarView state))
-  (local AppBootstrap (require :app-bootstrap))
-  (AppBootstrap.init-themes)
-  (local ctx (BuildContext {:clickables (make-clickables-stub)
-                             :hoverables (make-hoverables-stub)
-                             :icons (make-icons-stub)}))
+  (local ctx (make-test-ctx))
   (local entity (builder ctx))
   (local drag-btn (find-entity-by-layout-name entity "sandbox-toolbar-drag-attachment"))
   (assert drag-btn.on-click "Drag attachment button must have on-click handler")
@@ -153,6 +148,91 @@
   (drag-btn:on-click {})
   (assert (= state.drag-attachment :anchor)
           "Drag attachment must be :anchor after click"))
+
+(fn find-text-widget [widget]
+  "Walk from a widget to find a Text widget with set-text method."
+  (when widget
+    (if widget.set-text
+        widget
+        (= widget.__type :text-widget) ;; next-app text widget
+        widget
+        (and widget.children (= (type widget.children) :table))
+        (do
+          (var found nil)
+          (each [_ child (ipairs widget.children)]
+            (when (not found)
+              (local candidate
+                (if (and (= (type child) :table) child.element)
+                    (find-text-widget child.element)
+                    (find-text-widget child)))
+              (when candidate
+                (set found candidate))))
+          found)
+        nil)))
+
+(fn sandbox-toolbar-view-camera-button-text-updates-on-toggle []
+  "Camera mode button text must show Flight or Grounded based on state."
+  (local state (SandboxToolbarState {}))
+  (local builder (SandboxToolbarView state))
+  (local ctx (make-test-ctx))
+  (local entity (builder ctx))
+  (local camera-btn (find-entity-by-layout-name entity "sandbox-toolbar-camera-mode"))
+  (local text-widget (find-text-widget camera-btn.text))
+  (assert text-widget "Camera button must have a text widget")
+  ;; Codepoints for "Flight": [70, 108, 105, 103, 104, 116]
+  (local initial-cp (text-widget:get-codepoints))
+  (assert (= (. initial-cp 1) 70)
+          (.. "Camera button text must start with 'Flight', got first codepoint " (tostring (. initial-cp 1))))
+  ;; Toggle to grounded and update — text must change to "Grounded"
+  (state:toggle-camera-mode)
+  (entity:update)
+  (local updated-cp (text-widget:get-codepoints))
+  (assert (= (. updated-cp 1) 71)
+          (.. "Camera button text must change to 'Grounded' after toggle, got first codepoint " (tostring (. updated-cp 1)))))
+
+(fn sandbox-toolbar-view-variant-changes-background-color []
+  "Variant changes must update background-color and related color fields."
+  (local state (SandboxToolbarState {}))
+  (local builder (SandboxToolbarView state))
+  (local ctx (make-test-ctx))
+  (local entity (builder ctx))
+  (local camera-btn (find-entity-by-layout-name entity "sandbox-toolbar-camera-mode"))
+  (assert camera-btn.variant "Camera button must have a variant")
+  (local initial-background camera-btn.background-color)
+  (assert initial-background "Camera button must have background-color")
+  ;; Toggle camera mode and update
+  (state:toggle-camera-mode)
+  (entity:update)
+  ;; Variant must have changed
+  (assert (not (= camera-btn.variant (if (= state.camera-mode :grounded) :secondary :primary)))
+          "Camera button variant must have changed")
+  ;; Background color must have changed (variant re-resolution)
+  (assert (not (= camera-btn.background-color initial-background))
+          "Camera button background-color must change when variant changes"))
+
+(fn sandbox-toolbar-view-drop-disconnects-from-state-changed []
+  "Calling root:drop() must disconnect from state.changed so stale callbacks
+  do not fire after the UI is dropped."
+  (local state (SandboxToolbarState {}))
+  ;; Wrap state.changed:connect to capture the handler the view registers
+  (var captured-handler nil)
+  (local real-connect state.changed.connect)
+  (set state.changed.connect (fn [self handler]
+                               (set captured-handler handler)
+                               (real-connect self handler)))
+  (local builder (SandboxToolbarView state))
+  (local ctx (make-test-ctx))
+  (local entity (builder ctx))
+  (assert captured-handler "View must connect a handler to state.changed")
+  ;; Restore original connect (not strictly needed but clean)
+  (set state.changed.connect real-connect)
+  ;; Drop the entity (should disconnect the captured handler)
+  (entity:drop)
+  ;; Verify: the handler is no longer connected. disconnect with
+  ;; not-connected-ok?=false should error because the handler was already removed.
+  (local (ok err) (pcall state.changed.disconnect state.changed captured-handler false))
+  (assert (not ok)
+          (.. "After drop, state.changed handler must be disconnected, but disconnect succeeded. Error: " (tostring err))))
 
 (table.insert tests {:name "sandbox toolbar view creates camera mode button"
                       :fn sandbox-toolbar-view-creates-camera-mode-button})
@@ -166,6 +246,12 @@
                       :fn sandbox-toolbar-view-object-move-click-toggles-state})
 (table.insert tests {:name "sandbox toolbar view drag attachment click toggles state"
                       :fn sandbox-toolbar-view-drag-attachment-click-toggles-state})
+(table.insert tests {:name "sandbox toolbar view camera button text updates on toggle"
+                      :fn sandbox-toolbar-view-camera-button-text-updates-on-toggle})
+(table.insert tests {:name "sandbox toolbar view variant changes background color"
+                      :fn sandbox-toolbar-view-variant-changes-background-color})
+(table.insert tests {:name "sandbox toolbar view drop disconnects from state changed"
+                      :fn sandbox-toolbar-view-drop-disconnects-from-state-changed})
 
 (local main
   (fn []

--- a/assets/lua/tests/test-sandbox-toolbar-view.fnl
+++ b/assets/lua/tests/test-sandbox-toolbar-view.fnl
@@ -1,0 +1,178 @@
+(local tests [])
+(local _ (require :main))
+(local BuildContext (require :build-context))
+(local SandboxToolbarState (require :sandbox-toolbar-state))
+(local SandboxToolbarView (require :sandbox-toolbar-view))
+
+(fn make-clickables-stub []
+  (local stub {})
+  (set stub.register (fn [_self _obj] nil))
+  (set stub.unregister (fn [_self _obj] nil))
+  (set stub.register-right-click (fn [_self _obj] nil))
+  (set stub.unregister-right-click (fn [_self _obj] nil))
+  (set stub.register-double-click (fn [_self _obj] nil))
+  (set stub.unregister-double-click (fn [_self _obj] nil))
+  (set stub.register-left-click-void-callback (fn [_self _cb] nil))
+  (set stub.unregister-left-click-void-callback (fn [_self _cb] nil))
+  (set stub.register-right-click-void-callback (fn [_self _cb] nil))
+  (set stub.unregister-right-click-void-callback (fn [_self _cb] nil))
+  stub)
+
+(fn make-hoverables-stub []
+  (local stub {})
+  (set stub.register (fn [_self _obj] nil))
+  (set stub.unregister (fn [_self _obj] nil))
+  stub)
+
+(fn make-icons-stub []
+  (local glyph {:advance 1
+                :planeBounds {:left 0 :right 1 :top 1 :bottom 0}
+                :atlasBounds {:left 0 :right 1 :top 1 :bottom 0}})
+  (local font {:metadata {:metrics {:ascender 1 :descender -1}
+                          :atlas {:width 1 :height 1}}
+               :glyph-map {4242 glyph}
+               :advance 1})
+  (local stub {:font font})
+  (set stub.resolve
+       (fn [_self _name]
+         {:type :font
+          :codepoint 4242
+          :font font}))
+  stub)
+
+(fn find-entity-by-layout-name [root layout-name]
+  "Walk the entity tree looking for a layout with the given name."
+  (var found nil)
+  (fn walk [entity]
+    (when (and entity entity.layout (= entity.layout.name layout-name))
+      (set found entity))
+    ;; Walk entity children (e.g. Flex metadata wrappers)
+    (when (and entity entity.children (not found))
+      (each [_ child (ipairs entity.children)]
+        ;; Flex wraps children in {:flex N :element <entity>}
+        (when (and (= (type child) :table) child.element)
+          (walk child.element))
+        (walk child))))
+  (walk root)
+  found)
+
+(fn sandbox-toolbar-view-creates-camera-mode-button []
+  "The toolbar view must create a button named sandbox-toolbar-camera-mode."
+  (local state (SandboxToolbarState {}))
+  (local builder (SandboxToolbarView state))
+  (local AppBootstrap (require :app-bootstrap))
+  (AppBootstrap.init-themes)
+  (local ctx (BuildContext {:clickables (make-clickables-stub)
+                             :hoverables (make-hoverables-stub)
+                             :icons (make-icons-stub)}))
+  (local entity (builder ctx))
+  (assert entity "Toolbar view must return an entity")
+  (assert entity.children "Toolbar view must have children")
+  (local camera-btn (find-entity-by-layout-name entity "sandbox-toolbar-camera-mode"))
+  (assert camera-btn
+          "Toolbar view must contain a button named sandbox-toolbar-camera-mode"))
+
+(fn sandbox-toolbar-view-creates-object-move-button []
+  "The toolbar view must create a button named sandbox-toolbar-object-move."
+  (local state (SandboxToolbarState {}))
+  (local builder (SandboxToolbarView state))
+  (local AppBootstrap (require :app-bootstrap))
+  (AppBootstrap.init-themes)
+  (local ctx (BuildContext {:clickables (make-clickables-stub)
+                             :hoverables (make-hoverables-stub)
+                             :icons (make-icons-stub)}))
+  (local entity (builder ctx))
+  (local move-btn (find-entity-by-layout-name entity "sandbox-toolbar-object-move"))
+  (assert move-btn
+          "Toolbar view must contain a button named sandbox-toolbar-object-move"))
+
+(fn sandbox-toolbar-view-creates-drag-attachment-button []
+  "The toolbar view must create a button named sandbox-toolbar-drag-attachment."
+  (local state (SandboxToolbarState {}))
+  (local builder (SandboxToolbarView state))
+  (local AppBootstrap (require :app-bootstrap))
+  (AppBootstrap.init-themes)
+  (local ctx (BuildContext {:clickables (make-clickables-stub)
+                             :hoverables (make-hoverables-stub)
+                             :icons (make-icons-stub)}))
+  (local entity (builder ctx))
+  (local drag-btn (find-entity-by-layout-name entity "sandbox-toolbar-drag-attachment"))
+  (assert drag-btn
+          "Toolbar view must contain a button named sandbox-toolbar-drag-attachment"))
+
+(fn sandbox-toolbar-view-camera-mode-click-toggles-state []
+  "Clicking the camera mode button must toggle state.camera-mode."
+  (local state (SandboxToolbarState {}))
+  (local builder (SandboxToolbarView state))
+  (local AppBootstrap (require :app-bootstrap))
+  (AppBootstrap.init-themes)
+  (local ctx (BuildContext {:clickables (make-clickables-stub)
+                             :hoverables (make-hoverables-stub)
+                             :icons (make-icons-stub)}))
+  (local entity (builder ctx))
+  (local camera-btn (find-entity-by-layout-name entity "sandbox-toolbar-camera-mode"))
+  (assert camera-btn.on-click "Camera mode button must have on-click handler")
+  (assert (= state.camera-mode :flight)
+          "Camera mode must start as :flight")
+  (camera-btn:on-click {})
+  (assert (= state.camera-mode :grounded)
+          "Camera mode must be :grounded after click"))
+
+(fn sandbox-toolbar-view-object-move-click-toggles-state []
+  "Clicking the object move button must toggle state.object-move-enabled?."
+  (local state (SandboxToolbarState {}))
+  (local builder (SandboxToolbarView state))
+  (local AppBootstrap (require :app-bootstrap))
+  (AppBootstrap.init-themes)
+  (local ctx (BuildContext {:clickables (make-clickables-stub)
+                             :hoverables (make-hoverables-stub)
+                             :icons (make-icons-stub)}))
+  (local entity (builder ctx))
+  (local move-btn (find-entity-by-layout-name entity "sandbox-toolbar-object-move"))
+  (assert move-btn.on-click "Object move button must have on-click handler")
+  (assert (= state.object-move-enabled? false)
+          "Object move must start as false")
+  (move-btn:on-click {})
+  (assert (= state.object-move-enabled? true)
+          "Object move must be true after click"))
+
+(fn sandbox-toolbar-view-drag-attachment-click-toggles-state []
+  "Clicking the drag attachment button must toggle state.drag-attachment."
+  (local state (SandboxToolbarState {}))
+  (local builder (SandboxToolbarView state))
+  (local AppBootstrap (require :app-bootstrap))
+  (AppBootstrap.init-themes)
+  (local ctx (BuildContext {:clickables (make-clickables-stub)
+                             :hoverables (make-hoverables-stub)
+                             :icons (make-icons-stub)}))
+  (local entity (builder ctx))
+  (local drag-btn (find-entity-by-layout-name entity "sandbox-toolbar-drag-attachment"))
+  (assert drag-btn.on-click "Drag attachment button must have on-click handler")
+  (assert (= state.drag-attachment :center)
+          "Drag attachment must start as :center")
+  (drag-btn:on-click {})
+  (assert (= state.drag-attachment :anchor)
+          "Drag attachment must be :anchor after click"))
+
+(table.insert tests {:name "sandbox toolbar view creates camera mode button"
+                      :fn sandbox-toolbar-view-creates-camera-mode-button})
+(table.insert tests {:name "sandbox toolbar view creates object move button"
+                      :fn sandbox-toolbar-view-creates-object-move-button})
+(table.insert tests {:name "sandbox toolbar view creates drag attachment button"
+                      :fn sandbox-toolbar-view-creates-drag-attachment-button})
+(table.insert tests {:name "sandbox toolbar view camera mode click toggles state"
+                      :fn sandbox-toolbar-view-camera-mode-click-toggles-state})
+(table.insert tests {:name "sandbox toolbar view object move click toggles state"
+                      :fn sandbox-toolbar-view-object-move-click-toggles-state})
+(table.insert tests {:name "sandbox toolbar view drag attachment click toggles state"
+                      :fn sandbox-toolbar-view-drag-attachment-click-toggles-state})
+
+(local main
+  (fn []
+    (local runner (require :tests/runner))
+    (runner.run-tests {:name "sandbox-toolbar-view"
+                       :tests tests})))
+
+{:name "sandbox-toolbar-view"
+ :tests tests
+ :main main}

--- a/assets/lua/tests/test-scene-drag.fnl
+++ b/assets/lua/tests/test-scene-drag.fnl
@@ -681,12 +681,575 @@
   (when (not ok)
     (error err)))
 
+(fn no-alt-drag-blocked-without-predicate []
+  (local original-scene app.scene)
+  (local original-layout-root app.layout-root)
+  (local original-movables app.movables)
+  (local original-intersectables app.intersectables)
+  (local original-camera app.camera)
+  (local original-controls app.first-person-controls)
+  (local original-runtime app.active-world-runtime)
+  (local original-hoverables app.hoverables)
+  (local original-clickables app.clickables)
+  (local original-events app.engine.events)
+  (local original-states app.states)
+  (local original-viewport app.viewport)
+  (local original-create-default-projection app.create-default-projection)
+  (local original-active-surface app.active-interaction-surface)
+  (local original-scene-interactive? app.scene-interactive?)
+  (local original-canvas-interactive? app.canvas-interactive?)
+  (local original-predicate app.activity-object-move-predicate)
+  (var scene nil)
+  (var movables nil)
+  (var intersector nil)
+  (var clickables nil)
+  (var hoverables nil)
+  (var camera nil)
+  (var controls nil)
+  (var state nil)
+  (var target-layout nil)
+
+  (fn cleanup []
+    (when state
+      (state.on-leave)
+      (set state nil))
+    (when scene
+      (scene:drop)
+      (set scene nil))
+    (when movables
+      (movables:drop)
+      (set movables nil))
+    (when intersector
+      (intersector:drop)
+      (set intersector nil))
+    (when clickables
+      (clickables:drop)
+      (set clickables nil))
+    (when hoverables
+      (hoverables:drop)
+      (set hoverables nil))
+    (when controls
+      (controls:drop)
+      (set controls nil))
+    (when camera
+      (camera:drop)
+      (set camera nil))
+    (set app.scene original-scene)
+    (set app.layout-root original-layout-root)
+    (set app.movables original-movables)
+    (set app.intersectables original-intersectables)
+    (set app.camera original-camera)
+    (set app.first-person-controls original-controls)
+    (set app.active-world-runtime original-runtime)
+    (set app.hoverables original-hoverables)
+    (set app.clickables original-clickables)
+    (set app.engine.events original-events)
+    (restore-states! original-states)
+    (set app.create-default-projection original-create-default-projection)
+    (set app.active-interaction-surface original-active-surface)
+    (set app.scene-interactive? original-scene-interactive?)
+    (set app.canvas-interactive? original-canvas-interactive?)
+    (set app.activity-object-move-predicate original-predicate))
+
+  (let [(ok err)
+        (pcall
+          (fn []
+            (reset-engine-events)
+            (set intersector (Intersectables))
+            (set clickables (Clickables {:intersectables intersector}))
+            (set hoverables (Hoverables {:intersectables intersector}))
+            (set movables (Movables {:intersectables intersector}))
+            (set camera (Camera {:position (glm.vec3 0 0 10)}))
+            (set controls (FirstPersonControls {:camera camera}))
+            (set app.active-world-runtime
+                 {:presentation {:input-controls (fn [_self] controls)
+                                 :camera (fn [_self _opts] camera)}})
+            (set app.camera nil)
+            (set app.first-person-controls nil)
+            (set app.create-default-projection AppProjection.create-default-projection)
+            (set scene (Scene {:position (glm.vec3 0 0 0)
+                               :rotation (glm.quat 1 0 0 0)
+                               :camera camera}))
+            (set app.intersectables intersector)
+            (set app.clickables clickables)
+            (set app.hoverables hoverables)
+            (set app.movables movables)
+            (set app.scene scene)
+            (set app.layout-root scene.layout-root)
+            (set app.active-interaction-surface :scene)
+            (set app.scene-interactive? true)
+            (set app.canvas-interactive? false)
+            (scene:ensure-activity-slot "sandbox")
+            (local sandbox-slot (scene:activate-activity-slot "sandbox"))
+            (assert sandbox-slot "No-Alt drag test requires a valid sandbox slot")
+            (scene:build
+              (fn [_ctx]
+                (set target-layout
+                     (Layout {:name "no-alt-drag-target"
+                              :measurer (fn [self]
+                                          (set self.measure (glm.vec3 1 1 1)))
+                              :layouter (fn [self]
+                                          (set self.size self.measure))}))
+                {:layout target-layout
+                 :drop (fn [_] (target-layout:drop))}))
+            (scene:update)
+            (set scene.screen-pos-ray
+                 (fn [_self pointer _opts]
+                   {:origin (glm.vec3 pointer.x pointer.y 10)
+                    :direction (glm.vec3 0 0 -1)}))
+
+            ;; Ensure no predicate is installed
+            (set app.activity-object-move-predicate nil)
+
+            (set state (NormalState))
+            (bind-normal-state! state)
+            (state.on-enter)
+
+            ;; Fire mouse-down without Alt modifier (mod 0)
+            (app.engine.events.mouse-button-down.emit {:button 1 :x 0.25 :y 0.25 :mod 0})
+            (app.engine.events.mouse-motion.emit {:x 5.25 :y 5.75 :mod 0})
+
+            (assert (not (app.movables:drag-active?))
+                    "No-Alt drag should NOT start when predicate is nil")))]
+    (cleanup)
+    (when (not ok)
+      (error err))))
+
+(fn no-alt-drag-blocked-when-predicate-returns-false []
+  (local original-scene app.scene)
+  (local original-layout-root app.layout-root)
+  (local original-movables app.movables)
+  (local original-intersectables app.intersectables)
+  (local original-camera app.camera)
+  (local original-controls app.first-person-controls)
+  (local original-runtime app.active-world-runtime)
+  (local original-hoverables app.hoverables)
+  (local original-clickables app.clickables)
+  (local original-events app.engine.events)
+  (local original-states app.states)
+  (local original-viewport app.viewport)
+  (local original-create-default-projection app.create-default-projection)
+  (local original-active-surface app.active-interaction-surface)
+  (local original-scene-interactive? app.scene-interactive?)
+  (local original-canvas-interactive? app.canvas-interactive?)
+  (local original-predicate app.activity-object-move-predicate)
+  (var scene nil)
+  (var movables nil)
+  (var intersector nil)
+  (var clickables nil)
+  (var hoverables nil)
+  (var camera nil)
+  (var controls nil)
+  (var state nil)
+  (var target-layout nil)
+
+  (fn cleanup []
+    (when state
+      (state.on-leave)
+      (set state nil))
+    (when scene
+      (scene:drop)
+      (set scene nil))
+    (when movables
+      (movables:drop)
+      (set movables nil))
+    (when intersector
+      (intersector:drop)
+      (set intersector nil))
+    (when clickables
+      (clickables:drop)
+      (set clickables nil))
+    (when hoverables
+      (hoverables:drop)
+      (set hoverables nil))
+    (when controls
+      (controls:drop)
+      (set controls nil))
+    (when camera
+      (camera:drop)
+      (set camera nil))
+    (set app.scene original-scene)
+    (set app.layout-root original-layout-root)
+    (set app.movables original-movables)
+    (set app.intersectables original-intersectables)
+    (set app.camera original-camera)
+    (set app.first-person-controls original-controls)
+    (set app.active-world-runtime original-runtime)
+    (set app.hoverables original-hoverables)
+    (set app.clickables original-clickables)
+    (set app.engine.events original-events)
+    (restore-states! original-states)
+    (set app.create-default-projection original-create-default-projection)
+    (set app.active-interaction-surface original-active-surface)
+    (set app.scene-interactive? original-scene-interactive?)
+    (set app.canvas-interactive? original-canvas-interactive?)
+    (set app.activity-object-move-predicate original-predicate))
+
+  (let [(ok err)
+        (pcall
+          (fn []
+            (reset-engine-events)
+            (set intersector (Intersectables))
+            (set clickables (Clickables {:intersectables intersector}))
+            (set hoverables (Hoverables {:intersectables intersector}))
+            (set movables (Movables {:intersectables intersector}))
+            (set camera (Camera {:position (glm.vec3 0 0 10)}))
+            (set controls (FirstPersonControls {:camera camera}))
+            (set app.active-world-runtime
+                 {:presentation {:input-controls (fn [_self] controls)
+                                 :camera (fn [_self _opts] camera)}})
+            (set app.camera nil)
+            (set app.first-person-controls nil)
+            (set app.create-default-projection AppProjection.create-default-projection)
+            (set scene (Scene {:position (glm.vec3 0 0 0)
+                               :rotation (glm.quat 1 0 0 0)
+                               :camera camera}))
+            (set app.intersectables intersector)
+            (set app.clickables clickables)
+            (set app.hoverables hoverables)
+            (set app.movables movables)
+            (set app.scene scene)
+            (set app.layout-root scene.layout-root)
+            (set app.active-interaction-surface :scene)
+            (set app.scene-interactive? true)
+            (set app.canvas-interactive? false)
+            (scene:ensure-activity-slot "sandbox")
+            (local sandbox-slot (scene:activate-activity-slot "sandbox"))
+            (assert sandbox-slot "Predicate-false drag test requires a valid sandbox slot")
+            (scene:build
+              (fn [_ctx]
+                (set target-layout
+                     (Layout {:name "predicate-false-drag-target"
+                              :measurer (fn [self]
+                                          (set self.measure (glm.vec3 1 1 1)))
+                              :layouter (fn [self]
+                                          (set self.size self.measure))}))
+                {:layout target-layout
+                 :drop (fn [_] (target-layout:drop))}))
+            (scene:update)
+            (set scene.screen-pos-ray
+                 (fn [_self pointer _opts]
+                   {:origin (glm.vec3 pointer.x pointer.y 10)
+                    :direction (glm.vec3 0 0 -1)}))
+
+            ;; Install predicate returning false
+            (set app.activity-object-move-predicate (fn [] false))
+
+            (set state (NormalState))
+            (bind-normal-state! state)
+            (state.on-enter)
+
+            ;; Fire mouse-down without Alt modifier
+            (app.engine.events.mouse-button-down.emit {:button 1 :x 0.25 :y 0.25 :mod 0})
+            (app.engine.events.mouse-motion.emit {:x 5.25 :y 5.75 :mod 0})
+
+            (assert (not (app.movables:drag-active?))
+                    "No-Alt drag should NOT start when predicate returns false")))]
+    (cleanup)
+    (when (not ok)
+      (error err))))
+
+(fn no-alt-drag-enabled-when-predicate-returns-true []
+  (local original-scene app.scene)
+  (local original-layout-root app.layout-root)
+  (local original-movables app.movables)
+  (local original-intersectables app.intersectables)
+  (local original-camera app.camera)
+  (local original-controls app.first-person-controls)
+  (local original-runtime app.active-world-runtime)
+  (local original-hoverables app.hoverables)
+  (local original-clickables app.clickables)
+  (local original-events app.engine.events)
+  (local original-states app.states)
+  (local original-viewport app.viewport)
+  (local original-create-default-projection app.create-default-projection)
+  (local original-active-surface app.active-interaction-surface)
+  (local original-scene-interactive? app.scene-interactive?)
+  (local original-canvas-interactive? app.canvas-interactive?)
+  (local original-predicate app.activity-object-move-predicate)
+  (var scene nil)
+  (var movables nil)
+  (var intersector nil)
+  (var clickables nil)
+  (var hoverables nil)
+  (var camera nil)
+  (var controls nil)
+  (var state nil)
+  (var target-layout nil)
+
+  (fn cleanup []
+    (when state
+      (state.on-leave)
+      (set state nil))
+    (when scene
+      (scene:drop)
+      (set scene nil))
+    (when movables
+      (movables:drop)
+      (set movables nil))
+    (when intersector
+      (intersector:drop)
+      (set intersector nil))
+    (when clickables
+      (clickables:drop)
+      (set clickables nil))
+    (when hoverables
+      (hoverables:drop)
+      (set hoverables nil))
+    (when controls
+      (controls:drop)
+      (set controls nil))
+    (when camera
+      (camera:drop)
+      (set camera nil))
+    (set app.scene original-scene)
+    (set app.layout-root original-layout-root)
+    (set app.movables original-movables)
+    (set app.intersectables original-intersectables)
+    (set app.camera original-camera)
+    (set app.first-person-controls original-controls)
+    (set app.active-world-runtime original-runtime)
+    (set app.hoverables original-hoverables)
+    (set app.clickables original-clickables)
+    (set app.engine.events original-events)
+    (restore-states! original-states)
+    (set app.create-default-projection original-create-default-projection)
+    (set app.active-interaction-surface original-active-surface)
+    (set app.scene-interactive? original-scene-interactive?)
+    (set app.canvas-interactive? original-canvas-interactive?)
+    (set app.activity-object-move-predicate original-predicate))
+
+  (let [(ok err)
+        (pcall
+          (fn []
+            (reset-engine-events)
+            (set intersector (Intersectables))
+            (set clickables (Clickables {:intersectables intersector}))
+            (set hoverables (Hoverables {:intersectables intersector}))
+            (set movables (Movables {:intersectables intersector}))
+            (set camera (Camera {:position (glm.vec3 0 0 10)}))
+            (set controls (FirstPersonControls {:camera camera}))
+            (set app.active-world-runtime
+                 {:presentation {:input-controls (fn [_self] controls)
+                                 :camera (fn [_self _opts] camera)}})
+            (set app.camera nil)
+            (set app.first-person-controls nil)
+            (set app.create-default-projection AppProjection.create-default-projection)
+            (set scene (Scene {:position (glm.vec3 0 0 0)
+                               :rotation (glm.quat 1 0 0 0)
+                               :camera camera}))
+            (set app.intersectables intersector)
+            (set app.clickables clickables)
+            (set app.hoverables hoverables)
+            (set app.movables movables)
+            (set app.scene scene)
+            (set app.layout-root scene.layout-root)
+            (set app.active-interaction-surface :scene)
+            (set app.scene-interactive? true)
+            (set app.canvas-interactive? false)
+            (scene:ensure-activity-slot "sandbox")
+            (local sandbox-slot (scene:activate-activity-slot "sandbox"))
+            (assert sandbox-slot "Predicate-true drag test requires a valid sandbox slot")
+            (scene:build
+              (fn [_ctx]
+                (set target-layout
+                     (Layout {:name "predicate-true-drag-target"
+                              :measurer (fn [self]
+                                          (set self.measure (glm.vec3 1 1 1)))
+                              :layouter (fn [self]
+                                          (set self.size self.measure))}))
+                {:layout target-layout
+                 :drop (fn [_] (target-layout:drop))}))
+            (scene:update)
+            (set scene.screen-pos-ray
+                 (fn [_self pointer _opts]
+                   {:origin (glm.vec3 pointer.x pointer.y 10)
+                    :direction (glm.vec3 0 0 -1)}))
+
+            ;; Install predicate returning true
+            (set app.activity-object-move-predicate (fn [] true))
+
+            (set state (NormalState))
+            (bind-normal-state! state)
+            (state.on-enter)
+
+            ;; Fire mouse-down without Alt modifier
+            (app.engine.events.mouse-button-down.emit {:button 1 :x 0.25 :y 0.25 :mod 0})
+            (app.engine.events.mouse-motion.emit {:x 5.25 :y 5.75 :mod 0})
+
+            (assert (app.movables:drag-active?)
+                    "No-Alt drag should start when predicate returns true")
+            (assert target-layout "Scene should create a target layout")
+            (assert (approx target-layout.position.x 5.0)
+                    "No-Alt drag should update layout X position when predicate allows")
+            (assert (approx target-layout.position.y 5.5)
+                    "No-Alt drag should update layout Y position when predicate allows")
+
+            (app.engine.events.mouse-button-up.emit {:button 1})
+            (assert (not (app.movables:drag-active?))
+                    "Drag should end on mouse-up")))]
+    (cleanup)
+    (when (not ok)
+      (error err))))
+
+(fn click-without-drag-threshold-remains-click []
+  (local original-scene app.scene)
+  (local original-layout-root app.layout-root)
+  (local original-movables app.movables)
+  (local original-intersectables app.intersectables)
+  (local original-camera app.camera)
+  (local original-controls app.first-person-controls)
+  (local original-runtime app.active-world-runtime)
+  (local original-hoverables app.hoverables)
+  (local original-clickables app.clickables)
+  (local original-events app.engine.events)
+  (local original-states app.states)
+  (local original-viewport app.viewport)
+  (local original-create-default-projection app.create-default-projection)
+  (local original-active-surface app.active-interaction-surface)
+  (local original-scene-interactive? app.scene-interactive?)
+  (local original-canvas-interactive? app.canvas-interactive?)
+  (local original-predicate app.activity-object-move-predicate)
+  (var scene nil)
+  (var movables nil)
+  (var intersector nil)
+  (var clickables nil)
+  (var hoverables nil)
+  (var camera nil)
+  (var controls nil)
+  (var state nil)
+  (var target-layout nil)
+
+  (fn cleanup []
+    (when state
+      (state.on-leave)
+      (set state nil))
+    (when scene
+      (scene:drop)
+      (set scene nil))
+    (when movables
+      (movables:drop)
+      (set movables nil))
+    (when intersector
+      (intersector:drop)
+      (set intersector nil))
+    (when clickables
+      (clickables:drop)
+      (set clickables nil))
+    (when hoverables
+      (hoverables:drop)
+      (set hoverables nil))
+    (when controls
+      (controls:drop)
+      (set controls nil))
+    (when camera
+      (camera:drop)
+      (set camera nil))
+    (set app.scene original-scene)
+    (set app.layout-root original-layout-root)
+    (set app.movables original-movables)
+    (set app.intersectables original-intersectables)
+    (set app.camera original-camera)
+    (set app.first-person-controls original-controls)
+    (set app.active-world-runtime original-runtime)
+    (set app.hoverables original-hoverables)
+    (set app.clickables original-clickables)
+    (set app.engine.events original-events)
+    (restore-states! original-states)
+    (set app.create-default-projection original-create-default-projection)
+    (set app.active-interaction-surface original-active-surface)
+    (set app.scene-interactive? original-scene-interactive?)
+    (set app.canvas-interactive? original-canvas-interactive?)
+    (set app.activity-object-move-predicate original-predicate))
+
+  (let [(ok err)
+        (pcall
+          (fn []
+            (reset-engine-events)
+            (set intersector (Intersectables))
+            (set clickables (Clickables {:intersectables intersector}))
+            (set hoverables (Hoverables {:intersectables intersector}))
+            (set movables (Movables {:intersectables intersector}))
+            (set camera (Camera {:position (glm.vec3 0 0 10)}))
+            (set controls (FirstPersonControls {:camera camera}))
+            (set app.active-world-runtime
+                 {:presentation {:input-controls (fn [_self] controls)
+                                 :camera (fn [_self _opts] camera)}})
+            (set app.camera nil)
+            (set app.first-person-controls nil)
+            (set app.create-default-projection AppProjection.create-default-projection)
+            (set scene (Scene {:position (glm.vec3 0 0 0)
+                               :rotation (glm.quat 1 0 0 0)
+                               :camera camera}))
+            (set app.intersectables intersector)
+            (set app.clickables clickables)
+            (set app.hoverables hoverables)
+            (set app.movables movables)
+            (set app.scene scene)
+            (set app.layout-root scene.layout-root)
+            (set app.active-interaction-surface :scene)
+            (set app.scene-interactive? true)
+            (set app.canvas-interactive? false)
+            (scene:ensure-activity-slot "sandbox")
+            (local sandbox-slot (scene:activate-activity-slot "sandbox"))
+            (assert sandbox-slot "Click-without-drag test requires a valid sandbox slot")
+            (scene:build
+              (fn [_ctx]
+                (set target-layout
+                     (Layout {:name "click-without-drag-target"
+                              :measurer (fn [self]
+                                          (set self.measure (glm.vec3 1 1 1)))
+                              :layouter (fn [self]
+                                          (set self.size self.measure))}))
+                {:layout target-layout
+                 :drop (fn [_] (target-layout:drop))}))
+            (scene:update)
+            (set scene.screen-pos-ray
+                 (fn [_self pointer _opts]
+                   {:origin (glm.vec3 pointer.x pointer.y 10)
+                    :direction (glm.vec3 0 0 -1)}))
+
+            ;; Install predicate returning true (so no-Alt drag is allowed)
+            (set app.activity-object-move-predicate (fn [] true))
+
+            (set state (NormalState))
+            (bind-normal-state! state)
+            (state.on-enter)
+
+            ;; Record initial position
+            (local initial-x target-layout.position.x)
+            (local initial-y target-layout.position.y)
+
+            ;; Fire mouse-down without Alt, but mouse-motion is tiny (within threshold)
+            (app.engine.events.mouse-button-down.emit {:button 1 :x 0.25 :y 0.25 :mod 0})
+            (app.engine.events.mouse-motion.emit {:x 0.26 :y 0.26 :mod 0})
+
+            (assert (not (app.movables:drag-active?))
+                    "Tiny motion below threshold should not start drag")
+            (assert (approx target-layout.position.x initial-x)
+                    "Click without drag should not move layout X")
+            (assert (approx target-layout.position.y initial-y)
+                    "Click without drag should not move layout Y")
+
+            (app.engine.events.mouse-button-up.emit {:button 1})))]
+    (cleanup)
+    (when (not ok)
+      (error err))))
+
 (table.insert tests {:name "Normal state drags real scene entity" :fn drag-through-normal-state-moves-scene-entity})
 (table.insert tests {:name "Normal state drags scene ball" :fn drag-through-normal-state-moves-scene-ball})
 (table.insert tests {:name "Normal state drags runtime physics body"
                      :fn drag-through-normal-state-moves-scene-physics-body})
 (table.insert tests {:name "Normal state keeps scene alt-drag when canvas is hidden"
                      :fn drag-through-normal-state-moves-scene-entity-when-canvas-hidden})
+(table.insert tests {:name "No-Alt drag blocked without predicate"
+                     :fn no-alt-drag-blocked-without-predicate})
+(table.insert tests {:name "No-Alt drag blocked when predicate returns false"
+                     :fn no-alt-drag-blocked-when-predicate-returns-false})
+(table.insert tests {:name "No-Alt drag enabled when predicate returns true"
+                     :fn no-alt-drag-enabled-when-predicate-returns-true})
+(table.insert tests {:name "Click without drag threshold remains click"
+                     :fn click-without-drag-threshold-remains-click})
 
 (local main
   (fn []

--- a/docs/dev/notes/index.md
+++ b/docs/dev/notes/index.md
@@ -67,6 +67,7 @@ Architecture notes, design sketches, debugging logs, and explorations. These are
 - [Render Capture](./render-capture)
 - [Resize Bugs](./resize-bugs)
 - [Ripgrep](./ripgrep)
+- [Sandbox Interaction Toolbar](./sandbox-interaction-toolbar)
 - [Scene Terrain Recovery](./scene-terrain-recovery)
 - [Sdl3 Input Migration](./sdl3-input-migration)
 - [Selection](./selection)

--- a/docs/dev/notes/sandbox-interaction-toolbar.md
+++ b/docs/dev/notes/sandbox-interaction-toolbar.md
@@ -1,0 +1,183 @@
+---
+type: dev-note
+tags:
+  - note
+---
+
+# Sandbox Interaction Toolbar
+
+This note describes the Sandbox-owned center-column activity toolbar added in `docs/dev/notes/sandbox-interaction-toolbar.md`. It covers the layout, activity hooks, Sandbox toolbar state, object move mode, anchor drag, and grounded camera controls.
+
+## Layout
+
+The Sandbox toolbar is contributed by the active activity and laid out in the HUD center column between full-height left and right rails.
+
+- **`hud-layout.fnl`** reserves a top-toolbar slot in the center column only, placed above the scene stack. It does not appear in the left or right rails.
+- **`activity-top-toolbar-view.fnl`** is a Layout wrapper that tracks `app.activity-top-toolbar-builder`. When the builder changes (e.g., activation or deactivation), it drops the previous toolbar and builds the new one. Its measured height is stored in `app.activity-top-toolbar-height`.
+- **Expanded sidebar panels** query `app.activity-top-toolbar-height` so their content area reserves that height. The rails retain full height.
+- **Left and right rails** remain full-height general HUD controls outside Sandbox ownership. Non-Sandbox activities have no toolbar by default; the toolbar slot is empty until an activity contributes a builder.
+
+## Activity Hooks
+
+The activity activation context (`ctx`) in `activities.fnl` exposes three new hooks:
+
+### `ctx:set-top-toolbar-builder!(builder)`
+Sets the current activity's top-toolbar builder. The builder must be a function `(fn [ctx] -> widget)` that produces a Layout-compatible widget tree. Sandbox sets this to `(SandboxToolbarView toolbar-state)`. The toolbar is rebuilt when the builder reference changes or on each frame.
+
+### `ctx:set-object-move-predicate!(predicate)`
+Sets a zero-argument function that returns `true` when no-`Alt` object dragging is enabled for this activity. `state-runtime.fnl` calls `app.activity-object-move-predicate` to gate `MovableMouseButtonDown`. Sandbox sets this to `(fn [] (= toolbar-state.object-move-enabled? true))`. When no activity sets a predicate (or it returns `false`/`nil`), only `Alt`+drag works — this is the safe default for all other activities.
+
+### `ctx:set-drag-attachment-provider!(provider)`
+Sets a zero-argument function that returns either `:center` (default) or `:anchor`. This controls the drag attachment mode for physics-backed movables. Sandbox sets this to `(fn [] toolbar-state.drag-attachment)`. When no provider is set, drag uses center attachment.
+
+All three hooks are cleared by `clear-activity-runtime-hooks!` during activity deactivation (`app.activity-top-toolbar-builder`, `app.activity-object-move-predicate`, `app.activity-drag-attachment-provider` all set to `nil`).
+
+## Sandbox Toolbar State
+
+**File:** `assets/lua/sandbox-toolbar-state.fnl`
+
+`(SandboxToolbarState opts)` creates a toolbar state table with three properties and a `Signal` for change notifications.
+
+### Properties
+| Property | Type | Default | Valid Values |
+|---|---|---|---|
+| `camera-mode` | keyword | `:flight` | `:flight`, `:grounded` |
+| `object-move-enabled?` | boolean | `false` | `true`, `false` |
+| `drag-attachment` | keyword | `:center` | `:center`, `:anchor` |
+
+State fields are accessed via metatable `__index` (e.g., `state.camera-mode`) though the tests primarily use the accessor and setter methods.
+
+### Key Methods
+
+- **`state:set-camera-mode(mode)`** / **`state:toggle-camera-mode()`** — set or toggle between `:flight` and `:grounded`. Emits `changed` signal.
+- **`state:set-object-move-enabled!(enabled?)`** / **`state:toggle-object-move-enabled!()`** — set or toggle object move mode. Emits `changed` signal. Validates that `enabled?` is boolean; errors on non-boolean input.
+- **`state:set-drag-attachment(mode)`** / **`state:toggle-drag-attachment()`** — set or toggle between `:center` and `:anchor`. Emits `changed` signal.
+- **`state:capture-state()`** — returns a serializable table `{:camera-mode "flight"/"grounded" :object-move-enabled? bool :drag-attachment "center"/"anchor"}`.
+- **`state:restore-state(payload)`** — restores from a capture-state payload. Validates all fields. Accepts `nil` (no-op).
+- **`state.changed`** — a `Signal` emitted whenever any state field changes. Connected by `SandboxToolbarView` to trigger toolbar button updates.
+
+### Errors
+- Invalid `camera-mode` or `drag-attachment` keyword raises a descriptive error.
+- Non-boolean `object-move-enabled?` raises a descriptive error.
+- Invalid values in `restore-state` payload raise descriptive errors.
+
+## Sandbox Toolbar View
+
+**File:** `assets/lua/sandbox-toolbar-view.fnl`
+
+`(SandboxToolbarView state)` returns a builder function `(fn [ctx] -> root-widget)`. The builder creates a horizontal `Flex` (axis=1, yalign=:center) containing three `Button` widgets:
+
+| Button | Icon | Default Text | Mode Toggle |
+|---|---|---|---|
+| Camera mode | `flight` | "Flight" / "Grounded" | `:primary` when grounded, `:secondary` when flight |
+| Object move | `open_with` | "Move" | `:primary` when enabled, `:secondary` when disabled |
+| Drag attachment | `anchor` | "Anchor" | `:primary` when anchor, `:secondary` when center |
+
+### Update Cycle
+
+The view connects to `state.changed`. On any state change, it:
+1. Updates the camera button label between "Flight" and "Grounded"
+2. Re-resolves theme colors for each button based on the new variant
+3. Marks layout dirty for the affected button background color change
+
+### Layout Names
+Each button's `layout.name` is set for testing and debugging: `sandbox-toolbar-camera-mode`, `sandbox-toolbar-object-move`, `sandbox-toolbar-drag-attachment`.
+
+### Cleanup
+`root.drop` disconnects from `state.changed` before delegating to the Flex's original `drop`, preventing stale callbacks on rebuilt toolbars.
+
+## Dragging
+
+### Alt-Drag
+`Alt` + left drag always works, regardless of activity. This is the unconditional drag path in `MovableMouseButtonDown` (`pointer.fnl`).
+
+### Object Move Mode
+When Sandbox is active and `object-move-enabled?` is `true`, `state-runtime.fnl`'s `activity-object-move-enabled?` returns `true`. This allows `MovableMouseButtonDown` to initiate a drag without `Alt` being held. The drag threshold is preserved — the pointer must move at least the configured distance before a drag session begins. This prevents accidental drags on click.
+
+When `object-move-enabled?` is `false` (default) or no activity sets a predicate, only `Alt`+drag works.
+
+### Anchor Drag
+When `drag-attachment` is `:anchor`, physics-backed movable entries receive an `on-drag-update` callback that applies force at the clicked anchor point rather than teleporting the entity via layout.
+
+**File:** `assets/lua/layout-physics-bodies.fnl`
+
+**Mechanism:**
+1. On drag start: `relative-anchor` is computed as `(drag.hit-point - body-center)` and stored on the drag table.
+2. On drag update: `apply-anchor-force!` computes a spring force from the displacement between the current anchor world position and the desired position, applies velocity damping via `getVelocityInLocalPoint` when available, and calls `body:applyForceAtPosition(damped-force, relative-anchor)`.
+3. Spring strength: 35.0, damping multiplier: 4.0 (conservative values for stability).
+4. `resolve-entry-world-state` reads the actual body transform during anchor drag (skipping `apply-layout-to-body`) so the body moves via forces without being reset every frame.
+5. On drag end: the layout position and rotation are synced **from** the body's final transform (position + rotation from `getCenterOfMassTransform`). `apply-layout-to-body` is NOT called for anchor mode.
+
+**Limitations:**
+- No native Bullet constraint bindings (point-to-point or 6DOF) are added. Force-at-anchor uses `applyForceAtPosition` and `getVelocityInLocalPoint` only — these are existing Bullet Lua bindings.
+- If `getVelocityInLocalPoint` is unavailable, damping is skipped (spring force only, may oscillate).
+- Assertions fail loudly when `entry.body`, `body.applyForceAtPosition`, or related bindings are missing.
+
+## Grounded Camera
+
+**File:** `assets/lua/sandbox-camera-controls.fnl`
+
+`SandboxCameraControls` is a wrapper around `FirstPersonControls` that delegates all handlers in `:flight` mode and provides terrain-following grounded movement in `:grounded` mode.
+
+### Dependencies
+- `camera` — the scene camera (required)
+- `toolbar-state` — `SandboxToolbarState` instance (required)
+- `flight-controls` — a `FirstPersonControls` instance (required)
+- `terrain-sampler` — an object with `:height-at-world-point(world-point)` method (required for grounded mode)
+
+### Terrain Sampler
+The Scene (`scene.fnl`) implements `:height-at-world-point` by querying `TerrainQuery.surface-info-at-world-point` and returning the world-space Y of the surface point, or 0.0 when no surface is found.
+
+### Failure Behavior
+- **Missing terrain sampler at construction with grounded mode**: immediate error.
+- **Missing terrain sampler after construction**: every handler that touches grounded state (`update`, `on-key-down`, `on-key-up`, `on-mouse-button-down`, `on-mouse-button-up`, `on-mouse-motion`) calls `ensure-grounded-deps!` before any camera or state mutation.
+- Invalid `delta-unit` raises an error with the expected values.
+
+### Movement
+- **Horizontal**: Keyboard keys (`move-left`/`move-right`/`move-forward`/`move-backward`) move the camera along the horizontal projection of the camera's forward and right vectors. Speed is multiplied by 1.5 while the jump key is held (sprint).
+- **Look**: Keyboard `look-up`/`look-down` adjust pitch. `look-left`/`look-right` adjust yaw. Mouse left-drag also adjusts yaw and pitch.
+- **Pitch clamp**: Accumulated pitch is clamped to `[pitch-min, pitch-max]` (default `[-1.2, 1.2]` radians). The pitch accumulator is tracked internally and reset on `drop`.
+
+### Jump and Gravity
+- **Jump**: Pressing `Space` sets `vertical-velocity` to `jump-speed` (default 8.0) and sets `airborne?` to `true`. Jumps are only possible from the grounded state.
+- **Gravity**: While airborne, `vertical-velocity` decreases by `gravity * delta-seconds` (default gravity: 18.0). Position is integrated directly.
+- **Landing**: When `vertical-velocity <= 0` and the camera Y position reaches or passes the terrain + eye-height threshold, the camera snaps to the terrain and `airborne?` is cleared.
+- **Terrain following**: While grounded, a `CameraAnimation.scalar-channel` with smoothing rate 8.0 smoothly adjusts the camera Y to follow terrain height changes. The channel uses exponential easing (`alpha = 1 - exp(-rate * delta-seconds)`).
+
+### What It's Not
+- Grounded camera is terrain-following movement, **not a full character controller**. There is no collision detection, no step-up, no crouch, and no slope handling beyond the terrain height query.
+- `on-mouse-wheel` is a no-op in grounded mode.
+- Gamepad controls delegate to flight controls; grounded mode has no native gamepad support.
+
+### Additional Options
+| Option | Default | Description |
+|---|---|---|
+| `eye-height` | 2.0 | Height above terrain for camera |
+| `gravity` | 18.0 | Downward acceleration |
+| `jump-speed` | 8.0 | Initial vertical speed on jump |
+| `pitch-min` | -1.2 | Minimum pitch angle (radians) |
+| `pitch-max` | 1.2 | Maximum pitch angle (radians) |
+| `movement-speed` | 10.0 | Horizontal movement speed |
+| `mouse-look-speed` | 0.001 | Mouse-look sensitivity |
+| `delta-unit` | `:milliseconds` | Unit for delta (`:milliseconds` or `:seconds`) |
+
+## Camera Animation
+
+**File:** `assets/lua/camera-animation.fnl`
+
+`CameraAnimation.scalar-channel(opts)` is a lightweight easing helper used by grounded camera for smooth terrain following.
+
+- `channel:value` — returns the current scalar value
+- `channel:set-target(n)` — sets the target value; returns `true`
+- `channel:snap(n)` — sets both current and target to `n`; returns `true`
+- `channel:update(delta-seconds)` — approaches target exponentially via `alpha = 1 - exp(-rate * delta)`; snaps when distance < 1e-5
+- All inputs validated; non-numeric values raise errors
+
+## See Also
+
+- [Layout](./sandbox-interaction-toolbar) — this document
+- [Activity Retention Tests](../assets/lua/tests/test-activity-retention.fnl) — tests for hook lifecycle
+- [Scene Drag Tests](../assets/lua/tests/test-scene-drag.fnl) — tests for predicate-gated dragging
+- [Layout Physics Bodies Tests](../assets/lua/tests/test-layout-physics-bodies.fnl) — tests for anchor drag
+- [Sandbox Camera Controls Tests](../assets/lua/tests/test-sandbox-camera-controls.fnl) — tests for grounded camera
+- [Camera Animation Tests](../assets/lua/tests/test-camera-animation.fnl) — tests for scalar channel

--- a/docs/dev/notes/sandbox-interaction-toolbar.md
+++ b/docs/dev/notes/sandbox-interaction-toolbar.md
@@ -22,7 +22,7 @@ The Sandbox toolbar is contributed by the active activity and laid out in the HU
 The activity activation context (`ctx`) in `activities.fnl` exposes three new hooks:
 
 ### `ctx:set-top-toolbar-builder!(builder)`
-Sets the current activity's top-toolbar builder. The builder must be a function `(fn [ctx] -> widget)` that produces a Layout-compatible widget tree. Sandbox sets this to `(SandboxToolbarView toolbar-state)`. The toolbar is rebuilt when the builder reference changes or on each frame.
+Sets the current activity's top-toolbar builder. The builder must be a function `(fn [ctx] -> widget)` that produces a Layout-compatible widget tree. Sandbox sets this to `(SandboxToolbarView toolbar-state)`. The toolbar is built when the builder reference changes (e.g., on activation or deactivation); the retained child is measured and laid out on subsequent frames.
 
 ### `ctx:set-object-move-predicate!(predicate)`
 Sets a zero-argument function that returns `true` when no-`Alt` object dragging is enabled for this activity. `state-runtime.fnl` calls `app.activity-object-move-predicate` to gate `MovableMouseButtonDown`. Sandbox sets this to `(fn [] (= toolbar-state.object-move-enabled? true))`. When no activity sets a predicate (or it returns `false`/`nil`), only `Alt`+drag works — this is the safe default for all other activities.

--- a/docs/plans/2026-07-29-sandbox-interaction-toolbar.md
+++ b/docs/plans/2026-07-29-sandbox-interaction-toolbar.md
@@ -1,0 +1,700 @@
+# Sandbox Interaction Toolbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Sandbox-owned center-column toolbar for camera mode, object move mode, and drag attachment, plus grounded camera movement and force-at-anchor physics dragging.
+
+**Architecture:** HUD layout provides a small activity toolbar slot in the middle center column only; left/right rails remain full-height general HUD controls. Sandbox owns toolbar state, toolbar view, activity predicates, camera controls, and session persistence. Movable dragging gains a single override callback so physics-backed Sandbox bodies can apply force at the clicked anchor using existing Bullet Lua bindings instead of teleporting.
+
+**Tech Stack:** Fennel modules in `assets/lua`, existing HUD `Layout`/`Flex`/`Stack`/`Button` widgets, existing activity hooks in `assets/lua/activities.fnl`, existing Bullet Lua `RigidBody` force bindings, and Fennel tests under `assets/lua/tests`.
+
+## Global Constraints
+
+- The toolbar is Sandbox-owned and does not appear for Graph, Drawing, Board, or other activities unless those activities contribute their own toolbar in a future change.
+- The toolbar is below the global control panel but only inside the center column between left and right rails.
+- Left and right rails remain full-height because they are general controls outside Sandbox ownership.
+- Expanded sidebar panels must not overlap the Sandbox toolbar; their panel content reserves the toolbar height while their rails remain full-height.
+- Current `Alt` + left drag remains supported.
+- Object move mode allows no-`Alt` object dragging only while Sandbox enables it.
+- Default drag attachment remains `:center`; anchor dragging is explicitly opt-in.
+- Anchor dragging uses existing Bullet force APIs first; do not add native Bullet constraint bindings in this implementation.
+- Grounded camera is terrain-following movement, not a full character controller.
+- Invalid state values and missing required grounded-camera dependencies fail loudly.
+- Use canonical option keys only; do not add compatibility aliases.
+- For icon names used by new buttons, validate exact names against `assets/material-design-icons/icons.txt` before committing implementation tasks.
+
+---
+
+## File Structure
+
+- Create `assets/lua/activity-top-toolbar-view.fnl`: dynamic HUD wrapper that builds the active activity toolbar and publishes its measured height to `app.activity-top-toolbar-height`.
+- Create `assets/lua/sandbox-toolbar-state.fnl`: Sandbox toolbar mode state, mutation API, changed signal, capture, and restore.
+- Create `assets/lua/sandbox-toolbar-view.fnl`: compact horizontal Sandbox toolbar with camera, object move, and drag attachment buttons.
+- Create `assets/lua/camera-animation.fnl`: scalar smoothing channel used by grounded camera vertical follow.
+- Create `assets/lua/sandbox-camera-controls.fnl`: mode-switching controls wrapper; delegates to existing flight controls or runs grounded movement.
+- Modify `assets/lua/activities.fnl`: add toolbar, object-move predicate, and drag-attachment provider hooks.
+- Modify `assets/lua/hud-layout.fnl`: lay out center toolbar above the center scene stack while rails remain full-height.
+- Modify `assets/lua/hud-extended-sidebar-view.fnl`: reserve top toolbar height for expanded right sidebar panel only.
+- Modify `assets/lua/activity-dock-view.fnl`: reserve top toolbar height for expanded left activity panel only.
+- Modify `assets/lua/main.fnl`: wire `ActivityTopToolbarView` and sidebar reserve providers into HUD construction.
+- Modify `assets/lua/sandbox-activity-unit.fnl`: create Sandbox toolbar state, install hooks, persist toolbar state, and install Sandbox camera controls.
+- Modify `assets/lua/state-runtime.fnl` and `assets/lua/state-handlers/pointer.fnl`: route object move predicate into the movable mouse-down condition.
+- Modify `assets/lua/movables.fnl`: pass drag lifecycle state to callbacks and add `:on-drag-update` override.
+- Modify `assets/lua/layout-physics-bodies.fnl`: implement force-at-anchor drag for physics-backed bodies.
+- Modify `assets/lua/scene.fnl`: preserve `:on-drag-update` when scene movable entries are normalized/registered.
+- Create or modify focused tests under `assets/lua/tests` listed in each task.
+- Create `docs/dev/notes/sandbox-interaction-toolbar.md` and link it from `docs/dev/notes/index.md`.
+
+Use this focused test environment for Fennel module commands throughout:
+
+```bash
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m <module>:main
+```
+
+---
+
+### Task 1: Activity Toolbar Hook and Center-Column HUD Layout
+
+**Files:**
+- Create: `assets/lua/activity-top-toolbar-view.fnl`
+- Modify: `assets/lua/activities.fnl`
+- Modify: `assets/lua/hud-layout.fnl`
+- Modify: `assets/lua/hud-extended-sidebar-view.fnl`
+- Modify: `assets/lua/activity-dock-view.fnl`
+- Modify: `assets/lua/main.fnl`
+- Modify: `assets/lua/tests/test-activity-retention.fnl`
+- Modify: `assets/lua/tests/test-hud-layout.fnl`
+- Modify: `assets/lua/tests/test-hud-extended-sidebar.fnl`
+
+**Interfaces:**
+- Consumes: existing `Activities.activity-context`, `HudLayout.make-hud-builder(opts)`, `HudExtendedSidebarView(sidebar)`, and `ActivityDockView(opts)`.
+- Produces:
+  ```fennel
+  (ctx:set-top-toolbar-builder! builder-or-nil) ; -> builder-or-nil
+  (ctx:set-object-move-predicate! predicate-or-nil) ; -> predicate-or-nil
+  (ctx:set-drag-attachment-provider! provider-or-nil) ; -> provider-or-nil
+  app.activity-top-toolbar-builder
+  app.activity-object-move-predicate
+  app.activity-drag-attachment-provider
+  app.activity-top-toolbar-height ; number, defaults to 0 when absent
+  (ActivityTopToolbarView {}) ; -> builder
+  (HudExtendedSidebarView sidebar {:top-reserve-height-provider provider})
+  (ActivityDockView {:top-reserve-height-provider provider})
+  ```
+
+- [ ] **Step 1: Add failing activity hook tests**
+
+  In `assets/lua/tests/test-activity-retention.fnl`, add a test named `activity-hooks-include-toolbar-and-sandbox-interaction-providers` that registers a temporary activity whose `activate` callback calls:
+
+  ```fennel
+  (ctx:set-top-toolbar-builder! toolbar-builder)
+  (ctx:set-object-move-predicate! move-predicate)
+  (ctx:set-drag-attachment-provider! drag-provider)
+  ```
+
+  Assert after activation that `app.activity-top-toolbar-builder`, `app.activity-object-move-predicate`, and `app.activity-drag-attachment-provider` are exactly those functions. Then deactivate and assert all three app fields are nil.
+
+- [ ] **Step 2: Run the activity hook test and verify it fails**
+
+  Run:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-activity-retention:main
+  ```
+
+  Expected: FAIL because the three `ctx:set-*` methods do not exist.
+
+- [ ] **Step 3: Implement activity hook plumbing**
+
+  In `activities.fnl`:
+
+  - add `app.activity-top-toolbar-builder`, `app.activity-object-move-predicate`, and `app.activity-drag-attachment-provider` resets to `clear-activity-runtime-hooks!`;
+  - add `:top-toolbar-builder`, `:object-move-predicate`, and `:drag-attachment-provider` keys to `empty-activity-hooks`;
+  - copy those keys into app fields in `apply-activity-hooks!`;
+  - add context methods with these exact names:
+
+  ```fennel
+  :set-top-toolbar-builder! (fn [_self value] (set-staged-hook! :top-toolbar-builder value))
+  :set-object-move-predicate! (fn [_self value] (set-staged-hook! :object-move-predicate value))
+  :set-drag-attachment-provider! (fn [_self value] (set-staged-hook! :drag-attachment-provider value))
+  ```
+
+- [ ] **Step 4: Add failing center-column HUD layout tests**
+
+  In `test-hud-layout.fnl`, add a test named `top-toolbar-reserves-center-column-between-full-height-rails`. Build a HUD with:
+
+  ```fennel
+  {:control-builder (fixed-widget "control" (glm.vec3 100 3 0))
+   :status-builder (fixed-widget "status" (glm.vec3 100 2 0))
+   :left-dock-builder (fixed-widget "left" (glm.vec3 5 7 0))
+   :right-dock-builder (fixed-widget "right" (glm.vec3 6 7 0))
+   :top-toolbar-builder (fixed-widget "toolbar" (glm.vec3 20 4 0))}
+  ```
+
+  With HUD content `100 x 40`, assert after layout:
+
+  ```fennel
+  (assert (= entity.top-toolbar-root.layout.size.x 89)) ; 100 - 5 - 6
+  (assert (= entity.top-toolbar-root.layout.size.y 4))
+  (assert (= entity.left-dock-root.layout.size.y 35)) ; 40 - control 3 - status 2
+  (assert (= entity.right-dock-root.layout.size.y 35))
+  (assert (= entity.tiles-root.layout.size.y 31)) ; middle 35 - toolbar 4
+  ```
+
+- [ ] **Step 5: Run the HUD layout test and verify it fails**
+
+  Run:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-hud-layout:main
+  ```
+
+  Expected: FAIL because `top-toolbar-root` is not produced and the middle layout has no center-column toolbar.
+
+- [ ] **Step 6: Implement `activity-top-toolbar-view.fnl`**
+
+  Create a builder that reads `app.activity-top-toolbar-builder`. It returns an entity with a `Layout` named `activity-top-toolbar-view`. Its measurer:
+
+  - builds a child when the app builder identity changes;
+  - measures the child when present;
+  - sets measure to `glm.vec3 0 0 0` when absent;
+  - sets `app.activity-top-toolbar-height` to the measured height.
+
+  Its layouter assigns child `position`, `size`, `rotation`, `clip-region`, and `depth-offset-index` directly. Its `drop` drops the child and sets `app.activity-top-toolbar-height` to `0`.
+
+- [ ] **Step 7: Modify `hud-layout.fnl` for center-column toolbar**
+
+  Add `local top-toolbar-builder options.top-toolbar-builder`. In `build`, create `top-toolbar` when the builder exists. Replace the single center `tiles` child in the middle row with a center stack made from vertical `Flex`:
+
+  ```fennel
+  (local scene-stack ((Stack {:depth-offset-step panel-depth-layer-step
+                             :children [(fn [_ctx] tiles)
+                                        (fn [_ctx] float)
+                                        (fn [_ctx] middle-overlay)]}) ctx))
+  (local center-children [])
+  (when top-toolbar
+    (table.insert center-children (FlexChild (fn [_ctx] top-toolbar))))
+  (table.insert center-children (FlexChild (fn [_ctx] scene-stack) 1))
+  (local center-column ((Flex {:axis 2 :xalign :stretch :yspacing 0 :children center-children}) ctx))
+  ```
+
+  Insert `center-column` as the flexing middle child between left and right docks. Expose `:top-toolbar-root top-toolbar` and keep `:middle-root` pointing to the scene stack or a clearly named center entity used by tests. Update `update` and `drop` to include `top-toolbar`.
+
+- [ ] **Step 8: Add failing sidebar reserve tests**
+
+  In `test-hud-extended-sidebar.fnl`, add a test named `expanded-panel-reserves-toolbar-height-while-rail-remains-full-height`. Build `HudExtendedSidebarView` with `{:top-reserve-height-provider (fn [] 4)}`. Allocate height `30`. Assert:
+
+  ```fennel
+  (assert (= entity.rail-entity.layout.size.y 30))
+  (assert (= entity.active-panel-entity.layout.position.y 4))
+  (assert (= entity.active-panel-entity.layout.size.y 26))
+  ```
+
+  In the existing activity dock tests or `test-hud-layout.fnl`, add equivalent coverage for the left activity dock expanded content while the feature rail remains full-height.
+
+- [ ] **Step 9: Implement sidebar reserve support**
+
+  In `hud-extended-sidebar-view.fnl`, accept an optional `opts` table. Add local:
+
+  ```fennel
+  (fn top-reserve-height []
+    (math.max 0 (or (and options.top-reserve-height-provider
+                         (options.top-reserve-height-provider)) 0)))
+  ```
+
+  During layout, keep rail size `(glm.vec3 rail-w height 0)`. For `active-panel-entity`, set y offset to reserve height and size.y to `(math.max 0 (- height reserve))`.
+
+  In `activity-dock-view.fnl`, accept the same option and apply the reserve only to activity-provided content, not to the feature rail.
+
+- [ ] **Step 10: Wire the toolbar view in `main.fnl`**
+
+  Require `activity-top-toolbar-view`. When building HUD options, pass `:top-toolbar-builder (ActivityTopToolbarView {})`. When building right sidebar and left activity dock, pass `{:top-reserve-height-provider (fn [] (or app.activity-top-toolbar-height 0))}`.
+
+- [ ] **Step 11: Run focused validation and commit Task 1**
+
+  Run:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-activity-retention:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-hud-layout:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-hud-extended-sidebar:main
+  ```
+
+  Commit:
+
+  ```bash
+  git add assets/lua/activity-top-toolbar-view.fnl assets/lua/activities.fnl assets/lua/hud-layout.fnl assets/lua/hud-extended-sidebar-view.fnl assets/lua/activity-dock-view.fnl assets/lua/main.fnl assets/lua/tests/test-activity-retention.fnl assets/lua/tests/test-hud-layout.fnl assets/lua/tests/test-hud-extended-sidebar.fnl
+  git commit -m "feat(ui): add activity center toolbar slot"
+  ```
+
+---
+
+### Task 2: Sandbox Toolbar State, View, and Persistence
+
+**Files:**
+- Create: `assets/lua/sandbox-toolbar-state.fnl`
+- Create: `assets/lua/sandbox-toolbar-view.fnl`
+- Create: `assets/lua/tests/test-sandbox-toolbar-state.fnl`
+- Create: `assets/lua/tests/test-sandbox-toolbar-view.fnl`
+- Modify: `assets/lua/sandbox-activity-unit.fnl`
+- Modify: `assets/lua/tests/test-sandbox-activity.fnl`
+- Modify: `assets/lua/tests/fast.fnl`
+
+**Interfaces:**
+- Consumes: Task 1 activity hooks.
+- Produces:
+  ```fennel
+  (SandboxToolbarState opts) ; -> state
+  state.camera-mode ; :flight or :grounded
+  state.object-move-enabled? ; boolean
+  state.drag-attachment ; :center or :anchor
+  state.changed ; Signal
+  (state:set-camera-mode mode) ; -> mode
+  (state:toggle-camera-mode) ; -> mode
+  (state:set-object-move-enabled! enabled?) ; -> boolean
+  (state:toggle-object-move-enabled!) ; -> boolean
+  (state:set-drag-attachment mode) ; -> mode
+  (state:toggle-drag-attachment) ; -> mode
+  (state:capture-state) ; -> table with string values
+  (state:restore-state payload) ; -> true
+  (SandboxToolbarView state) ; -> builder
+  ```
+
+- [ ] **Step 1: Add failing toolbar state tests**
+
+  Create `test-sandbox-toolbar-state.fnl` with tests for defaults, changed signal count, invalid value errors, capture, and restore. Canonical capture output is:
+
+  ```fennel
+  {:camera-mode "flight"
+   :object-move-enabled? false
+   :drag-attachment "center"}
+  ```
+
+- [ ] **Step 2: Run state tests and verify failure**
+
+  Run:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-toolbar-state:main
+  ```
+
+  Expected: FAIL because `sandbox-toolbar-state` does not exist.
+
+- [ ] **Step 3: Implement `sandbox-toolbar-state.fnl`**
+
+  Implement validation sets:
+
+  ```fennel
+  (local valid-camera-modes {:flight true :grounded true})
+  (local valid-drag-attachments {:center true :anchor true})
+  ```
+
+  Emit `changed` only after successful mutation. Restore accepts nil by leaving defaults unchanged; non-nil restore must use canonical strings `"flight"`, `"grounded"`, `"center"`, and `"anchor"`.
+
+- [ ] **Step 4: Add failing toolbar view tests**
+
+  Create `test-sandbox-toolbar-view.fnl`. Build the view with a fresh state and assert it creates buttons named:
+
+  ```text
+  sandbox-toolbar-camera-mode
+  sandbox-toolbar-object-move
+  sandbox-toolbar-drag-attachment
+  ```
+
+  Invoke each button's `on-click` and assert the corresponding state field changes. Assert `entity:update()` after a state change updates button text or variant so active modes are visible.
+
+- [ ] **Step 5: Implement `sandbox-toolbar-view.fnl`**
+
+  Use existing `Button`, `Flex`, `FlexChild`, `Padding`, and `Rectangle`/`Stack`. Validate icon names with:
+
+  ```bash
+  rg -n "^(flight|directions_walk|open_with|anchor)" assets/material-design-icons/icons.txt
+  ```
+
+  If `anchor` is unavailable, use the exact closest available Material icon from the search result and record it in the implementation commit message. Use compact labels: `Flight`/`Grounded`, `Move`, and `Anchor`.
+
+- [ ] **Step 6: Add failing Sandbox integration tests**
+
+  In `test-sandbox-activity.fnl`, add coverage that Sandbox activation:
+
+  - creates or reuses `runtime.sandbox-toolbar-state`;
+  - installs `app.activity-top-toolbar-builder`;
+  - installs object move predicate returning state value;
+  - installs drag attachment provider returning state value;
+  - snapshots toolbar state under `scene.toolbar`;
+  - restores `scene.toolbar` into the state.
+
+- [ ] **Step 7: Integrate Sandbox toolbar**
+
+  In `sandbox-activity-unit.fnl`:
+
+  - require `sandbox-toolbar-state` and `sandbox-toolbar-view`;
+  - ensure `world-runtime.sandbox-toolbar-state` before controls are created;
+  - set `app.sandbox-toolbar-state` while Sandbox is active;
+  - install hooks:
+
+  ```fennel
+  (ctx:set-top-toolbar-builder! (SandboxToolbarView toolbar-state))
+  (ctx:set-object-move-predicate! (fn [] (= toolbar-state.object-move-enabled? true)))
+  (ctx:set-drag-attachment-provider! (fn [] toolbar-state.drag-attachment))
+  ```
+
+  Add `(set app.sandbox-toolbar-state nil)` in Sandbox deactivation. Snapshot with `(set captured.toolbar (toolbar-state:capture-state))`. Restore with `(toolbar-state:restore-state scene-state.toolbar)`.
+
+- [ ] **Step 8: Register tests and validate**
+
+  Add new modules to `tests/fast.fnl`. Run:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-toolbar-state:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-toolbar-view:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-activity:main
+  ```
+
+  Commit:
+
+  ```bash
+  git add assets/lua/sandbox-toolbar-state.fnl assets/lua/sandbox-toolbar-view.fnl assets/lua/sandbox-activity-unit.fnl assets/lua/tests/test-sandbox-toolbar-state.fnl assets/lua/tests/test-sandbox-toolbar-view.fnl assets/lua/tests/test-sandbox-activity.fnl assets/lua/tests/fast.fnl
+  git commit -m "feat(lua): add sandbox toolbar state and view"
+  ```
+
+---
+
+### Task 3: Object Move Predicate and Physics Anchor Drag
+
+**Files:**
+- Modify: `assets/lua/state-runtime.fnl`
+- Modify: `assets/lua/state-handlers/pointer.fnl`
+- Modify: `assets/lua/movables.fnl`
+- Modify: `assets/lua/layout-physics-bodies.fnl`
+- Modify: `assets/lua/scene.fnl`
+- Modify: `assets/lua/tests/test-movables.fnl`
+- Modify: `assets/lua/tests/test-scene-drag.fnl`
+- Modify: `assets/lua/tests/test-layout-physics-bodies.fnl`
+
+**Interfaces:**
+- Consumes:
+  ```fennel
+  app.activity-object-move-predicate ; function or nil
+  app.activity-drag-attachment-provider ; function or nil
+  ```
+- Produces:
+  ```fennel
+  (Runtime.activity-object-move-enabled? payload) ; -> boolean
+  (Runtime.drag-attachment-mode) ; -> :center or :anchor
+  (Movables.register widget {:on-drag-update callback})
+  ;; callback signature:
+  (fn [entry drag update] handled?)
+  ;; update fields: :payload :pointer :ray :hit :new-position :plane
+  ```
+
+- [ ] **Step 1: Add failing pointer predicate tests**
+
+  In `test-scene-drag.fnl`, add tests proving:
+
+  - `Alt` + left drag still starts movement;
+  - no-`Alt` left drag does not start movement when predicate is nil or false;
+  - no-`Alt` left drag starts movement when `app.activity-object-move-predicate` returns true;
+  - click without crossing the existing drag threshold remains a click.
+
+- [ ] **Step 2: Implement predicate routing**
+
+  In `state-runtime.fnl`, add:
+
+  ```fennel
+  (fn activity-object-move-enabled? [_payload]
+    (and app.activity-object-move-predicate
+         (= (app.activity-object-move-predicate) true)))
+  ```
+
+  In `pointer.fnl`, change `MovableMouseButtonDown` to allow drag when either `(Runtime.alt-held? payload)` or `(Runtime.activity-object-move-enabled? payload)` is true.
+
+- [ ] **Step 3: Add failing Movables override tests**
+
+  In `test-movables.fnl`, add tests proving:
+
+  - `on-drag-start` receives `(entry drag payload)` and `drag.hit-point`;
+  - `on-drag-update` receives `update.new-position`;
+  - when `on-drag-update` returns true, default `target:set-position` is not called;
+  - when `on-drag-update` returns false, default `target:set-position` still runs;
+  - `on-drag-end` receives `(entry drag)` before drag state is cleared.
+
+- [ ] **Step 4: Implement Movables drag callbacks**
+
+  In `movables.fnl`:
+
+  - store `options.on-drag-update` on each entry;
+  - call `entry.on-drag-start entry drag payload`;
+  - in `update-drag`, build:
+
+  ```fennel
+  {:payload payload :pointer pointer :ray ray :hit hit :new-position new-position :plane drag.plane}
+  ```
+
+  - call `entry.on-drag-update entry drag update`; skip default `target:set-position` only when it returns true;
+  - call `entry.on-drag-end entry drag` before clearing `self.drag`.
+
+- [ ] **Step 5: Add failing physics anchor tests**
+
+  In `test-layout-physics-bodies.fnl`, add a fake body that records `applyForceAtPosition`, `activate`, and `forceActivationState`. Assert in anchor mode:
+
+  - clicked relative anchor is recorded on drag start;
+  - `applyForceAtPosition` is called during drag update;
+  - default layout teleport is suppressed;
+  - body activation is requested;
+  - physics-backed anchor mode raises an explicit error if `applyForceAtPosition` is absent.
+
+- [ ] **Step 6: Implement anchor force drag**
+
+  In `layout-physics-bodies.fnl`, add `drag-attachment-mode`, `body-center`, and `apply-anchor-force!` helpers. `drag-attachment-mode` returns `:center` when no provider is installed. `body-center` reads `entry.body:getCenterOfMassTransform():getOrigin()` when a body is active and falls back to the entry layout center. `apply-anchor-force!` computes current anchor world position, spring displacement, optional velocity damping, and calls `entry.body:applyForceAtPosition`.
+
+  In `create-movable-entry`, add `:on-drag-update`. For `:center`, return false so current direct movement runs. For `:anchor`, require `entry.body` and `entry.body.applyForceAtPosition`; compute `relative-anchor` from `drag.hit-point - body-center`; compute `force = (desired-anchor-world - current-anchor-world) * spring-strength`; call `body:applyForceAtPosition (bt-glm-vec3 force) (bt-glm-vec3 relative-anchor)`; activate the body; return true.
+
+  Use `spring-strength` default `35.0`. If `body:getVelocityInLocalPoint` is available, subtract `velocity * 4.0` from force for damping.
+
+- [ ] **Step 7: Preserve new movable option through scene registration**
+
+  In `scene.fnl`, update movable entry normalization/registration to preserve `:on-drag-update` exactly as a function value. Do not rename existing option keys.
+
+- [ ] **Step 8: Validate and commit Task 3**
+
+  Run:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-movables:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-scene-drag:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-layout-physics-bodies:main
+  ```
+
+  Commit:
+
+  ```bash
+  git add assets/lua/state-runtime.fnl assets/lua/state-handlers/pointer.fnl assets/lua/movables.fnl assets/lua/layout-physics-bodies.fnl assets/lua/scene.fnl assets/lua/tests/test-movables.fnl assets/lua/tests/test-scene-drag.fnl assets/lua/tests/test-layout-physics-bodies.fnl
+  git commit -m "feat(lua): add sandbox object move and anchor drag"
+  ```
+
+---
+
+### Task 4: Camera Animation Foundation and Grounded Sandbox Controls
+
+**Files:**
+- Create: `assets/lua/camera-animation.fnl`
+- Create: `assets/lua/sandbox-camera-controls.fnl`
+- Create: `assets/lua/tests/test-camera-animation.fnl`
+- Create: `assets/lua/tests/test-sandbox-camera-controls.fnl`
+- Modify: `assets/lua/sandbox-activity-unit.fnl`
+- Modify: `assets/lua/tests/test-sandbox-activity.fnl`
+- Modify: `assets/lua/tests/fast.fnl`
+
+**Interfaces:**
+- Consumes: `SandboxToolbarState` from Task 2 and existing `FirstPersonControls`.
+- Produces:
+  ```fennel
+  (CameraAnimation.scalar-channel {:value n :target n :smoothing-rate n}) ; -> channel
+  (channel:value) ; -> number
+  (channel:set-target n) ; -> true
+  (channel:snap n) ; -> true
+  (channel:update delta-seconds) ; -> number
+  (SandboxCameraControls opts) ; -> controls with existing control handler interface
+  ```
+
+  Required `SandboxCameraControls` opts: `:camera`, `:toolbar-state`, and `:flight-controls`. Optional opts: `:terrain-sampler`, `:delta-unit`, `:eye-height`, `:gravity`, `:jump-speed`, `:pitch-min`, and `:pitch-max`.
+
+- [ ] **Step 1: Add failing camera animation tests**
+
+  Create `test-camera-animation.fnl` with tests for snap, target update, monotonic approach, no overshoot for positive smoothing, deterministic fixed-delta output, and explicit errors for non-number value/target/delta.
+
+- [ ] **Step 2: Implement `camera-animation.fnl`**
+
+  Implement scalar smoothing only. Use exponential approach:
+
+  ```fennel
+  (local alpha (- 1 (math.exp (* -1 smoothing-rate delta-seconds))))
+  (set current (+ current (* (- target current) alpha)))
+  ```
+
+  Clamp `alpha` to `[0, 1]` and snap to target when distance is below `1e-5`.
+
+- [ ] **Step 3: Add failing Sandbox camera controls tests**
+
+  Create `test-sandbox-camera-controls.fnl`. Use fake camera and fake flight controls. Verify:
+
+  - flight mode delegates `update`, mouse, wheel, gamepad, and key handlers to flight controls;
+  - grounded mode does not call flight `update`;
+  - grounded mouse look clamps pitch between configured min/max;
+  - grounded `Space` sets positive vertical velocity;
+  - gravity lands camera at sampled terrain height plus eye height;
+  - terrain follow uses the scalar channel rather than snapping immediately;
+  - missing terrain sampler in grounded mode raises `SandboxCameraControls grounded mode requires terrain sampler`.
+
+- [ ] **Step 4: Implement `sandbox-camera-controls.fnl`**
+
+  Mirror `FirstPersonControls` handler names: `update`, `drop`, `drag-active?`, `should-suppress-click?`, `on-key-down`, `on-key-up`, `on-mouse-wheel`, `on-mouse-button-down`, `on-mouse-button-up`, `on-mouse-motion`, `on-gamepad-button-down`, `on-gamepad-axis-motion`, and `on-gamepad-removed`.
+
+  In `:flight`, delegate to `flight-controls`. In `:grounded`, track key state, yaw, pitch, vertical velocity, airborne flag, mouse drag state, and a y scalar channel. Use defaults: `eye-height 2.0`, `gravity 18.0`, `jump-speed 8.0`, `pitch-min -1.2`, `pitch-max 1.2`, `movement-speed 10.0`.
+
+- [ ] **Step 5: Integrate controls into Sandbox activation**
+
+  In `sandbox-activity-unit.fnl`, create the inner `FirstPersonControls` as before, then wrap it:
+
+  ```fennel
+  (SandboxCameraControls {:camera sandbox-camera
+                          :toolbar-state toolbar-state
+                          :flight-controls flight-controls
+                          :terrain-sampler scene})
+  ```
+
+  Store the wrapper in `world-runtime.activity-controls.scene.sandbox`. If a previous raw `FirstPersonControls` is present, replace it with the wrapper and keep the raw controls as the wrapper's `flight-controls`.
+
+- [ ] **Step 6: Add terrain sampler method if missing**
+
+  If `scene` has no height query matching the controls tests, add `scene:height-at-world-point(world-point)` that queries the active Sandbox terrain and returns a number. If no terrain is under the point, return `0` for the default ground plane.
+
+- [ ] **Step 7: Register tests, validate, and commit Task 4**
+
+  Add new tests to `fast.fnl`. Run:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-camera-animation:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-camera-controls:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-first-person-controls:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-activity:main
+  ```
+
+  Commit:
+
+  ```bash
+  git add assets/lua/camera-animation.fnl assets/lua/sandbox-camera-controls.fnl assets/lua/sandbox-activity-unit.fnl assets/lua/scene.fnl assets/lua/tests/test-camera-animation.fnl assets/lua/tests/test-sandbox-camera-controls.fnl assets/lua/tests/test-sandbox-activity.fnl assets/lua/tests/fast.fnl
+  git commit -m "feat(lua): add grounded sandbox camera controls"
+  ```
+
+---
+
+### Task 5: Developer Documentation and Final Validation
+
+**Files:**
+- Create: `docs/dev/notes/sandbox-interaction-toolbar.md`
+- Modify: `docs/dev/notes/index.md`
+- Modify: `assets/lua/tests/fast.fnl` only if a new test module from earlier tasks was not registered in its task.
+
+**Interfaces:**
+- Consumes: all interfaces produced by Tasks 1 through 4.
+- Produces: developer documentation for the activity toolbar hook, Sandbox toolbar state, object move mode, anchor drag limitations, and grounded camera controls.
+
+- [ ] **Step 1: Write the developer note**
+
+  Create `docs/dev/notes/sandbox-interaction-toolbar.md` with sections:
+
+  ```markdown
+  # Sandbox Interaction Toolbar
+
+  ## Layout
+  The Sandbox toolbar is contributed by the active activity and laid out in the HUD center column between full-height left and right rails.
+
+  ## Activity Hooks
+  Document set-top-toolbar-builder!, set-object-move-predicate!, and set-drag-attachment-provider!.
+
+  ## Sandbox State
+  Document camera-mode, object-move-enabled?, and drag-attachment.
+
+  ## Dragging
+  Alt-drag always works. Object move mode permits no-Alt drag. Anchor drag applies force at the clicked point and does not add Bullet constraints.
+
+  ## Grounded Camera
+  Grounded camera follows terrain, jumps with Space, clamps pitch, and is not a character controller.
+  ```
+
+- [ ] **Step 2: Link the developer note**
+
+  Add a bullet for `sandbox-interaction-toolbar.md` in `docs/dev/notes/index.md` using the file's existing link style.
+
+- [ ] **Step 3: Verify all focused tests are registered**
+
+  Confirm `assets/lua/tests/fast.fnl` includes:
+
+  ```fennel
+  :tests.test-sandbox-toolbar-state
+  :tests.test-sandbox-toolbar-view
+  :tests.test-camera-animation
+  :tests.test-sandbox-camera-controls
+  ```
+
+- [ ] **Step 4: Run focused validation**
+
+  Run all focused modules touched by this plan:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-activity-retention:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-hud-layout:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-hud-extended-sidebar:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-toolbar-state:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-toolbar-view:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-activity:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-movables:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-scene-drag:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-layout-physics-bodies:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-camera-animation:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-sandbox-camera-controls:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.test-first-person-controls:main
+  ```
+
+- [ ] **Step 5: Run broad validation**
+
+  Run:
+
+  ```bash
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets ./build/space -m tests.fast:main
+  SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets make test
+  ```
+
+- [ ] **Step 6: Commit documentation**
+
+  Commit:
+
+  ```bash
+  git add docs/dev/notes/sandbox-interaction-toolbar.md docs/dev/notes/index.md assets/lua/tests/fast.fnl
+  git commit -m "docs: document sandbox interaction toolbar"
+  ```
+
+---
+
+## Validation Ladder
+
+1. Each task runs its focused tests before commit.
+2. Task 5 reruns all focused modules in one pass.
+3. Task 5 runs `tests.fast:main`.
+4. Task 5 runs the repository standard full test command from `AGENTS.md`:
+
+```bash
+SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets make test
+```
+
+## Acceptance Criteria
+
+- Sandbox displays a horizontal toolbar below the global control panel.
+- Toolbar is laid out only in the center column between rails.
+- Left and right rails remain full-height.
+- Expanded sidebar panels do not overlap the toolbar.
+- Toolbar exists only when Sandbox contributes it.
+- Camera mode toggles between flight and grounded.
+- Grounded camera supports jump, gravity landing, pitch clamp, and terrain-follow smoothing.
+- Object move mode allows no-`Alt` dragging only when Sandbox enables it.
+- Existing `Alt` drag remains supported.
+- Anchor drag applies force at the clicked point for physics-backed movables.
+- Center drag remains the default.
+- No native Bullet constraint binding is added.
+
+## Risks and Mitigations
+
+- HUD layout changes can regress rail and center sizing. Mitigation: Task 1 asserts exact rail, toolbar, and scene sizes.
+- Pointer dispatch changes can steal clicks. Mitigation: Task 3 preserves the drag threshold and reruns scene drag tests.
+- Force-at-anchor tuning may feel weak or unstable. Mitigation: first implementation uses conservative spring and damping constants and fails loudly for missing physics methods.
+- Grounded camera terrain sampling may be absent in test or non-Sandbox contexts. Mitigation: grounded mode requires an explicit sampler and errors clearly when it is missing.
+
+## Out of Scope
+
+- Toolbars for non-Sandbox activities.
+- A broad toolbar customization framework.
+- Native Bullet point-to-point or 6DOF constraint bindings.
+- Full character controller behavior.
+- Cinematic camera timelines, spline paths, or keybinding UI.

--- a/docs/specs/2026-07-29-sandbox-interaction-toolbar-design.md
+++ b/docs/specs/2026-07-29-sandbox-interaction-toolbar-design.md
@@ -1,0 +1,174 @@
+# Sandbox Interaction Toolbar Design
+
+## Context
+
+The Sandbox activity needs richer direct manipulation controls. Today the global HUD has a top control panel, left and right rail/sidebar areas, scene/canvas middle content, and a bottom status panel. Camera movement is handled by the existing free first-person controls, while object movement is only available through `Alt` + left drag in the `movables` pointer pipeline. Physics bodies can be teleported or pushed through existing Bullet Lua bindings, but native Bullet constraints such as `btPoint2PointConstraint` are not currently bound.
+
+## Goals
+
+- Add a Sandbox-owned horizontal toolbar below the global control panel.
+- Keep the toolbar visually separate from global HUD controls and scoped to Sandbox only.
+- Let the Sandbox toolbar toggle:
+  - camera mode between current free flight and a grounded terrain-following mode;
+  - object move mode so scene objects can be dragged without holding `Alt`;
+  - drag attachment behavior between current center/teleport-style dragging and clicked-anchor physics dragging.
+- Make expanded sidebars accommodate the toolbar vertically instead of overlapping it.
+- Introduce a small, clean camera animation foundation suitable for later camera features.
+- Implement clicked-anchor physics dragging using currently available Bullet APIs first, and defer native constraint bindings unless force-based dragging proves insufficient.
+
+## Non-Goals
+
+- No toolbar for Graph, Drawing, Board, or other activities in this change.
+- No global toolbar customization framework beyond the activity-owned HUD hook required for Sandbox.
+- No full character controller, capsule collision, stair stepping, crouching, or slope-material behavior.
+- No native Bullet constraint binding in the first implementation.
+- No cinematic timeline/path editor, spline camera system, or user keybinding editor.
+
+## Alternatives Considered
+
+### A. Sandbox-specific toolbar hard-wired directly into HUD layout
+
+This is the smallest surface area: `hud-layout` would directly know about Sandbox and insert a Sandbox toolbar band. It is fast but couples the generic HUD to one activity and makes later activity-specific toolbars harder.
+
+### B. Generic activity-owned top-toolbar hook with Sandbox as the only provider
+
+HUD layout gains a single optional top-toolbar band. Activities can contribute a builder, but Sandbox is the only built-in activity that does so now. This keeps Sandbox ownership intact, avoids global control-panel bloat, and leaves a reusable path for future activities without designing a large extension framework.
+
+### C. Overlay toolbar floating above scene and sidebars
+
+The toolbar could render in the HUD overlay layer and ignore layout. That maximizes screen space but creates ambiguous hit testing, can hide controls behind expanded sidebars, and makes toolbar width unpredictable.
+
+**Decision:** Use approach B. It gives the right ownership boundary and predictable layout while staying small.
+
+## Layout Design
+
+The HUD keeps the global control panel as the full-width top band and keeps the left/right rails as general HUD affordances outside Sandbox ownership. Inside the middle HUD band, the layout becomes:
+
+1. left rail/sidebar column;
+2. center column containing the optional activity top toolbar above the scene/tile/float area;
+3. right rail/sidebar column.
+
+The Sandbox toolbar is measured only inside the center column between the left and right rails. It consumes vertical space from the center scene area before scene/tile/float layout occurs. Rails remain full-height general HUD anchors and must not be pushed down by Sandbox-owned controls.
+
+Expanded sidebar panels are associated with their rail columns but should accommodate the Sandbox toolbar by starting below the toolbar or otherwise shrinking vertically to avoid covering it. This preserves rail access for global/app-level controls while keeping Sandbox toolbar controls visible and predictable.
+
+The toolbar content itself is Sandbox-owned. It should be horizontally centered or start-aligned within the center column, use existing button primitives where possible, and remain compact enough for a 1280x720 viewport. Reusable button-group/view helpers are acceptable if they naturally fall out of the implementation, but the design should not introduce a broad toolbar framework.
+
+## Sandbox Toolbar State
+
+Sandbox runtime state owns three user-facing controls:
+
+- `camera-mode`: `:flight` or `:grounded`; default `:flight`.
+- `object-move-enabled?`: boolean; default `false`.
+- `drag-attachment`: `:center` or `:anchor`; default `:center`.
+
+The state exposes explicit setters/toggles and emits a `changed` signal after successful mutations so views and controls can update without polling. Invalid mode values fail loudly.
+
+Toolbar state should be captured/restored with the Sandbox activity session so user preferences survive ordinary HomeWorld save/restore. Legacy aliases are not added.
+
+## Input and Interaction Modes
+
+Terminology:
+
+- **Camera mode** controls how the camera moves (`:flight` vs `:grounded`).
+- **Object move mode** controls whether left-drag can begin object movement without `Alt`.
+- **Drag attachment** controls how movable physics bodies respond once dragging starts (`:center` vs `:anchor`).
+
+Current `Alt` + left drag remains supported in all modes. When Sandbox object move mode is enabled, ordinary left drag can start a movable object drag without `Alt`. This behavior is supplied through an activity-level predicate so it is active only when Sandbox owns the active interaction context.
+
+The pointer dispatch order should continue to protect existing click/resize/selection semantics. Object move mode should not force every click to become a drag immediately; the existing drag threshold should still distinguish click from drag.
+
+## Drag Attachment Behavior
+
+The existing drag flow ray-casts to the clicked object, stores the hit point, computes ray/plane intersections during pointer motion, and by default moves the target layout to the desired position.
+
+For `:center` drag attachment, behavior remains equivalent to the current direct movement path.
+
+For `:anchor` drag attachment on physics-backed movables:
+
+- preserve the clicked world-space point as the drag anchor;
+- compute the anchor relative to the rigid body at drag start;
+- on drag update, compute a desired anchor position from the pointer ray/plane hit;
+- apply a spring-like force at the relative anchor using existing Bullet binding `RigidBody:applyForceAtPosition` / `applyForce` semantics;
+- activate the body while dragging;
+- avoid teleporting the layout transform during anchor updates.
+
+This should allow gravity and torque to rotate an object when lifted from one side. The first implementation may tune spring strength and damping conservatively for stability. If force-at-anchor proves too unstable or too weak for desired UX, the follow-up design should add native Bullet point-to-point constraint bindings instead of hiding the limitation.
+
+## Grounded Camera Mode
+
+Flight mode delegates to the existing first-person controls and preserves current behavior, including current movement mapping and `Space` as speed boost.
+
+Grounded mode is a Sandbox camera controls wrapper with the same input interface expected by existing state handlers. In grounded mode:
+
+- horizontal movement uses the existing movement action mapping where possible;
+- yaw is unrestricted around world up;
+- pitch is clamped to a comfortable range so the camera cannot flip or look far beyond vertical limits;
+- roll is not applied;
+- the camera has an eye height above terrain;
+- terrain-follow samples the active Sandbox terrain below the camera's horizontal position;
+- `Space` starts a jump by setting positive vertical velocity;
+- gravity pulls the camera back down to terrain height plus eye height;
+- when not airborne, camera height smoothly follows terrain height instead of snapping.
+
+The first grounded implementation is terrain-following movement, not a physical character controller. It should fail loudly if required terrain sampling APIs are missing in contexts that claim grounded mode support, while tests can use a stub scene sampler.
+
+## Camera Animation Foundation
+
+Introduce a small camera animation module rather than embedding ad-hoc smoothing into grounded controls. The first primitive should be enough for terrain-follow and future expansion:
+
+- scalar channel with current value, target value, smoothing rate, snap, and update;
+- no overshoot for normal positive smoothing values;
+- deterministic update from delta seconds.
+
+Grounded controls use this for vertical terrain-follow smoothing. Future camera transitions can add vector/quaternion channels or timelines without changing the camera object itself.
+
+## Architecture Components
+
+- `hud-layout`: accepts an optional top-toolbar builder and lays it at the top of the center middle column, between the left and right rails.
+- activity runtime/contribution layer: lets the active activity install or clear a top-toolbar builder and object-move predicate.
+- `sandbox-toolbar-state`: owns toolbar mode state, signals, capture, and restore.
+- `sandbox-toolbar-view`: builds the Sandbox toolbar buttons and mutates `sandbox-toolbar-state`.
+- `movables`: supports an optional drag update callback that can override default position-setting behavior.
+- physics-backed movable registration: implements anchor drag by applying force at the clicked local anchor when `drag-attachment` is `:anchor`.
+- `camera-animation`: provides the initial scalar smoothing channel.
+- `sandbox-camera-controls`: wraps existing flight controls and adds grounded controls behind the same handler interface.
+
+## Data Flow
+
+1. Sandbox activation ensures toolbar state and installs the toolbar builder plus object-move predicate.
+2. HUD rebuild/layout calls the active toolbar builder and reserves toolbar height in the center column while preserving full-height rails.
+3. Toolbar button clicks mutate Sandbox toolbar state and emit `changed`.
+4. Pointer handlers allow movable drag when `Alt` is held or the active activity predicate returns true.
+5. Movables compute hit/drag information and either use default target movement or delegate drag update to physics anchor behavior.
+6. State handler update events call Sandbox camera controls; the controls delegate to flight controls or update grounded movement/jump/terrain-follow based on `camera-mode`.
+
+## Error Handling
+
+- Invalid toolbar state modes raise explicit errors.
+- Missing required camera, state, or terrain sampler dependencies raise explicit errors at construction or grounded-mode use.
+- Anchor dragging falls back to default movement only when the movable is not physics-backed or when `drag-attachment` is `:center`; physics-backed anchor mode should not silently no-op.
+- Pointer predicates absent from non-Sandbox activities are treated as disabled, preserving existing behavior.
+
+## Testing Strategy
+
+- HUD layout tests verify the top toolbar consumes vertical space in the center column between rails, rails remain full-height, and expanded sidebars do not overlap the toolbar.
+- Activity tests verify Sandbox installs and clears the toolbar and predicates on activation/deactivation.
+- Toolbar state/view tests verify defaults, toggles, invalid values, capture/restore, button names, and button actions.
+- Pointer/movables tests verify `Alt` drag still works and no-`Alt` drag only works when Sandbox object move mode is enabled.
+- Physics movable tests verify anchor mode applies force at the clicked relative point and avoids teleport movement during anchor drag.
+- Camera animation tests verify smoothing, snap, monotonic approach, and no overshoot.
+- Grounded camera tests verify delegation in flight mode, pitch clamps, jump/gravity, terrain-follow sampling, and vertical smoothing.
+- Final validation should run focused Fennel tests, the fast suite, and the repository's standard full test command.
+
+## Acceptance Criteria
+
+- Sandbox displays a horizontal toolbar below the global control panel.
+- The toolbar is Sandbox-owned; other activities do not show it unless they explicitly contribute their own later.
+- The toolbar reserves center-column layout space; left/right rails remain full-height and expanded sidebar panels do not overlap it.
+- The camera button switches between free flight and grounded terrain-following controls.
+- In grounded mode, `Space` jumps, gravity lands the camera back on terrain, and pitch is clamped.
+- Object move mode allows dragging Sandbox objects without holding `Alt`; existing `Alt` drag remains available.
+- Anchor drag mode applies force at the clicked point for physics-backed objects so off-center lifting can rotate under gravity.
+- Direct center dragging remains available as the default.
+- No native Bullet constraint binding is required for the first implementation.


### PR DESCRIPTION
## Summary
- add a Sandbox-owned center-column toolbar with camera mode, object move, and drag attachment controls
- add grounded Sandbox camera controls plus scalar camera animation support
- add no-Alt object move mode and force-at-anchor physics drag using existing Bullet APIs
- document the new Sandbox interaction toolbar architecture

## Testing
- SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets make test