### PR TITLE
docs: add July 31 journal entry

### DIFF
--- a/docs/dev/devlog.md
+++ b/docs/dev/devlog.md
@@ -1,5 +1,8 @@
 # Devlog
 
+## 2026-07-31
+Runtime portability tightened with asset discovery that resolves from the executable through a deduplicated search order while preserving explicit overrides, and native logging now settles in a deliberate user log directory after dotenv has a chance to provide `SPACE_LOG_DIR`, keeping CLI, REPL, module, developer, installed, and portable runs predictable instead of scattering assets or `gl.log` around arbitrary launch directories.
+
 ## 2026-07-30
 Late July added grounded camera controls and physics anchor dragging through a new sandbox interaction toolbar, migrated the presentation layer from app-global assumptions to activity-owned delegates, shipped external-unit MCP tooling for loader-neutral user code, and matured the daily devlog automation with a retrospective journal backfill — giving the project a durable narrative record as it builds toward the next graph and world-editing milestones.
 

--- a/docs/dev/journal/2026-07-31.md
+++ b/docs/dev/journal/2026-07-31.md
@@ -1,0 +1,9 @@
+---
+type: journal
+tags: [journal, devlog]
+created: 2026-07-31
+---
+
+# 2026-07-31
+
+Runtime portability tightened with asset discovery that resolves from the executable through a deduplicated search order while preserving explicit overrides, and native logging now settles in a deliberate user log directory after dotenv has a chance to provide `SPACE_LOG_DIR`, keeping CLI, REPL, module, developer, installed, and portable runs predictable instead of scattering assets or `gl.log` around arbitrary launch directories.

--- a/docs/dev/journal/index.md
+++ b/docs/dev/journal/index.md
@@ -11,6 +11,7 @@ tags:
 
 Chronological log of development work and decisions. Each entry records what was built, problems encountered, and ideas surfaced on a given day.
 
+- [2026-07-31](./2026-07-31)
 - [2026-07-30](./2026-07-30)
 - [2026-07-14](./2026-07-14)
 - [2026-06-15](./2026-06-15)

--- a/docs/specs/2026-07-30-native-log-directory-design.md
+++ b/docs/specs/2026-07-30-native-log-directory-design.md
@@ -78,7 +78,7 @@ logger as a parse side effect.
 
 In `apps/space/main.cpp`, resolve and validate the log path before the first
 `log_init(LOG_CONFIG)`. On failure, print `error: failed to initialize logging:
-<details>` to stderr and exit non-zero. This keeps the no-silent-failures rule
+&lt;details&gt;` to stderr and exit non-zero. This keeps the no-silent-failures rule
 and prevents the runtime from silently falling back to CWD logs.
 
 Update `assets/lua/main.fnl` so normal app startup preserves the native-selected


### PR DESCRIPTION
Impact:
- Adds today's brief devlog narrative for runtime portability work.

What:
- Adds the 2026-07-31 journal entry and regenerates devlog indexes.
- Escapes a literal placeholder in the native log directory spec so VitePress treats it as text.

Why:
- Daily devlog automation found meaningful asset discovery and native log directory progress that was not covered by the latest journal entry.
- The docs build must remain green before publishing the automation branch.

Risk:
- Low; documentation-only changes with regenerated indexes and a narrow syntax fix.

Testing:
- docs: npm run devlog:indices && npm run docs:build passed.
- repo: SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH=$(pwd)/assets make test passed (17/17).
