### PR TITLE
docs(devlog): add August 1 journal entry

### DIFF
--- a/docs/dev/devlog.md
+++ b/docs/dev/devlog.md
@@ -1,5 +1,8 @@
 # Devlog
 
+## 2026-08-01
+Fennel constraints graduated from experimental to stable infrastructure, with validation output now summarized by default while preserving full detail behind a verbose flag for debugging, and agent workflows tightened in parallel through skill routing, MCP-accessible lint and repair tools, and hardened enclosing-form lookup — together sharpening the compile-check-and-iterate loop so constraint-aware development stays fast and reliable as the project scales.
+
 ## 2026-07-31
 Runtime portability tightened with asset discovery that resolves from the executable through a deduplicated search order while preserving explicit overrides, and native logging now settles in a deliberate user log directory after dotenv has a chance to provide `SPACE_LOG_DIR`, keeping CLI, REPL, module, developer, installed, and portable runs predictable instead of scattering assets or `gl.log` around arbitrary launch directories.
 

--- a/docs/dev/journal/2026-08-01.md
+++ b/docs/dev/journal/2026-08-01.md
@@ -1,0 +1,9 @@
+---
+type: journal
+tags: [journal, devlog]
+created: 2026-08-01
+---
+
+# 2026-08-01
+
+Fennel constraints graduated from experimental to stable infrastructure, with validation output now summarized by default while preserving full detail behind a verbose flag for debugging, and agent workflows tightened in parallel through skill routing, MCP-accessible lint and repair tools, and hardened enclosing-form lookup — together sharpening the compile-check-and-iterate loop so constraint-aware development stays fast and reliable as the project scales.

--- a/docs/dev/journal/index.md
+++ b/docs/dev/journal/index.md
@@ -11,6 +11,7 @@ tags:
 
 Chronological log of development work and decisions. Each entry records what was built, problems encountered, and ideas surfaced on a given day.
 
+- [2026-08-01](./2026-08-01)
 - [2026-07-31](./2026-07-31)
 - [2026-07-30](./2026-07-30)
 - [2026-07-14](./2026-07-14)


### PR DESCRIPTION
Impact:
- Adds the August 1 daily devlog entry covering stable Fennel constraints, concise validation output, and agent workflow reliability momentum.

What:
- Create docs/dev/journal/2026-08-01.md using the journal/devlog contract.
- Regenerate the journal index and aggregate devlog.

Why:
- Recent meaningful development work warrants a brief narrative devlog entry.

Risk:
- Low. Changes are limited to journal/devlog documentation artifacts.

Testing:
- cd docs && npm run devlog:indices — passed.
- cd docs && npm run docs:build — passed after installing existing docs dependencies in this checkout.

Follow-ups:
- None.
