### PR TITLE
fix(opencode): verify devlog ruleset protection

### DIFF
--- a/.opencode/agents/supervisor.md
+++ b/.opencode/agents/supervisor.md
@@ -40,12 +40,14 @@ permission:
     "gh auth status*": allow
     "gh repo view --json owner,name --jq *": allow
     "gh api repos/*/*/branches/main/protection*": allow
+    "gh api repos/*/*/rules/branches/main*": allow
     "gh pr create --base main --head automation/daily-devlog/????-??-?? --fill": allow
     "gh pr create --base main --head automation/weekly-agent-workflow/????-W?? --fill": allow
     "gh pr view automation/daily-devlog/????-??-??": allow
     "gh pr view automation/weekly-agent-workflow/????-W??*": allow
     "gh pr checks automation/weekly-agent-workflow/????-W?? --watch": allow
     "gh pr merge --auto --squash automation/daily-devlog/????-??-??": allow
+    "gh pr merge --auto --merge automation/daily-devlog/????-??-??": allow
     "gh pr merge --auto --squash automation/weekly-agent-workflow/????-W??": allow
     "git push origin --delete *": ask
     "git push *--force*": deny

--- a/.opencode/skills/daily-devlog-automation/SKILL.md
+++ b/.opencode/skills/daily-devlog-automation/SKILL.md
@@ -14,7 +14,7 @@ This skill turns a scheduled Orca/OpenCode run into a reviewed, brief devlog PR.
 1. Verify a clean dedicated checkout with `git status --porcelain`; stop if dirty.
 2. Verify the checkout is on a branch that can safely create `automation/daily-devlog/YYYY-MM-DD` from `origin/main`.
 3. Verify `gh auth status` before relying on PR creation or auto-merge.
-4. Verify branch protection rules and required status checks are active on the target repository before attempting auto-merge; do not assume they are available just because `gh auth status` succeeds.
+4. Verify branch protection rules and required status checks are active on the target repository before attempting auto-merge; do not assume they are available just because `gh auth status` succeeds. Protection may come from classic branch protection (HTTP 200 on `gh api repos/<owner>/<repo>/branches/main/protection`) or GitHub rulesets (classic endpoint returns HTTP 404). When the classic endpoint returns 404, verify effective branch rules via `gh api repos/<owner>/<repo>/rules/branches/main`. Required status checks (for this repo: `test`) and pull-request protection must be present in the effective rules before auto-merge. If neither classic protection nor active effective branch rules can be confirmed, fail closed.
 
 ## Workflow
 
@@ -58,11 +58,11 @@ Run `cd docs && npm run devlog:indices && npm run docs:build`. Inspect the final
 
 ## Commit, Push, and PR
 
-Commit after review. Push using `git push origin HEAD:refs/heads/automation/daily-devlog/YYYY-MM-DD`. Use `gh pr create --base main --head automation/daily-devlog/YYYY-MM-DD --fill` when authenticated. Verify branch protection and required checks are active before attempting auto-merge. Use `gh pr merge --auto --squash automation/daily-devlog/YYYY-MM-DD` only when protection rules and checks are confirmed available. Do not enable auto-merge merely because `gh` is authenticated. Never push directly to `origin/main`.
+Commit after review. Push using `git push origin HEAD:refs/heads/automation/daily-devlog/YYYY-MM-DD`. Use `gh pr create --base main --head automation/daily-devlog/YYYY-MM-DD --fill` when authenticated. Verify branch protection, required status checks, and pull-request protection are active before attempting auto-merge (classic protection or rulesets). Inspect the effective branch rules for allowed merge methods, then use the corresponding flag: `gh pr merge --auto --merge automation/daily-devlog/YYYY-MM-DD` when rules allow merge commits (current for this repo), `gh pr merge --auto --squash ...` when rules require squash, or `gh pr merge --auto --rebase ...` when rules require rebase. Do not enable auto-merge merely because `gh` is authenticated. Never push directly to `origin/main`.
 
 ## Fail-Closed Cases
 
-Stop with a clear BLOCKED summary when the checkout is dirty, credentials are missing, `gh` is unavailable, validation fails, branch protection or required status checks are unavailable or cannot be verified, auto-merge cannot proceed, or the diff includes unexpected files.
+Stop with a clear BLOCKED summary when the checkout is dirty, credentials are missing, `gh` is unavailable, validation fails, branch protection or required status checks are unavailable or cannot be verified (via classic protection or rulesets/effective branch rules), auto-merge cannot proceed, or the diff includes unexpected files.
 
 ## Red Flags
 

--- a/docs/dev/notes/daily-devlog-automation.md
+++ b/docs/dev/notes/daily-devlog-automation.md
@@ -39,7 +39,7 @@ The UI prompt is intentionally short because `.opencode/skills/daily-devlog-auto
 
 ## Safety model
 
-The automation fails closed when credentials, `gh` authentication, branch protection, checks, or a clean checkout are unavailable. Daily entries contain only frontmatter, a date heading, and one short narrative paragraph connecting concrete work to current project goals or milestones — no commit hashes, author lists, raw file lists, or bullet-point summaries.
+The automation fails closed when credentials, `gh` authentication, branch protection (classic protection or GitHub rulesets/effective branch rules), required status checks, pull-request protection, or a clean checkout are unavailable. The auto-merge method is selected from the effective branch rules (`--merge`, `--squash`, or `--rebase`) rather than hard-coded. Daily entries contain only frontmatter, a date heading, and one short narrative paragraph connecting concrete work to current project goals or milestones — no commit hashes, author lists, raw file lists, or bullet-point summaries.
 
 ## Validation and recovery
 

--- a/docs/scripts/test-opencode-automation-config.mjs
+++ b/docs/scripts/test-opencode-automation-config.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..', '..')
+
+let skillContent = ''
+let supervisorContent = ''
+let notesContent = ''
+
+async function loadFiles() {
+    if (skillContent) return
+    skillContent = await readFile(join(repoRoot, '.opencode', 'skills', 'daily-devlog-automation', 'SKILL.md'), 'utf8')
+    supervisorContent = await readFile(join(repoRoot, '.opencode', 'agents', 'supervisor.md'), 'utf8')
+    try {
+        notesContent = await readFile(join(repoRoot, 'docs', 'dev', 'notes', 'daily-devlog-automation.md'), 'utf8')
+    } catch { /* optional */ }
+}
+
+test('daily devlog skill mentions GitHub rulesets or effective branch rules, not only classic protection', async () => {
+    await loadFiles()
+    const hasRulesets = skillContent.includes('ruleset') ||
+        skillContent.includes('rules/branches') ||
+        skillContent.includes('effective branch rule') ||
+        skillContent.includes('effective rules')
+    assert.ok(hasRulesets,
+        'SKILL.md should mention rulesets or effective branch rules, not only classic protection')
+})
+
+test('daily devlog skill includes effective branch rules command', async () => {
+    await loadFiles()
+    const hasCommand = skillContent.includes('rules/branches/main') ||
+        skillContent.includes('rules/branches/<branch>')
+    assert.ok(hasCommand,
+        'SKILL.md should include gh api repos/<owner>/<repo>/rules/branches/main or equivalent')
+})
+
+test('daily devlog skill requires verifying required status checks before auto-merge', async () => {
+    await loadFiles()
+    assert.ok(
+        // Must mention required status checks in context of verification/auto-merge
+        /required.status.check/i.test(skillContent),
+        'SKILL.md should require verifying required status checks before auto-merge'
+    )
+})
+
+test('daily devlog skill requires verifying pull-request protection before auto-merge', async () => {
+    await loadFiles()
+    // Must mention pull-request rules / PR protection in context of verification
+    const hasPrProtection = /pull.request.*(?:protect|rule|required|verified)|pull.request/i.test(skillContent) &&
+        /auto.merge/i.test(skillContent)
+    assert.ok(hasPrProtection,
+        'SKILL.md should require verifying pull-request protection before auto-merge')
+})
+
+test('daily devlog skill does not hard-code --squash and instead selects merge method from rules', async () => {
+    await loadFiles()
+    // The skill must NOT require --squash as the only option
+    const hasHardcodedSquash = /gh pr merge --auto --squash automation\/daily-devlog/.test(skillContent)
+    // The skill must mention using the merge method from verified rules
+    const hasMergeMethodFromRules = /merge.method/i.test(skillContent) ||
+        /allowed.merge/i.test(skillContent) ||
+        /--merge automation\/daily-devlog/.test(skillContent) ||
+        /merge.*allowed/i.test(skillContent)
+    assert.ok(!hasHardcodedSquash,
+        'SKILL.md must NOT hard-code --squash for daily auto-merge')
+    assert.ok(hasMergeMethodFromRules,
+        'SKILL.md should say to use the merge method allowed by verified branch rules')
+})
+
+test('supervisor permissions allow rules/branches/main API', async () => {
+    await loadFiles()
+    const hasAllow = supervisorContent.includes('gh api repos/*/*/rules/branches/main')
+    assert.ok(hasAllow,
+        'supervisor.md must allow gh api repos/*/*/rules/branches/main*')
+})
+
+test('supervisor permissions allow --merge for daily auto-merge', async () => {
+    await loadFiles()
+    const hasMergeAllow = /gh pr merge --auto --merge automation\/daily-devlog\/\?\?\?\?-\?\?-\?\?/.test(supervisorContent)
+    assert.ok(hasMergeAllow,
+        'supervisor.md must allow gh pr merge --auto --merge automation/daily-devlog/????-??-??')
+})
+
+test('supervisor permissions keep existing --squash daily allow alongside new --merge allow', async () => {
+    await loadFiles()
+    const hasSquashAllow = /gh pr merge --auto --squash automation\/daily-devlog\/\?\?\?\?-\?\?-\?\?/.test(supervisorContent)
+    assert.ok(hasSquashAllow,
+        'supervisor.md should retain the existing --squash daily allow for transitional safety')
+})


### PR DESCRIPTION
Impact:
- Daily devlog automation no longer fails closed when main is protected by GitHub rulesets instead of classic branch protection.
- Auto-merge guidance now follows the merge method allowed by effective branch rules.

What:
- Update the daily devlog skill to verify classic protection or effective branch rules, including required status checks and pull-request protection.
- Add narrow supervisor permissions for the effective branch rules API and daily merge-commit auto-merge.
- Document the ruleset safety model in the devlog automation note.
- Add regression tests for the OpenCode automation configuration.

Why:
- The classic branch-protection API returns 404 for ruleset-protected repositories, which caused a false blocker before devlog entry creation.

Risk:
- Low. Permissions remain scoped to GitHub rules inspection and dated daily automation branches; direct main pushes remain guarded.

Testing:
- cd docs && npm run test:scripts — 19/19 pass.
- gh api repos/semanticdreams/space/rules/branches/main --jq '[.[] | {type, parameters}]' — confirms effective main rules include required status checks and pull-request protection.

Follow-ups:
- Restart OpenCode/Orca before relying on the updated project skill and supervisor permissions in a fresh scheduled run.
