### PR TITLE
docs(devlog): add July daily journal entry

### DIFF
--- a/docs/dev/devlog.md
+++ b/docs/dev/devlog.md
@@ -1,5 +1,8 @@
 # Devlog
 
+## 2026-07-30
+Late July added grounded camera controls and physics anchor dragging through a new sandbox interaction toolbar, migrated the presentation layer from app-global assumptions to activity-owned delegates, shipped external-unit MCP tooling for loader-neutral user code, and matured the daily devlog automation with a retrospective journal backfill — giving the project a durable narrative record as it builds toward the next graph and world-editing milestones.
+
 ## 2026-07-14
 By mid-July, the project consolidated its operating loop around panel transfer, the repository workbench, conversation-first supervision, and the new VitePress knowledge base, turning months of scattered architecture notes into a navigable map for future graph, world-building, and live-development milestones.
 

--- a/docs/dev/journal/2026-07-30.md
+++ b/docs/dev/journal/2026-07-30.md
@@ -1,0 +1,9 @@
+---
+type: journal
+tags: [journal, devlog]
+created: 2026-07-30
+---
+
+# 2026-07-30
+
+Late July added grounded camera controls and physics anchor dragging through a new sandbox interaction toolbar, migrated the presentation layer from app-global assumptions to activity-owned delegates, shipped external-unit MCP tooling for loader-neutral user code, and matured the daily devlog automation with a retrospective journal backfill — giving the project a durable narrative record as it builds toward the next graph and world-editing milestones.

--- a/docs/dev/journal/index.md
+++ b/docs/dev/journal/index.md
@@ -11,6 +11,7 @@ tags:
 
 Chronological log of development work and decisions. Each entry records what was built, problems encountered, and ideas surfaced on a given day.
 
+- [2026-07-30](./2026-07-30)
 - [2026-07-14](./2026-07-14)
 - [2026-06-15](./2026-06-15)
 - [2026-05-08](./2026-05-08)


### PR DESCRIPTION
Impact:
- Adds today's brief devlog narrative for late-July project momentum.

What:
- Adds the 2026-07-30 journal entry.
- Regenerates the journal index and consolidated devlog.

Why:
- Keep the daily devlog automation's narrative record current when meaningful changes are present.

Risk:
- Low; docs-only generated index update.

Testing:
- cd docs && npm run devlog:indices && npm run docs:build (passed after npm ci installed locked docs dependencies).
