### PR TITLE
stingray

### DIFF
--- a/.opencode/agents/supervisor.md
+++ b/.opencode/agents/supervisor.md
@@ -271,9 +271,10 @@ When the human asks to build something:
    branch against current `origin/main` (safe merge from `origin/main` when
    behind, resolve conflicts through `implementer` → `reviewer` → pass), verify
    clean tree and required validation, use `systematic-debugging` plus
-   `implementer` → `reviewer` for any validation failure (do not treat
+   `implementer` → `reviewer` → pass for any validation failure (do not treat
    unrelated/flaky/environmental failures as immediate `BLOCKED`), then consult
-   project policy and execute the integration action only when green.
+   project policy and execute the integration action only when green. Do not
+   rebase or force-push unless the human explicitly requests it.
 
 When the human asks to debug something, invoke **systematic-debugging**.
 
@@ -296,7 +297,8 @@ When the human asks to debug something, invoke **systematic-debugging**.
   that progress requires human input (credentials, inaccessible
   infrastructure, unsafe git history decisions, unreproducible behavior
   after reasonable evidence gathering, or a product/API/data/architecture
-  choice).
+  choice). Do not rebase or force-push unless the human
+  explicitly requests it.
 - Never fix code yourself. That's what `implementer` is for.
 
 User instructions (AGENTS.md, direct requests) take precedence over skills,

--- a/.opencode/agents/supervisor.md
+++ b/.opencode/agents/supervisor.md
@@ -176,18 +176,29 @@ changes you didn't route through review, unstage them and route them properly.
 
 After the implementer→reviewer→fix-loop passes, do not report completion yet.
 Commit all reviewed changes, then verify the worktree is clean (`git status`
-shows nothing to commit, nothing staged). Before reporting completion or
-ready-to-merge, you must also complete any verification or finishing checks
-required by the active skill or plan (e.g., running tests, validating with
-finishing-a-development-branch). Only report completion / ready-to-merge
-when the tree is clean, changes are committed, and all required checks have
-passed. If required validation fails, do not report completion and do not stop
-at the failure summary. Invoke `systematic-debugging`, identify the root cause,
-route any fix through `implementer` → `reviewer` → pass, commit reviewed fixes,
-rerun the failed validation, and restart finishing checks from the top. Report
-BLOCKED only when systematic debugging establishes that the failure cannot be
-resolved without human input, is external/environmental, is unreproducible with
-available evidence, or requires a product/API/data/architecture decision.
+shows nothing to commit, nothing staged).
+
+Before reporting completion, ready-to-merge, or ready-to-PR, fetch `origin` and
+verify that the branch has been evaluated against current `origin/main`. If the
+branch is behind `origin/main` or a remote integration action would be rejected,
+do not report completion. Update by a safe merge from `origin/main` when
+permitted, route conflicts or resulting repository fixes through `implementer`
+→ `reviewer` → pass, commit reviewed fixes, rerun required validation, and
+restart finishing checks from the top. Do not rebase or force-push unless the
+human explicitly requests it.
+
+If required validation fails, do not report completion and do not stop at the
+failure summary. Capture the failing command, failing tests, relevant output,
+current branch state, and `git status --porcelain`. Invoke
+`systematic-debugging`, continue investigating even when the failure appears
+unrelated, flaky, timing-dependent, or environmental, identify root cause or the
+limits of available evidence, route any fix through `implementer` → `reviewer`
+→ pass, commit reviewed fixes, rerun validation, and restart finishing checks
+from the top. Report BLOCKED or HUMAN_DECISION_REQUIRED only when systematic
+debugging establishes that progress requires human input: credentials,
+inaccessible infrastructure, unsafe git history decisions, unreproducible
+behavior after reasonable evidence gathering, or a product/API/data/architecture
+choice.
 
 ## Your Subagents
 
@@ -256,10 +267,13 @@ When the human asks to build something:
    dispatch `implementer` per task, `reviewer` after each task, `adjudicator`
    at the fix-loop breaker. Maintain the ledger, manage the workspace.
 
-4. Invoke **finishing-a-development-branch** — verify clean tree and required
-   validation, use `systematic-debugging` plus `implementer` → `reviewer` for
-   any validation failure, then consult project policy and execute the
-   integration action only when green.
+4. Invoke **finishing-a-development-branch** — fetch `origin`, evaluate the
+   branch against current `origin/main` (safe merge from `origin/main` when
+   behind, resolve conflicts through `implementer` → `reviewer` → pass), verify
+   clean tree and required validation, use `systematic-debugging` plus
+   `implementer` → `reviewer` for any validation failure (do not treat
+   unrelated/flaky/environmental failures as immediate `BLOCKED`), then consult
+   project policy and execute the integration action only when green.
 
 When the human asks to debug something, invoke **systematic-debugging**.
 
@@ -271,12 +285,18 @@ When the human asks to debug something, invoke **systematic-debugging**.
 - If a subagent returns BLOCKED or the adjudicator escalates, present to the
   human with a clear summary and recommendation.
 - Do not report completion until all reviewed changes are committed, the
-  worktree is clean, and any verification or finishing checks required by
-  the active skill or plan (e.g., tests, finishing-a-development-branch
-  validation) have passed. If required validation fails, follow the
-  Completion discipline contract (`systematic-debugging`, `implementer` →
-  `reviewer` → pass, rerun validation); report BLOCKED only when systematic
-  debugging establishes an unresolved blocker.
+  worktree is clean, the branch has been evaluated against current
+  `origin/main` (safe merge from `origin/main` when behind, with conflicts
+  routed through `implementer` → `reviewer` → pass), and any verification or
+  finishing checks required by the active skill or plan (e.g., tests,
+  finishing-a-development-branch validation) have passed. If required
+  validation fails, follow the Completion discipline contract
+  (`systematic-debugging`, `implementer` → `reviewer` → pass, rerun
+  validation); report BLOCKED only when systematic debugging establishes
+  that progress requires human input (credentials, inaccessible
+  infrastructure, unsafe git history decisions, unreproducible behavior
+  after reasonable evidence gathering, or a product/API/data/architecture
+  choice).
 - Never fix code yourself. That's what `implementer` is for.
 
 User instructions (AGENTS.md, direct requests) take precedence over skills,

--- a/.opencode/skills/daily-devlog-automation/SKILL.md
+++ b/.opencode/skills/daily-devlog-automation/SKILL.md
@@ -25,10 +25,11 @@ This skill turns a scheduled Orca/OpenCode run into a reviewed, brief devlog PR.
 5. If no entry is warranted, stop without edits, commits, pushes, or PRs.
 6. If an entry is warranted, dispatch `implementer` to write/update the journal entry and regenerate indexes.
 7. Dispatch `reviewer` before commit and before push.
-8. Run validation.
-9. Commit only reviewed devlog automation files.
-10. Push only the dated automation branch.
-11. Open a PR and attempt auto-merge when allowed.
+8. Fetch `origin` and confirm the automation branch has accounted for current `origin/main`. If the branch is behind, safe-merge `origin/main` when permitted, route conflicts or regenerated docs changes through `implementer` → `reviewer` → pass, and rerun validation from a clean tree. Do not rebase or force-push unless the human explicitly requests it.
+9. Run validation.
+10. Commit only reviewed devlog automation files.
+11. Push only the dated automation branch.
+12. Open a PR and attempt auto-merge when allowed.
 
 ## Meaningful Change Filter
 
@@ -56,13 +57,35 @@ The paragraph connects concrete work to current project goals, milestones, or re
 
 Run `cd docs && npm run devlog:indices && npm run docs:build`. Inspect the final diff and require only expected journal/devlog/docs automation files.
 
+## Validation Failure Recovery
+
+If required validation fails, do not commit, push, create a PR, enable
+auto-merge, or report the automation branch as ready. Capture the failing
+command, failing tests or docs build phase, relevant output, current branch
+state, and `git status --porcelain`. Invoke `systematic-debugging` and continue
+investigating even when the failure appears unrelated, flaky,
+timing-dependent, or environmental.
+
+Any repository fix, generated-doc repair, or conflict resolution must go
+through `implementer` → `reviewer` → pass before commit. After reviewed fixes
+are committed and the tree is clean, re-fetch `origin`, recheck current
+`origin/main`, rerun validation, and continue only when validation is green.
+Report BLOCKED or HUMAN_DECISION_REQUIRED only when systematic debugging
+establishes that progress requires credentials, inaccessible infrastructure,
+unsafe git history decisions, unreproducible behavior after reasonable evidence
+gathering, or a product/API/data/architecture choice.
+
 ## Commit, Push, and PR
 
-Commit after review. Push using `git push origin HEAD:refs/heads/automation/daily-devlog/YYYY-MM-DD`. Use `gh pr create --base main --head automation/daily-devlog/YYYY-MM-DD --fill` when authenticated. Verify branch protection, required status checks, and pull-request protection are active before attempting auto-merge (classic protection or rulesets). Inspect the effective branch rules for allowed merge methods, then use the corresponding flag: `gh pr merge --auto --merge automation/daily-devlog/YYYY-MM-DD` when rules allow merge commits (current for this repo), `gh pr merge --auto --squash ...` when rules require squash, or `gh pr merge --auto --rebase ...` when rules require rebase. Do not enable auto-merge merely because `gh` is authenticated. Never push directly to `origin/main`.
+Commit after review. Push using `git push origin HEAD:refs/heads/automation/daily-devlog/YYYY-MM-DD`. Use `gh pr create --base main --head automation/daily-devlog/YYYY-MM-DD --fill` when authenticated. Verify branch protection, required status checks, and pull-request protection are active before attempting auto-merge (classic protection or rulesets). Inspect the effective branch rules for allowed merge methods, then use the corresponding flag: `gh pr merge --auto --merge automation/daily-devlog/YYYY-MM-DD` when rules allow merge commits (current for this repo) or `gh pr merge --auto --squash ...` when rules require squash. If repository rules require a rebase-only merge method, do not enable auto-merge automatically. Report HUMAN_DECISION_REQUIRED because the agent must not rebase unless the human explicitly requests it. Do not enable auto-merge merely because `gh` is authenticated. Never push directly to `origin/main`.
 
 ## Fail-Closed Cases
 
-Stop with a clear BLOCKED summary when the checkout is dirty, credentials are missing, `gh` is unavailable, validation fails, branch protection or required status checks are unavailable or cannot be verified (via classic protection or rulesets/effective branch rules), auto-merge cannot proceed, or the diff includes unexpected files.
+Stop with a clear BLOCKED or HUMAN_DECISION_REQUIRED summary when the checkout
+is dirty, credentials are missing, `gh` is unavailable, branch protection or
+required status checks are unavailable or cannot be verified, auto-merge cannot
+proceed safely, the diff includes unexpected files, or validation remains red
+after systematic debugging establishes a true human-input blocker.
 
 ## Red Flags
 

--- a/.opencode/skills/daily-devlog-automation/SKILL.md
+++ b/.opencode/skills/daily-devlog-automation/SKILL.md
@@ -28,8 +28,9 @@ This skill turns a scheduled Orca/OpenCode run into a reviewed, brief devlog PR.
 8. Fetch `origin` and confirm the automation branch has accounted for current `origin/main`. If the branch is behind, safe-merge `origin/main` when permitted, route conflicts or regenerated docs changes through `implementer` → `reviewer` → pass, and rerun validation from a clean tree. Do not rebase or force-push unless the human explicitly requests it.
 9. Run validation.
 10. Commit only reviewed devlog automation files.
-11. Push only the dated automation branch.
-12. Open a PR and attempt auto-merge when allowed.
+11. Re-fetch `origin` and recheck current `origin/main` before push or PR creation. If the branch is behind, safe-merge `origin/main` when permitted, route conflicts and fixes through `implementer` → `reviewer` → pass, and restart validation from a clean tree. Do not rebase or force-push unless the human explicitly requests it.
+12. Push only the dated automation branch.
+13. Open a PR and attempt auto-merge when allowed.
 
 ## Meaningful Change Filter
 

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -33,7 +33,7 @@ If they want help committing:
 
 If they want to handle it themselves: stop and exit the skill. The branch is not finished.
 
-Never auto-stage or auto-discard. Only allowlisted coordination-artifact files may be committed or discarded here; code changes always go through implementer → reviewer.
+Never auto-stage or auto-discard. Only allowlisted coordination-artifact files may be committed or discarded here; code changes always go through `implementer` → `reviewer` → pass.
 
 ## Step 1: Verify Current Base and Tests
 
@@ -191,6 +191,20 @@ git branch -d <feature-branch>
 ```
 
 ### Option 2: Push and Create PR
+
+Before pushing or creating a PR, re-fetch and recheck the base:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+If the branch is no longer current with `origin/main`, do not push or create a
+PR. Safe-merge `origin/main` when permitted, route conflicts or resulting fixes
+through `implementer` → `reviewer` → pass, commit reviewed fixes, and restart
+from Step 0 so validation runs on the updated branch. If push is rejected
+because the remote/base moved, do not force-push; fetch, update by safe merge
+when permitted, and restart from Step 0.
 
 Push the branch and create the pull request using the forge's tooling. Keep the worktree — the human iterates on PR feedback there.
 

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -7,7 +7,7 @@ description: Use when implementation is complete and reviewed, to run final vali
 
 ## Overview
 
-**Core principle:** Verify clean tree → Verify required validation → If validation fails, debug root cause and route reviewed fixes → Rerun validation until green or blocked → Consult project policy → Detect environment → Execute action (or present options if no policy) → Clean up.
+**Core principle:** Verify clean tree → Verify current `origin/main` base → Verify required validation → If validation fails, debug root cause and route reviewed fixes → Rerun validation from a clean/current-base tree until green or a true human-input blocker is established → Recheck `origin/main` before integration → Consult project policy → Detect environment → Execute action (or present options if no policy) → Clean up.
 
 **Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
 
@@ -35,33 +35,58 @@ If they want to handle it themselves: stop and exit the skill. The branch is not
 
 Never auto-stage or auto-discard. Only allowlisted coordination-artifact files may be committed or discarded here; code changes always go through implementer → reviewer.
 
-## Step 1: Verify Tests
+## Step 1: Verify Current Base and Tests
+
+Fetch the current base and confirm this branch has accounted for it:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+**If the merge-base check exits 0:** Continue to required validation.
+
+**If the merge-base check exits nonzero:** The branch has not incorporated
+current `origin/main`. Do not run final validation yet, and do not rebase or
+force-push. If a safe merge is permitted, run:
+
+```bash
+git merge --no-edit origin/main
+```
+
+If the merge has conflicts, generated-file changes, or code/test/doc changes
+that need repair, route that work through `implementer` → `reviewer` → pass.
+After reviewed fixes are committed and `git status --porcelain` is clean,
+restart this finishing skill from Step 0. If the merge requires a human
+permission or unsafe git-history decision, report HUMAN_DECISION_REQUIRED with
+the exact command and branch state.
 
 Run the project's full test suite. Consult AGENTS.md for the correct test command.
 
 **If tests fail**, integration is forbidden but the branch is not finished.
 Do all of the following:
 
-1. Capture the exact failing command, failing tests, relevant error output, and
-   current `git status --porcelain`.
+1. Capture the exact failing command, failing tests, relevant error output,
+   current branch name, `HEAD`, `origin/main`, merge-base state, and
+   `git status --porcelain`.
 2. Invoke `systematic-debugging` before proposing any fix.
-3. Identify and document the root cause. If root cause cannot be established,
-   continue gathering evidence and debugging. Do not BLOCKED here on unknown
-   root cause alone; only report BLOCKED/HUMAN_DECISION_REQUIRED when
-   systematic debugging establishes one of the enumerated blocker conditions
-   below.
-4. Route any fix through `implementer` → `reviewer` → pass. The supervisor must
-   not edit code, tests, `.opencode/**`, workflow files, or other non-allowlisted
-   files directly.
-5. After reviewed fixes are committed and the tree is clean, rerun this finishing
-   skill from Step 0.
-6. Only continue to Step 2 when the required validation suite passes.
+3. Continue investigating even when the failure appears unrelated, flaky,
+   timing-dependent, or environmental. Those labels are diagnostic information,
+   not a terminal workflow state.
+4. Establish root cause or gather enough evidence to justify why root cause
+   cannot be established with available access.
+5. Route any repository fix through `implementer` → `reviewer` → pass. The
+   supervisor must not edit code, tests, `.opencode/**`, workflow files, or
+   other non-allowlisted files directly.
+6. After reviewed fixes are committed and the tree is clean, rerun this
+   finishing skill from Step 0.
+7. Only continue to Step 2 when the required validation suite passes on a
+   clean tree that has accounted for current `origin/main`.
 
-If systematic debugging establishes that the failure is external/environmental,
-unreproducible with available evidence, or requires a human product/API/data/
-architecture decision, report BLOCKED or HUMAN_DECISION_REQUIRED with the
-evidence. A failure that is merely unrelated to this branch but does not meet
-one of these BLOCKED criteria still requires the standard debug/fix/rerun loop.
+Report `BLOCKED` or `HUMAN_DECISION_REQUIRED` only when systematic debugging
+establishes that progress requires human input: credentials, inaccessible
+infrastructure, unsafe git history decisions, unreproducible behavior after
+reasonable evidence gathering, or a product/API/data/architecture choice.
 Do not push, PR, merge, or clean up while required validation is red.
 
 **If tests pass:** continue to Step 2.
@@ -78,6 +103,21 @@ current branch and create a pull request targeting `main`"):
   1. Confirm the user has not explicitly requested a different integration action.
   2. Confirm the branch is safe for automatic integration (clean tree, tests
      passing — already confirmed in Steps 0–1).
+
+Before any automatic push or PR creation, re-fetch and recheck the base:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+If the branch is no longer current with `origin/main`, do not push or create a
+PR. Safe-merge `origin/main` when permitted, route conflicts or resulting fixes
+through `implementer` → `reviewer` → pass, commit reviewed fixes, and restart
+from Step 0 so validation runs on the updated branch. If push is rejected
+because the remote/base moved, do not force-push; fetch, update by safe merge
+when permitted, and restart from Step 0.
+
   3. If both checks pass: execute the default action automatically (push the
      current branch and create a pull request targeting the base branch).
      Keep the worktree for PR feedback and iteration — do not clean up.
@@ -186,5 +226,7 @@ git worktree prune
 | "Tests passed earlier this session" | Run the suite on the tree you are about to integrate. A green run only proves the tree it ran on. |
 | "They obviously want it merged" | Follow the project's integration policy, not assumptions. If AGENTS.md specifies an automatic action (push + create PR), execute it. Only present the menu when no policy exists or branch-unsafe conditions block the automatic action. |
 | "The base branch is obviously main" | Confirm the fork point or ask. Merging into the wrong base is expensive to undo. |
-| "The push was rejected — force-push will fix it" | A rejected push means the remote moved. Investigate; force-push only on your human partner's explicit request. |
-| "The final suite failed, so I'll just report it and stop" | A red final suite is a debugging task. Invoke `systematic-debugging`, route reviewed fixes through `implementer` → `reviewer`, rerun validation, and finish only when green or explicitly blocked. |
+| "The final suite failed, so I'll just report it and stop" | A red final suite is a debugging task. Invoke `systematic-debugging`, route reviewed fixes through `implementer` → `reviewer` → pass, rerun validation, and finish only when green or explicitly blocked. |
+| "The failure is unrelated/flaky/environmental — nothing to do" | "Unrelated," "flaky," and "environmental" are diagnostic labels, not terminal states. Investigate, gather evidence, and route fixes through `implementer` → `reviewer` → pass. Stop only when systematic debugging establishes a true human-input blocker. |
+| "The branch is behind origin/main — I'll just push anyway" | Do not push, PR, merge, or claim ready-to-merge against a stale base. Safe-merge `origin/main` when permitted, route conflicts through `implementer` → `reviewer` → pass, commit reviewed fixes, and rerun validation from Step 0. |
+| "The push was rejected — force-push will fix it" | A rejected push means the remote moved. Do not force-push. Fetch, update by safe merge from `origin/main` when permitted, resolve conflicts through `implementer` → `reviewer` → pass, and restart from Step 0. Do not rebase or force-push unless the human explicitly requests it. |

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -128,11 +128,23 @@ During final review preparation, triage repeated `constraint obstructed/noisy` n
 
 ## Finish
 
-When final review is clean, use the finishing-a-development-branch skill.
-If finishing validation fails, stay in coordination mode: follow the finishing
-skill's validation-failure loop, invoke `systematic-debugging`, route fixes
-through `implementer` → `reviewer` → pass, rerun validation, and only finish or
-PR when the required suite is green.
+When final review is clean, use the finishing-a-development-branch skill. Do
+not report implementation complete merely because final review passed.
+
+If finishing validation fails, or if the branch is behind current `origin/main`,
+stay in coordination mode. Follow the finishing skill's current-base and
+validation-failure loops: fetch `origin`, safe-merge `origin/main` when
+permitted, invoke `systematic-debugging` for required validation failures,
+continue investigating even when failures appear unrelated, flaky,
+timing-dependent, or environmental, route conflicts and repository fixes
+through `implementer` → `reviewer` → pass, commit reviewed fixes, rerun
+validation, and only finish or create a PR when the required suite is green.
+
+Report BLOCKED or HUMAN_DECISION_REQUIRED only when systematic debugging
+establishes that progress requires credentials, inaccessible infrastructure,
+unsafe git history decisions, unreproducible behavior after reasonable evidence
+gathering, or a product/API/data/architecture choice. Do not rebase or
+force-push unless the human explicitly requests it.
 
 ## Common Rationalizations
 

--- a/.opencode/skills/weekly-agent-workflow-automation/SKILL.md
+++ b/.opencode/skills/weekly-agent-workflow-automation/SKILL.md
@@ -19,7 +19,7 @@ This skill turns a scheduled Orca/OpenCode trigger into a guarded weekly audit o
 ## Workflow
 
 1. `git fetch origin main`.
-2. Create or reset the run branch from `origin/main`: `automation/weekly-agent-workflow/YYYY-Www`.
+2. Create the run branch from `origin/main` (`automation/weekly-agent-workflow/YYYY-Www`) only when it does not already exist. If the branch already exists, switch to it, fetch `origin`, safe-merge `origin/main` when permitted, route conflicts or regenerated docs changes through `implementer` → `reviewer` → pass, and do not reset unless the human explicitly requests it.
 3. Run the analyzer and save sanitized evidence to a local scratch path that is not under `docs/`, for example:
 
    ```bash

--- a/.opencode/skills/weekly-agent-workflow-automation/SKILL.md
+++ b/.opencode/skills/weekly-agent-workflow-automation/SKILL.md
@@ -38,9 +38,11 @@ This skill turns a scheduled Orca/OpenCode trigger into a guarded weekly audit o
 6. Choose only high-confidence improvements with sanitized evidence and clear maintenance value.
 7. Dispatch `implementer` for selected changes. For skill edits, the implementer must use `writing-skills` where practical.
 8. Dispatch `reviewer`; accepted findings go back through implementer and reviewer until the result is pass.
-9. Use `systematic-debugging` for validation failures; do not weaken valid tests or ignore noise.
-10. Inspect the final diff and confirm it contains only reviewed, expected files.
-11. Commit reviewed changes, push the automation branch, create the PR, verify branch protection and required checks, then enable auto-merge only when safe.
+9. Fetch `origin` and confirm the automation branch has accounted for current `origin/main`. If the branch is behind, safe-merge `origin/main` when permitted, route conflicts or regenerated docs changes through `implementer` → `reviewer` → pass, and rerun validation from a clean tree. Do not rebase or force-push unless the human explicitly requests it.
+10. Run validation. Use `systematic-debugging` for validation failures. A validation failure is not an immediate `BLOCKED` condition, even when it appears unrelated, flaky, timing-dependent, or environmental. Capture the failing command, failing tests, relevant output, current branch state, and `git status --porcelain`; establish root cause or the limits of available evidence; route any repository fix through `implementer` → `reviewer` → pass; commit reviewed fixes; re-fetch `origin`; recheck current `origin/main`; and rerun validation until green or a true human-input blocker is established. Do not weaken valid tests or ignore noise.
+11. Inspect the final diff and confirm it contains only reviewed, expected files.
+12. Re-fetch `origin` and recheck current `origin/main` before push or PR creation. If the branch is behind, safe-merge `origin/main` when permitted, route conflicts and fixes through `implementer` → `reviewer` → pass, and restart validation from a clean tree.
+13. Commit reviewed changes, push the automation branch, create the PR, verify branch protection and required checks, then enable auto-merge only when safe.
 
 ## Improvement Selection
 
@@ -84,6 +86,8 @@ SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO
 
 For Fennel-facing changes, follow `AGENTS.md`: `make fennel-check`, constraints, focused tests, then broader suite.
 
+If validation fails, follow the validation failure recovery steps in the Workflow section: invoke `systematic-debugging`, route repository fixes through `implementer` → `reviewer` → pass, commit reviewed fixes, re-fetch `origin`, recheck current `origin/main`, and rerun validation until green or a true human-input blocker is established.
+
 ## Commit, Push, and PR
 
 Commit only after implementer → reviewer → pass and validation. Push with `git push origin HEAD:refs/heads/automation/weekly-agent-workflow/YYYY-Www`. Use `gh pr create --base main --head automation/weekly-agent-workflow/YYYY-Www --fill` when authenticated.
@@ -92,7 +96,12 @@ Before auto-merge, run `gh auth status`, verify protection with `gh api repos/<o
 
 ## Fail-Closed Cases
 
-Stop with BLOCKED when the checkout is dirty, analyzer execution or redaction fails, sanitized evidence is insufficient, raw sensitive data would be needed, branch protection or required checks cannot be verified, GitHub authentication is missing for PR work, validation fails, reviewer does not pass the diff, or unexpected files appear.
+Stop with BLOCKED or HUMAN_DECISION_REQUIRED when the checkout is dirty,
+analyzer execution or redaction fails, sanitized evidence is insufficient, raw
+sensitive data would be needed, branch protection or required checks cannot be
+verified, GitHub authentication is missing for PR work, reviewer does not pass
+the diff, unexpected files appear, or validation remains red after systematic
+debugging establishes a true human-input blocker.
 
 ## Red Flags
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,14 @@ branch reference — not local `main`. Local `main` may be stale or contain
 unrelated local commits. Use local `main` only when explicitly performing a
 local merge or integration operation that requires it.
 
+Before final validation, PR creation, or any ready-to-merge claim, fetch
+`origin` and evaluate the branch against current `origin/main`. If the branch
+is behind `origin/main` or remote integration would be rejected, update the
+feature branch by a safe merge from `origin/main` when permitted, resolve any
+conflicts through `implementer` → `reviewer` → pass, commit reviewed fixes, and
+rerun validation from a clean tree. Do not rebase or force-push unless the human
+explicitly requests it.
+
 After implementation is complete — reviewed, committed, tests passing, tree
 clean — the default integration action is to push the current branch and create a
 pull request targeting `main`. Do this automatically; do not present an
@@ -22,10 +30,16 @@ unsafe (uncommitted changes, failing tests, unresolved merge conflicts with
 `main`).
 
 If required validation fails after implementation, review, or commit, do not
-finish, push, create a pull request, merge, or clean up the branch. Invoke the
-`systematic-debugging` skill, identify the root cause, route any fix through
-`implementer` → `reviewer` → pass, rerun validation, and only proceed with the
-default integration action when the required suite is green.
+finish, push, create a pull request, merge, clean up the branch, or claim
+ready-to-merge. Capture the failing command, failing tests, relevant output,
+current branch state, and `git status --porcelain`. Invoke the
+`systematic-debugging` skill and continue investigating even when the failure
+appears unrelated, flaky, timing-dependent, or environmental. Establish root
+cause or gather enough evidence to explain why root cause cannot be established
+with available access. Route any repository fix through `implementer` →
+`reviewer` → pass, commit reviewed fixes, rerun validation from a clean/current
+`origin/main` base, and only proceed with the default integration action when
+the required suite is green.
 
 ## Project Structure & Modules
 

--- a/docs/dev/features/opencode-agent-workflow.md
+++ b/docs/dev/features/opencode-agent-workflow.md
@@ -44,7 +44,7 @@ Once your agent environment is connected to a Space checkout, these repository c
 
 - **`AGENTS.md`** is the always-on repository guidance. Agents read it on startup and follow its rules for every session. It covers branch conventions, build commands, test invocation, coding style, and project structure.
 - **`.opencode/**`** is the repo-local source for Space agents, skills, and OpenCode configuration. It includes agent definitions, skill files that provide specialized guidance for Fennel, UI, testing, and graph work, and the OpenCode configuration file. This in-repo configuration is canonical for this repository — no separate global config repository is needed.
-- **Restart OpenCode after `.opencode/**` changes.** When you add or modify agents, skills, or configuration under `.opencode/`, restart OpenCode so the updated definitions take effect. OpenCode loads these files at startup and does not hot-reload them.
+- **Restart OpenCode after `.opencode/**` changes.** When you add or modify agents, skills, or configuration under `.opencode/`, restart OpenCode so the updated definitions and workflow instruction changes take effect. OpenCode loads these files at startup and does not hot-reload them.
 - **Follow repository validation expectations from `AGENTS.md`.** Agents must respect the validation ladder: for Fennel work, run compile checks first, then constraints, then focused tests, then the broader suite. Required validation failures are debugging tasks, not items to bypass.
 - **Full Space validation.** When a change touches code that could affect the broader system, run the full test suite:
 
@@ -53,18 +53,40 @@ Once your agent environment is connected to a Space checkout, these repository c
   ```
 
 - **Fennel-facing work** must use the project-native Fennel validation ladder from `AGENTS.md`. Do not use system `fennel`, `fennel-ls`, `fnlfmt`, or ad-hoc evaluation as validation oracles. Use `tools.fennel-check`, constraints, and the test harness instead.
-- **Required validation failures** should be treated as debugging tasks rather than bypassed. When a required suite fails, invoke systematic debugging, identify the root cause, route the fix through implement → review → pass, and only proceed when the suite is green.
+- **Required validation failures**: see [Validation continuation and current base](#validation-continuation-and-current-base) for the full contract.
+
+## Validation continuation and current base
+
+Required validation failures are active debugging work, not a terminal workflow
+state. When a required suite fails, agents capture the failing command, failing
+tests, relevant output, current branch state, and `git status --porcelain`;
+invoke `systematic-debugging`; and continue investigating even when the failure
+appears unrelated, flaky, timing-dependent, or environmental.
+
+Repository fixes, generated-file repairs, and conflict resolutions go through
+`implementer` → `reviewer` → pass before commit. Agents rerun validation from a
+clean tree and proceed only when the required suite is green, or when systematic
+debugging establishes a true human-input blocker such as missing credentials,
+inaccessible infrastructure, an unsafe git-history decision, unreproducible
+behavior after reasonable evidence gathering, or a product/API/data/architecture
+choice.
+
+Before final validation, PR creation, or a ready-to-merge claim, agents fetch
+`origin` and evaluate the branch against current `origin/main`. If the branch is
+behind, they use a safe merge from `origin/main` when permitted, route resulting
+fixes through review, and rerun validation. Agents do not rebase or force-push
+unless the human explicitly requests it.
 
 ## Branch and pull request policy
 
 All agent-driven changes follow these branch and PR rules:
 
 - Pull requests target `main`.
-- Final validation and diff/base checks use `origin/main`, not local `main`. Local `main` may be stale or contain unrelated local commits.
+- Final validation and PR creation require a branch that is current with `origin/main`. Diff/base checks always use `origin/main`, not local `main`. Local `main` may be stale or contain unrelated local commits.
 - After implementation is complete — reviewed, committed, all tests passing, and the tree clean — the default integration action is to push the current branch and create a pull request targeting `main`.
 - Do not push directly to `main`. Always work on a feature branch and open a pull request.
 
-If required validation fails after implementation, review, or commit, do not finish, push, create a PR, merge, or clean up the branch. Debug the failure, fix it through the normal review cycle, and only proceed with integration when the required suite is green.
+If required validation fails after implementation, review, or commit, see [Validation continuation and current base](#validation-continuation-and-current-base). Do not finish, push, create a PR, merge, or clean up the branch while validation is red.
 
 ## Exclusions
 

--- a/docs/plans/2026-08-01-agent-validation-continuation.md
+++ b/docs/plans/2026-08-01-agent-validation-continuation.md
@@ -1,0 +1,563 @@
+# Agent Validation Continuation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every Space/OpenCode workflow continue from required validation failures through systematic debugging, current-base recovery, reviewed fixes, and green validation before integration.
+
+**Architecture:** This is an instruction/workflow-only change. Keep the canonical invariant in `AGENTS.md`, supervisor completion discipline, and the finishing skill; then align daily automation, weekly automation, SDD handoff guidance, and the developer workflow page so no entry point treats red validation as immediate `BLOCKED`.
+
+**Tech Stack:** Markdown, OpenCode agent files, OpenCode skill files, Git/GitHub workflow instructions, focused `rg` and `git diff --check` validation.
+
+## Global Constraints
+
+- Committed spec: `docs/specs/2026-08-01-agent-validation-continuation-design.md`.
+- All Space agent workflows must treat required validation failures as active work to investigate and resolve, not as a terminal state.
+- This applies to normal implementation branches, final finishing, docs/OpenCode branches, daily devlog automation, weekly agent workflow automation, and any future scheduled or manual automation that performs required validation before integration.
+- Preserve integration safety: do not report completion, push, create a PR, merge, clean up, or claim ready-to-merge while validation is red.
+- Capture the failing command, failing tests, relevant output, current branch state, and `git status --porcelain`.
+- Invoke `systematic-debugging` and continue investigating even when the failure appears unrelated, flaky, timing-dependent, or environmental.
+- Route any repository fix through `implementer` → `reviewer` → pass, commit reviewed fixes, rerun validation, and restart finalization from the top.
+- Stop for the human only when systematic debugging establishes that progress requires human input: credentials, inaccessible infrastructure, unsafe git history decisions, unreproducible behavior after reasonable evidence gathering, or a product/API/data/architecture choice.
+- Before final validation and PR creation, workflows must ensure the branch is evaluated against current `origin/main`.
+- If the branch is behind or remote integration would be rejected, fetch `origin`, update the feature branch by a safe merge from `origin/main` when permitted, resolve any conflicts through the normal implementer/reviewer loop, and rerun validation.
+- The agent must not rebase or force-push unless the human explicitly requests it.
+- No production runtime code, product tests, OpenCode schema, package configuration, model settings, or permission frontmatter changes are in scope.
+- OpenCode users must restart after `.opencode/**` changes.
+- Acceptance criterion: every edited workflow surface uses consistent wording for `systematic-debugging`, `implementer` → `reviewer` → pass, `origin/main` freshness, safe merge, no automatic rebase/force-push, and no immediate `BLOCKED` on validation failure.
+- Validation is focused instruction validation: per-task `rg` checks, `git diff --check`, and changed-file scope inspection. Full product tests are not required unless implementation edits production, test, runtime, build, executable script, package, or schema/config files.
+- HUMAN_DECISION_REQUIRED: none for this plan.
+
+---
+
+### Task 1: Repository and Supervisor Validation Invariants
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `.opencode/agents/supervisor.md`
+- Test: focused `rg` checks and `git diff --check` for both files
+
+**Interfaces:**
+- Consumes: committed spec `docs/specs/2026-08-01-agent-validation-continuation-design.md`
+- Produces: repository-wide and supervisor-level invariant for current `origin/main` evaluation and validation-failure recovery
+
+- [ ] **Step 1: Inspect current wording**
+
+Read `AGENTS.md` and `.opencode/agents/supervisor.md`. Confirm the existing target sections are:
+- `AGENTS.md` → `## Branch Convention`
+- `.opencode/agents/supervisor.md` → `Completion discipline`, `## Core Workflow`, and `## Discipline`
+
+- [ ] **Step 2: Add current-base validation rule to `AGENTS.md`**
+
+Under `## Branch Convention`, immediately after the existing paragraph that names `origin/main` as the base for final validation and PR diff/base checks, add:
+
+```markdown
+Before final validation, PR creation, or any ready-to-merge claim, fetch
+`origin` and evaluate the branch against current `origin/main`. If the branch
+is behind `origin/main` or remote integration would be rejected, update the
+feature branch by a safe merge from `origin/main` when permitted, resolve any
+conflicts through `implementer` → `reviewer` → pass, commit reviewed fixes, and
+rerun validation from a clean tree. Do not rebase or force-push unless the human
+explicitly requests it.
+```
+
+- [ ] **Step 3: Strengthen required-validation failure policy in `AGENTS.md`**
+
+Replace the existing paragraph that starts `If required validation fails after implementation` with:
+
+```markdown
+If required validation fails after implementation, review, or commit, do not
+finish, push, create a pull request, merge, clean up the branch, or claim
+ready-to-merge. Capture the failing command, failing tests, relevant output,
+current branch state, and `git status --porcelain`. Invoke the
+`systematic-debugging` skill and continue investigating even when the failure
+appears unrelated, flaky, timing-dependent, or environmental. Establish root
+cause or gather enough evidence to explain why root cause cannot be established
+with available access. Route any repository fix through `implementer` →
+`reviewer` → pass, commit reviewed fixes, rerun validation from a clean/current
+`origin/main` base, and only proceed with the default integration action when
+the required suite is green.
+```
+
+- [ ] **Step 4: Update supervisor completion discipline**
+
+In `.opencode/agents/supervisor.md`, update the `Completion discipline` section so it preserves the existing clean-tree and committed-changes requirements and includes this contract:
+
+```markdown
+Before reporting completion, ready-to-merge, or ready-to-PR, fetch `origin` and
+verify that the branch has been evaluated against current `origin/main`. If the
+branch is behind `origin/main` or a remote integration action would be rejected,
+do not report completion. Update by a safe merge from `origin/main` when
+permitted, route conflicts or resulting repository fixes through `implementer`
+→ `reviewer` → pass, commit reviewed fixes, rerun required validation, and
+restart finishing checks from the top. Do not rebase or force-push unless the
+human explicitly requests it.
+
+If required validation fails, do not report completion and do not stop at the
+failure summary. Capture the failing command, failing tests, relevant output,
+current branch state, and `git status --porcelain`. Invoke
+`systematic-debugging`, continue investigating even when the failure appears
+unrelated, flaky, timing-dependent, or environmental, identify root cause or the
+limits of available evidence, route any fix through `implementer` → `reviewer`
+→ pass, commit reviewed fixes, rerun validation, and restart finishing checks
+from the top. Report BLOCKED or HUMAN_DECISION_REQUIRED only when systematic
+debugging establishes that progress requires human input: credentials,
+inaccessible infrastructure, unsafe git history decisions, unreproducible
+behavior after reasonable evidence gathering, or a product/API/data/architecture
+choice.
+```
+
+Do not change supervisor frontmatter permissions, model, mode, temperature, or tool rules.
+
+- [ ] **Step 5: Align supervisor summaries**
+
+Update the supervisor `## Core Workflow` finishing step and `## Discipline` completion bullet so both reference:
+- current `origin/main` evaluation before completion/integration;
+- `systematic-debugging` for required validation failures;
+- `implementer` → `reviewer` → pass for fixes;
+- no `BLOCKED` unless systematic debugging establishes a true human-input blocker.
+
+- [ ] **Step 6: Run focused validation for Task 1**
+
+```bash
+rg -n "origin/main|safe merge|rebase|force-push|force push|systematic-debugging|implementer.*reviewer|BLOCKED|HUMAN_DECISION_REQUIRED" AGENTS.md .opencode/agents/supervisor.md
+git diff --check AGENTS.md .opencode/agents/supervisor.md
+```
+
+Expected: both files mention current `origin/main` handling, require `systematic-debugging` for red validation, preserve `implementer` → `reviewer` → pass, avoid saying validation failure alone is immediate `BLOCKED`, and have no whitespace errors.
+
+- [ ] **Step 7: Commit Task 1 after reviewer pass**
+
+```bash
+git add AGENTS.md .opencode/agents/supervisor.md
+git commit -m "docs(workflow): strengthen validation continuation policy"
+```
+
+---
+
+### Task 2: Finishing Skill Current-Base and Red-Validation Loop
+
+**Files:**
+- Modify: `.opencode/skills/finishing-a-development-branch/SKILL.md`
+- Test: focused `rg` checks and `git diff --check` for the finishing skill
+
+**Interfaces:**
+- Consumes: Task 1 repository/supervisor invariant
+- Produces: canonical finishing procedure: clean tree → current `origin/main` check → required validation → systematic debugging/reviewed fixes on red → current-base recheck before integration
+
+- [ ] **Step 1: Inspect current finishing flow**
+
+Read `.opencode/skills/finishing-a-development-branch/SKILL.md`. Confirm the existing flow has `Step 0: Verify Clean Working Tree`, `Step 1: Verify Tests`, `Step 2: Consult Project Policy`, and the common rationalizations table.
+
+- [ ] **Step 2: Update the core principle**
+
+Replace the current core principle sentence with:
+
+```markdown
+**Core principle:** Verify clean tree → Verify current `origin/main` base → Verify required validation → If validation fails, debug root cause and route reviewed fixes → Rerun validation from a clean/current-base tree until green or a true human-input blocker is established → Recheck `origin/main` before integration → Consult project policy → Detect environment → Execute action (or present options if no policy) → Clean up.
+```
+
+- [ ] **Step 3: Rename and expand Step 1**
+
+Rename `## Step 1: Verify Tests` to:
+
+```markdown
+## Step 1: Verify Current Base and Tests
+```
+
+At the start of Step 1, before running the full suite, add:
+
+````markdown
+Fetch the current base and confirm this branch has accounted for it:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+**If the merge-base check exits 0:** Continue to required validation.
+
+**If the merge-base check exits nonzero:** The branch has not incorporated
+current `origin/main`. Do not run final validation yet, and do not rebase or
+force-push. If a safe merge is permitted, run:
+
+```bash
+git merge --no-edit origin/main
+```
+
+If the merge has conflicts, generated-file changes, or code/test/doc changes
+that need repair, route that work through `implementer` → `reviewer` → pass.
+After reviewed fixes are committed and `git status --porcelain` is clean,
+restart this finishing skill from Step 0. If the merge requires a human
+permission or unsafe git-history decision, report HUMAN_DECISION_REQUIRED with
+the exact command and branch state.
+````
+
+- [ ] **Step 4: Strengthen Step 1 validation-failure recovery**
+
+In the failed-tests branch of Step 1, ensure the recovery list includes:
+
+```markdown
+1. Capture the exact failing command, failing tests, relevant error output,
+   current branch name, `HEAD`, `origin/main`, merge-base state, and
+   `git status --porcelain`.
+2. Invoke `systematic-debugging` before proposing any fix.
+3. Continue investigating even when the failure appears unrelated, flaky,
+   timing-dependent, or environmental. Those labels are diagnostic information,
+   not a terminal workflow state.
+4. Establish root cause or gather enough evidence to justify why root cause
+   cannot be established with available access.
+5. Route any repository fix through `implementer` → `reviewer` → pass. The
+   supervisor must not edit code, tests, `.opencode/**`, workflow files, or
+   other non-allowlisted files directly.
+6. After reviewed fixes are committed and the tree is clean, rerun this
+   finishing skill from Step 0.
+7. Only continue to Step 2 when the required validation suite passes on a
+   clean tree that has accounted for current `origin/main`.
+```
+
+Ensure the blocker paragraph says `BLOCKED` or `HUMAN_DECISION_REQUIRED` is allowed only when systematic debugging establishes credentials, inaccessible infrastructure, unsafe git history decisions, unreproducible behavior after reasonable evidence gathering, or product/API/data/architecture choice.
+
+- [ ] **Step 5: Add current-base recheck before automatic integration**
+
+In `Step 2: Consult Project Policy`, before executing default push/PR action, add:
+
+````markdown
+Before any automatic push or PR creation, re-fetch and recheck the base:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+If the branch is no longer current with `origin/main`, do not push or create a
+PR. Safe-merge `origin/main` when permitted, route conflicts or resulting fixes
+through `implementer` → `reviewer` → pass, commit reviewed fixes, and restart
+from Step 0 so validation runs on the updated branch. If push is rejected
+because the remote/base moved, do not force-push; fetch, update by safe merge
+when permitted, and restart from Step 0.
+````
+
+- [ ] **Step 6: Update common rationalizations**
+
+Ensure the common rationalizations table includes rows covering:
+- final suite failure is a debugging task, not a stop point;
+- “unrelated/environmental/flaky” does not mean no investigation;
+- rejected push does not authorize force-push;
+- branch behind `origin/main` requires safe merge and rerun, not stale validation.
+
+- [ ] **Step 7: Run focused validation for Task 2**
+
+```bash
+rg -n "Verify Current Base|git fetch origin main|merge-base --is-ancestor origin/main HEAD|git merge --no-edit origin/main|systematic-debugging|unrelated|flaky|environmental|implementer.*reviewer|rebase|force-push|HUMAN_DECISION_REQUIRED|BLOCKED" .opencode/skills/finishing-a-development-branch/SKILL.md
+git diff --check .opencode/skills/finishing-a-development-branch/SKILL.md
+```
+
+Expected: finishing checks current `origin/main` before validation and push/PR, safe merge is the only automatic update path, automatic rebase/force-push are forbidden, validation failures enter `systematic-debugging`, and no whitespace errors exist.
+
+- [ ] **Step 8: Commit Task 2 after reviewer pass**
+
+```bash
+git add .opencode/skills/finishing-a-development-branch/SKILL.md
+git commit -m "docs(workflow): require current-base finishing validation"
+```
+
+---
+
+### Task 3: Daily and Weekly Automation Recovery Alignment
+
+**Files:**
+- Modify: `.opencode/skills/daily-devlog-automation/SKILL.md`
+- Modify: `.opencode/skills/weekly-agent-workflow-automation/SKILL.md`
+- Test: focused `rg` checks and `git diff --check` for both automation skills
+
+**Interfaces:**
+- Consumes: Task 1 invariant and Task 2 finishing recovery contract
+- Produces: automation instructions that do not treat validation failure as immediate `BLOCKED`, verify current `origin/main`, and avoid automatic rebase/force-push
+
+- [ ] **Step 1: Inspect current automation failure wording**
+
+Read both automation skills. Confirm daily has `## Validation`, `## Commit, Push, and PR`, and `## Fail-Closed Cases`; weekly has `## Workflow`, `## Validation`, `## Commit, Push, and PR`, and `## Fail-Closed Cases`.
+
+- [ ] **Step 2: Add daily current-base check before validation and PR**
+
+In `.opencode/skills/daily-devlog-automation/SKILL.md`, update the workflow so before validation and before push/PR it requires:
+
+```markdown
+Fetch `origin` and confirm the automation branch has accounted for current
+`origin/main`. If the branch is behind, safe-merge `origin/main` when
+permitted, route conflicts or regenerated docs changes through `implementer` →
+`reviewer` → pass, and rerun validation from a clean tree. Do not rebase or
+force-push unless the human explicitly requests it.
+```
+
+- [ ] **Step 3: Add daily validation-failure recovery section**
+
+Add this section after `## Validation`:
+
+```markdown
+## Validation Failure Recovery
+
+If required validation fails, do not commit, push, create a PR, enable
+auto-merge, or report the automation branch as ready. Capture the failing
+command, failing tests or docs build phase, relevant output, current branch
+state, and `git status --porcelain`. Invoke `systematic-debugging` and continue
+investigating even when the failure appears unrelated, flaky,
+timing-dependent, or environmental.
+
+Any repository fix, generated-doc repair, or conflict resolution must go
+through `implementer` → `reviewer` → pass before commit. After reviewed fixes
+are committed and the tree is clean, re-fetch `origin`, recheck current
+`origin/main`, rerun validation, and continue only when validation is green.
+Report BLOCKED or HUMAN_DECISION_REQUIRED only when systematic debugging
+establishes that progress requires credentials, inaccessible infrastructure,
+unsafe git history decisions, unreproducible behavior after reasonable evidence
+gathering, or a product/API/data/architecture choice.
+```
+
+- [ ] **Step 4: Remove daily immediate validation-failure fail-closed wording**
+
+In daily `## Fail-Closed Cases`, remove validation failure as an immediate stop condition. Replace fail-closed wording with:
+
+```markdown
+Stop with a clear BLOCKED or HUMAN_DECISION_REQUIRED summary when the checkout
+is dirty, credentials are missing, `gh` is unavailable, branch protection or
+required status checks are unavailable or cannot be verified, auto-merge cannot
+proceed safely, the diff includes unexpected files, or validation remains red
+after systematic debugging establishes a true human-input blocker.
+```
+
+- [ ] **Step 5: Remove daily automatic rebase auto-merge option**
+
+In daily `## Commit, Push, and PR`, remove any instruction to use `gh pr merge --auto --rebase` automatically. Replace it with:
+
+```markdown
+If repository rules require a rebase-only merge method, do not enable
+auto-merge automatically. Report HUMAN_DECISION_REQUIRED because the agent must
+not rebase unless the human explicitly requests it.
+```
+
+- [ ] **Step 6: Strengthen weekly current-base and validation recovery wording**
+
+In `.opencode/skills/weekly-agent-workflow-automation/SKILL.md`, update workflow and validation sections so they require fetch/recheck current `origin/main` before validation and push/PR, safe merge from `origin/main` when permitted, conflict/fix routing through `implementer` → `reviewer` → pass, and no automatic rebase or force-push. Use this paragraph where weekly discusses validation failures:
+
+```markdown
+Use `systematic-debugging` for validation failures. A validation failure is not
+an immediate `BLOCKED` condition, even when it appears unrelated, flaky,
+timing-dependent, or environmental. Capture the failing command, failing tests,
+relevant output, current branch state, and `git status --porcelain`; establish
+root cause or the limits of available evidence; route any repository fix
+through `implementer` → `reviewer` → pass; commit reviewed fixes; re-fetch
+`origin`; recheck current `origin/main`; and rerun validation until green or a
+true human-input blocker is established.
+```
+
+- [ ] **Step 7: Update weekly fail-closed cases**
+
+In weekly `## Fail-Closed Cases`, replace immediate validation-failure blocking with:
+
+```markdown
+Stop with BLOCKED or HUMAN_DECISION_REQUIRED when the checkout is dirty,
+analyzer execution or redaction fails, sanitized evidence is insufficient, raw
+sensitive data would be needed, branch protection or required checks cannot be
+verified, GitHub authentication is missing for PR work, reviewer does not pass
+the diff, unexpected files appear, or validation remains red after systematic
+debugging establishes a true human-input blocker.
+```
+
+- [ ] **Step 8: Run focused validation for Task 3**
+
+```bash
+rg -n "systematic-debugging|origin/main|safe-merge|safe merge|implementer.*reviewer|BLOCKED|HUMAN_DECISION_REQUIRED|rebase|force-push|force push|validation remains red|immediate `BLOCKED`" .opencode/skills/daily-devlog-automation/SKILL.md .opencode/skills/weekly-agent-workflow-automation/SKILL.md
+git diff --check .opencode/skills/daily-devlog-automation/SKILL.md .opencode/skills/weekly-agent-workflow-automation/SKILL.md
+```
+
+Expected: daily and weekly both contain validation recovery loops, fail-closed cases no longer list validation failure alone as terminal, daily no longer authorizes automatic `gh pr merge --auto --rebase`, both skills forbid automatic rebase/force-push, and no whitespace errors exist.
+
+- [ ] **Step 9: Commit Task 3 after reviewer pass**
+
+```bash
+git add .opencode/skills/daily-devlog-automation/SKILL.md .opencode/skills/weekly-agent-workflow-automation/SKILL.md
+git commit -m "docs(workflow): align automation validation recovery"
+```
+
+---
+
+### Task 4: SDD Handoff and Developer Workflow Documentation
+
+**Files:**
+- Modify: `.opencode/skills/subagent-driven-development/SKILL.md`
+- Modify: `docs/dev/features/opencode-agent-workflow.md`
+- Test: focused `rg` checks and `git diff --check` for both files
+
+**Interfaces:**
+- Consumes: Tasks 1–3 validation continuation contract
+- Produces: SDD finishing handoff remains in coordination mode, and collaborator docs describe the all-workflows rule
+
+- [ ] **Step 1: Update SDD finish handoff**
+
+In `.opencode/skills/subagent-driven-development/SKILL.md`, replace the `## Finish` section with:
+
+```markdown
+## Finish
+
+When final review is clean, use the finishing-a-development-branch skill. Do
+not report implementation complete merely because final review passed.
+
+If finishing validation fails, or if the branch is behind current `origin/main`,
+stay in coordination mode. Follow the finishing skill's current-base and
+validation-failure loops: fetch `origin`, safe-merge `origin/main` when
+permitted, invoke `systematic-debugging` for required validation failures,
+continue investigating even when failures appear unrelated, flaky,
+timing-dependent, or environmental, route conflicts and repository fixes
+through `implementer` → `reviewer` → pass, commit reviewed fixes, rerun
+validation, and only finish or create a PR when the required suite is green.
+
+Report BLOCKED or HUMAN_DECISION_REQUIRED only when systematic debugging
+establishes that progress requires credentials, inaccessible infrastructure,
+unsafe git history decisions, unreproducible behavior after reasonable evidence
+gathering, or a product/API/data/architecture choice. Do not rebase or
+force-push unless the human explicitly requests it.
+```
+
+- [ ] **Step 2: Add developer docs section for validation continuation**
+
+In `docs/dev/features/opencode-agent-workflow.md`, add this section before `## Branch and pull request policy`:
+
+```markdown
+## Validation continuation and current base
+
+Required validation failures are active debugging work, not a terminal workflow
+state. When a required suite fails, agents capture the failing command, failing
+tests, relevant output, current branch state, and `git status --porcelain`;
+invoke `systematic-debugging`; and continue investigating even when the failure
+appears unrelated, flaky, timing-dependent, or environmental.
+
+Repository fixes, generated-file repairs, and conflict resolutions go through
+`implementer` → `reviewer` → pass before commit. Agents rerun validation from a
+clean tree and proceed only when the required suite is green, or when systematic
+debugging establishes a true human-input blocker such as missing credentials,
+inaccessible infrastructure, an unsafe git-history decision, unreproducible
+behavior after reasonable evidence gathering, or a product/API/data/architecture
+choice.
+
+Before final validation, PR creation, or a ready-to-merge claim, agents fetch
+`origin` and evaluate the branch against current `origin/main`. If the branch is
+behind, they use a safe merge from `origin/main` when permitted, route resulting
+fixes through review, and rerun validation. Agents do not rebase or force-push
+unless the human explicitly requests it.
+```
+
+- [ ] **Step 3: Update existing docs bullets to avoid drift**
+
+In `docs/dev/features/opencode-agent-workflow.md`:
+- update the existing `Required validation failures` bullet so it points to the new section instead of restating a weaker rule;
+- update `## Branch and pull request policy` so it says final validation and PR creation require current `origin/main`;
+- ensure the page says OpenCode must be restarted after `.opencode/**` changes for workflow instruction changes to take effect.
+
+- [ ] **Step 4: Run focused validation for Task 4**
+
+```bash
+rg -n "Validation continuation|systematic-debugging|origin/main|safe merge|implementer.*reviewer|BLOCKED|HUMAN_DECISION_REQUIRED|rebase|force-push|restart" .opencode/skills/subagent-driven-development/SKILL.md docs/dev/features/opencode-agent-workflow.md
+git diff --check .opencode/skills/subagent-driven-development/SKILL.md docs/dev/features/opencode-agent-workflow.md
+```
+
+Expected: SDD finish handoff explicitly stays in coordination mode, docs page documents all-workflows validation continuation and current-base behavior, docs page mentions OpenCode restart after `.opencode/**` changes, and no whitespace errors exist.
+
+- [ ] **Step 5: Commit Task 4 after reviewer pass**
+
+```bash
+git add .opencode/skills/subagent-driven-development/SKILL.md docs/dev/features/opencode-agent-workflow.md
+git commit -m "docs(workflow): document validation continuation handoff"
+```
+
+---
+
+### Task 5: Focused Final Validation and Review Gate
+
+**Files:**
+- Test: all files modified by Tasks 1–4 plus the committed spec and plan files
+
+**Interfaces:**
+- Consumes: committed changes from Tasks 1–4
+- Produces: final validation evidence that instruction surfaces are consistent and no out-of-scope files changed
+
+- [ ] **Step 1: Confirm changed-file scope**
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Expected changed files are limited to:
+
+```text
+AGENTS.md
+.opencode/agents/supervisor.md
+.opencode/skills/finishing-a-development-branch/SKILL.md
+.opencode/skills/daily-devlog-automation/SKILL.md
+.opencode/skills/weekly-agent-workflow-automation/SKILL.md
+.opencode/skills/subagent-driven-development/SKILL.md
+docs/dev/features/opencode-agent-workflow.md
+docs/specs/2026-08-01-agent-validation-continuation-design.md
+docs/plans/2026-08-01-agent-validation-continuation.md
+```
+
+If production, runtime test, build, executable script, package, OpenCode schema/config, or unexpected generated files appear, stop and expand validation before finishing.
+
+- [ ] **Step 2: Run complete focused whitespace validation**
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 3: Run complete focused wording validation**
+
+```bash
+FILES="AGENTS.md .opencode/agents/supervisor.md .opencode/skills/finishing-a-development-branch/SKILL.md .opencode/skills/daily-devlog-automation/SKILL.md .opencode/skills/weekly-agent-workflow-automation/SKILL.md .opencode/skills/subagent-driven-development/SKILL.md docs/dev/features/opencode-agent-workflow.md"
+
+rg -n "systematic-debugging" $FILES
+rg -n "implementer.*reviewer|implementer` → `reviewer" $FILES
+rg -n "origin/main" $FILES
+rg -n "safe merge|safe-merge|merge from `origin/main`|git merge --no-edit origin/main" $FILES
+rg -n "rebase|force-push|force push" $FILES
+rg -n "BLOCKED|HUMAN_DECISION_REQUIRED" $FILES
+rg -n "unrelated|flaky|timing-dependent|environmental" $FILES
+```
+
+Expected: every edited workflow surface has `systematic-debugging` where validation failure is discussed; every fix path uses `implementer` → `reviewer` → pass; current-base behavior consistently names `origin/main`; safe merge is allowed when permitted; automatic rebase and force-push are forbidden; `BLOCKED`/`HUMAN_DECISION_REQUIRED` are reserved for true human-input blockers; unrelated/flaky/timing-dependent/environmental failures are not terminal by themselves.
+
+- [ ] **Step 4: Inspect automation fail-closed wording**
+
+```bash
+rg -n -C 4 "Fail-Closed|validation fails|validation failure|validation remains red|immediate `BLOCKED`|HUMAN_DECISION_REQUIRED" .opencode/skills/daily-devlog-automation/SKILL.md .opencode/skills/weekly-agent-workflow-automation/SKILL.md
+```
+
+Expected: daily and weekly fail-closed cases do not say validation failure alone is immediate `BLOCKED`; both skills say validation remains red only after systematic debugging establishes a true blocker.
+
+- [ ] **Step 5: Run final whole-branch review**
+
+Dispatch `reviewer` in FULL REVIEW MODE with the complete branch diff. Review expectations:
+- confirm spec coverage for all target surfaces;
+- confirm consistent wording around `systematic-debugging`;
+- confirm every repository fix path uses `implementer` → `reviewer` → pass;
+- confirm `origin/main` freshness is required before final validation and PR creation;
+- confirm safe merge is the only default base-update mechanism;
+- confirm no automatic rebase or force-push is authorized;
+- confirm no workflow reports immediate `BLOCKED` on validation failure alone;
+- confirm no out-of-scope files changed.
+
+- [ ] **Step 6: Commit validation fixes only if reviewer required changes**
+
+If the final reviewer requires wording fixes, route them through `implementer` → `reviewer` → pass, rerun Steps 1–4, then commit with:
+
+```bash
+git add AGENTS.md .opencode/agents/supervisor.md .opencode/skills/finishing-a-development-branch/SKILL.md .opencode/skills/daily-devlog-automation/SKILL.md .opencode/skills/weekly-agent-workflow-automation/SKILL.md .opencode/skills/subagent-driven-development/SKILL.md docs/dev/features/opencode-agent-workflow.md
+git commit -m "docs(workflow): align validation continuation wording"
+```
+
+If no fixes are required, create no additional commit.
+
+- [ ] **Step 7: Finish with focused validation only**
+
+Do not run full product tests for this instruction/workflow-only change. Full product tests become required only if implementation changed production code, tests, runtime assets, build files, executable scripts, package files, OpenCode schema/config, or executable workflow files.

--- a/docs/specs/2026-08-01-agent-validation-continuation-design.md
+++ b/docs/specs/2026-08-01-agent-validation-continuation-design.md
@@ -1,0 +1,166 @@
+# Agent Validation Continuation Design
+
+## Context
+
+Agents sometimes stop after final validation fails with a message that the
+failure is unrelated to the current branch, flaky, environmental, or caused by a
+known runtime suite issue. That behavior leaves the branch unfinished even though
+the next useful action is usually still agent-owned: investigate the failing
+suite, identify the root cause, fix the underlying issue when possible, update
+the branch from `origin/main` when needed, rerun validation, and continue toward
+the normal integration action.
+
+The repository already has a validation-failure recovery policy for normal
+development finishing, but workflow-specific instructions still leave loopholes:
+automation workflows can treat validation failure as `BLOCKED`, the finalization
+path does not explicitly require checking whether the branch is behind
+`origin/main`, and “unrelated” or “environmental” can be read as a reason to stop
+before attempting a clean recovery.
+
+## Requirement
+
+All Space agent workflows must treat required validation failures as active work
+to investigate and resolve, not as a terminal state. This applies to normal
+implementation branches, final finishing, docs/OpenCode branches, daily devlog
+automation, weekly agent workflow automation, and any future scheduled or manual
+automation that performs required validation before integration.
+
+When required validation fails, the agent must:
+
+1. Preserve integration safety: do not report completion, push, create a PR,
+   merge, clean up, or claim ready-to-merge while validation is red.
+2. Capture the failing command, failing tests, relevant output, current branch
+   state, and `git status --porcelain`.
+3. Invoke `systematic-debugging` and continue investigating even when the failure
+   appears unrelated, flaky, timing-dependent, or environmental.
+4. Establish root cause or gather enough evidence to justify why root cause
+   cannot be established with available access.
+5. Route any repository fix through `implementer` → `reviewer` → pass, commit
+   reviewed fixes, rerun validation, and restart finalization from the top.
+6. Stop for the human only when systematic debugging establishes that progress
+   requires human input: credentials, inaccessible infrastructure, unsafe git
+   history decisions, unreproducible behavior after reasonable evidence
+   gathering, or a product/API/data/architecture choice.
+
+Additionally, before final validation and PR creation, workflows must ensure the
+branch is evaluated against current `origin/main`. If the branch is behind or
+remote integration would be rejected, the agent should fetch `origin`, update the
+feature branch by a safe merge from `origin/main` when permitted, resolve any
+conflicts through the normal implementer/reviewer loop, and rerun validation. The
+agent must not rebase or force-push unless the human explicitly requests it.
+
+## Approaches Considered
+
+### Approach A: Update only `finishing-a-development-branch`
+
+This would improve the normal implementation path but leave scheduled automation
+skills and other workflow entry points with different failure semantics. Agents
+could still stop early in daily/weekly automation because those skills currently
+name validation failure as a `BLOCKED` condition.
+
+### Approach B: Patch every workflow independently
+
+This covers more entry points, but each skill would own its own variant of the
+recovery loop. Over time those variants can drift, especially around what counts
+as environmental, how much evidence is enough, and whether `origin/main` must be
+checked before final validation.
+
+### Approach C: Centralize the invariant and update all entry points
+
+This is the recommended approach. Keep the canonical policy in repository-wide
+guidance and the finishing skill, then make daily/weekly automation and related
+workflow docs defer to the same recovery contract. Add explicit current-base
+handling so final validation happens on a branch that has accounted for current
+`origin/main`.
+
+## Design
+
+### Architecture
+
+The workflow change is instruction-only. It updates the layers agents consult at
+different moments:
+
+- `AGENTS.md`: repository-wide invariant for all workflows: validation failure
+  means debug/fix/rerun, and all final validation is against current
+  `origin/main` state.
+- `.opencode/agents/supervisor.md`: completion discipline and core workflow
+  rules, including the distinction between “appears unrelated” and “cannot
+  proceed without human input.”
+- `.opencode/skills/finishing-a-development-branch/SKILL.md`: concrete final
+  validation loop, with a safe `origin/main` freshness check before required
+  validation and before automatic PR creation.
+- `.opencode/skills/daily-devlog-automation/SKILL.md`: remove validation failure
+  as an automatic terminal blocker; failed validation enters the shared recovery
+  loop.
+- `.opencode/skills/weekly-agent-workflow-automation/SKILL.md`: same recovery
+  loop and current-base expectation for weekly automation.
+- `.opencode/skills/subagent-driven-development/SKILL.md`: reinforce that the
+  finishing handoff stays in coordination mode until validation is green or a
+  true human-input blocker is established.
+- `docs/dev/features/opencode-agent-workflow.md`: document the all-workflows
+  expectation for collaborators.
+
+No production runtime code, product tests, OpenCode schema, or package
+configuration changes are in scope.
+
+### Data Flow
+
+1. A workflow reaches finalization with reviewed, committed changes.
+2. The agent verifies a clean tree and fetches current `origin/main`.
+3. If the feature branch is behind or has not incorporated current base changes,
+   the agent performs a safe merge from `origin/main` when allowed. Merge
+   conflicts or resulting code/test changes go through `implementer` →
+   `reviewer` → pass.
+4. The agent runs required validation.
+5. A red validation result creates a systematic-debugging task. Root cause may be
+   in the branch, in upstream changes, in flaky timing, in the test harness, in
+   environment setup, or in external services; all are investigated.
+6. Repository fixes are implemented and reviewed, then committed.
+7. The agent reruns from clean-tree/current-base validation until green.
+8. Only after green validation does the workflow perform its default integration
+   action, such as pushing and creating a PR.
+
+### Error Handling
+
+The instructions must avoid weakening safety gates:
+
+- Do not bypass, skip, xfail, or reduce required validation to make a branch
+  mergeable.
+- Do not label a failure `BLOCKED` merely because it appears unrelated to the
+  branch. “Unrelated” is diagnostic information; it does not end the workflow.
+- Do not label flaky or timing-dependent failures `BLOCKED` until the agent has
+  attempted to reproduce, isolate, and fix the flake or test harness problem.
+- Do not perform rebases, force pushes, destructive resets, or broad cleanup as
+  automatic recovery steps.
+- Do not ask the human to choose whether to investigate required validation
+  failures; investigation is the default. Ask only for credentials, permissions,
+  unsafe git-history decisions, unavailable infrastructure, or true product/API/
+  data/architecture choices.
+
+### Testing
+
+Because this is an instruction/workflow change, validation should focus on the
+edited instruction surface:
+
+- Review edited files for consistent wording that required validation failures
+  enter `systematic-debugging`, even when apparently unrelated/flaky/
+  environmental.
+- Confirm daily and weekly automation no longer treat validation failure as an
+  immediate `BLOCKED` condition.
+- Confirm current-base handling uses `origin/main`, allows safe merge, forbids
+  automatic rebase/force-push, and requires rerunning validation after base
+  updates.
+- Run `git diff --check`.
+- Run focused text searches over edited files for `systematic-debugging`,
+  `origin/main`, `BLOCKED`, `implementer`, and `reviewer`.
+- A full product test suite is not required unless implementation edits runtime
+  code, tests, build files, or executable scripts.
+
+## Self-Review Notes
+
+- No placeholders remain.
+- The scope covers all current agent workflows, including daily and weekly
+  automation.
+- The design preserves reviewed-fix discipline and does not authorize supervisor
+  edits to non-allowlisted files.
+- The `origin/main` update rule avoids rebase and force-push by default.


### PR DESCRIPTION
- **docs: add agent validation continuation spec**
- **docs: add implementation plan for agent validation continuation**
- **docs(workflow): strengthen validation continuation policy**
- **fix(workflow): add missing → pass and no-rebase/force-push to supervisor summaries**
- **docs(workflow): require current-base finishing validation**
- **fix(workflow): add origin/main recheck to menu PR path and add pass gate to dirty-tree rule**
- **docs(workflow): align automation validation recovery**
- **docs(workflow): add daily pre-push origin/main recheck**
- **docs(workflow): document validation continuation handoff**
- **docs(weekly-automation): remove destructive branch reset authorization**
