### PR TITLE
docs: document Orca worktree build warm-start

### DIFF
--- a/docs/dev/building.md
+++ b/docs/dev/building.md
@@ -159,6 +159,11 @@ The full profile configures with `-DSPACE_BUILD_PROFILE=full -DSPACE_ENABLE_CEF=
 To run the app directly, use `./build/space -m main`.
 By default, `./build/space` also starts the main app; use `./build/space --repl` for the embedded Fennel REPL.
 
+If you create fresh `git worktree`s for agent-driven development, you can
+warm the build directory from a cached main-checkout build to skip the
+initial full compile. See [OpenCode Agent Workflow](features/opencode-agent-workflow.md#optional-warm-new-worktrees-from-the-main-build)
+for the setup script and caveats.
+
 ### Runtime asset discovery
 
 Direct binary execution is supported from arbitrary working directories. After a normal build, assets are copied next to the executable at `build/assets`, so commands such as this work even outside the repository root:

--- a/docs/dev/features/opencode-agent-workflow.md
+++ b/docs/dev/features/opencode-agent-workflow.md
@@ -32,6 +32,124 @@ If you choose the local-Orca-plus-remote-SSH setup, work through these points:
 7. **Rely on the checked-out repository.** Once the checkout is opened, the agent reads `AGENTS.md` and `.opencode/**` from the repository itself — no external configuration repository is needed.
 8. **Final checks.** Run `command -v git node npm clangd opencode` on the remote VM to confirm the expected tools are available, then verify SSH connectivity with `ssh -T git@github.com`.
 
+### Optional: warm new worktrees from the main build
+
+When creating a fresh `git worktree` for agent-driven work, you can warm the
+new worktree from a cached main-checkout build instead of running a full
+`make build` from scratch. This is a cache warm-start, not a substitute for
+validation; agents must still run the normal Space validation ladder.
+
+**When to use:** Run only on a freshly created, clean worktree before any
+agent edits begin. The script assumes the same machine and toolchain as the
+main checkout and a valid, up-to-date main-checkout build directory.
+
+**When not to use:** Skip this on worktrees that already contain divergent
+changes, or when the main-checkout build may be stale relative to the target
+branch. If anything behaves unexpectedly after warming, delete the copied
+build directory and run `make build`.
+
+The script copies build artifacts from the main checkout's `build/` directory
+into the new worktree, then rewrites CMake-generated absolute paths (source and
+build directories) to point at the new worktree. After repathing, it re-runs
+`cmake` so generated files are refreshed for the new location, then builds the
+main target. It preserves the build profile and CEF settings from the main
+checkout's cache.
+
+**Safety notes:**
+- Run only for a freshly created, clean worktree before agent work begins.
+- Assumes the same machine/toolchain and a valid main-checkout `build/`.
+- Does not copy credentials. Repaths only generated text files; binary
+  artifacts are skipped (detected by the presence of null bytes).
+- Re-runs `cmake` after rewriting the cache so CMake refreshes generated
+  files for the new worktree.
+- Copies build files with fresh mtimes (`rsync --no-times`) so copied
+  artifacts appear newer than checkout files. On a divergent branch this
+  can hide needed rebuilds, which is why the clean-worktree caveat matters.
+  As a safety measure, the script compares source/destination HEAD and
+  touches tracked files that differ.
+
+Paste the script below into Orca's per-project or per-worktree setup step.
+Adjust the `SPACE_MAIN_CHECKOUT` and `ORCA_WORKTREE` environment variables
+(or the script's default paths) to match your environment.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+main_checkout="${SPACE_MAIN_CHECKOUT:-$HOME/space/space}"
+worktree="${ORCA_WORKTREE:-$PWD}"
+main_checkout="$(cd "$main_checkout" && pwd)"
+worktree="$(cd "$worktree" && pwd)"
+
+if [ "$main_checkout" = "$worktree" ]; then
+  echo "Refusing to seed the main checkout from itself: $worktree" >&2
+  exit 1
+fi
+
+src_build="$main_checkout/build"
+dst_build="$worktree/build"
+
+if [ ! -f "$src_build/CMakeCache.txt" ]; then
+  echo "No reusable build cache at $src_build; run make build in $main_checkout first." >&2
+  exit 1
+fi
+
+if [ -n "$(git -C "$worktree" status --porcelain)" ]; then
+  echo "Worktree is not clean; run this only before agent edits begin." >&2
+  exit 1
+fi
+
+mkdir -p "$dst_build"
+rsync -a --delete --no-times \
+  --exclude '/logs/' \
+  --exclude '/Testing/Temporary/' \
+  "$src_build/" "$dst_build/"
+
+python3 - "$main_checkout" "$worktree" <<'PY'
+import sys
+from pathlib import Path
+
+old_src = Path(sys.argv[1]).resolve()
+new_src = Path(sys.argv[2]).resolve()
+old_build = old_src / "build"
+new_build = new_src / "build"
+replacements = [
+    (str(old_build).encode(), str(new_build).encode()),
+    (str(old_src).encode(), str(new_src).encode()),
+]
+
+for path in new_build.rglob("*"):
+    if not path.is_file() or path.is_symlink():
+        continue
+    try:
+        data = path.read_bytes()
+    except OSError:
+        continue
+    if b"\0" in data:
+        continue
+    updated = data
+    for old, new in replacements:
+        updated = updated.replace(old, new)
+    if updated != data:
+        path.write_bytes(updated)
+PY
+
+profile="$(awk -F= '/^SPACE_BUILD_PROFILE:STRING=/{print $2}' "$dst_build/CMakeCache.txt" || true)"
+cef="$(awk -F= '/^SPACE_ENABLE_CEF:BOOL=/{print $2}' "$dst_build/CMakeCache.txt" || true)"
+cmake_args=(-S "$worktree" -B "$dst_build" -DCMAKE_BUILD_TYPE=Release)
+[ -n "$profile" ] && cmake_args+=("-DSPACE_BUILD_PROFILE=$profile")
+[ -n "$cef" ] && cmake_args+=("-DSPACE_ENABLE_CEF=$cef")
+cmake "${cmake_args[@]}"
+
+src_head="$(git -C "$main_checkout" rev-parse HEAD)"
+if git -C "$worktree" cat-file -e "$src_head^{commit}" 2>/dev/null; then
+  git -C "$worktree" diff --name-only -z "$src_head"...HEAD -- \
+    | xargs -0 -r -I{} touch "$worktree/{}"
+fi
+
+cmake --build "$dst_build" --target space -- -j"${BUILD_JOBS:-1}"
+```
+
 ## Remote-VM Orca alternative
 
 When running Orca entirely on the remote VM fits your environment better, install Orca on that host and launch your agent sessions there. Use your local Orca session only as a viewer or connector — some collaborators keep a local Orca window open that connects to the remote instance.

--- a/docs/dev/features/opencode-agent-workflow.md
+++ b/docs/dev/features/opencode-agent-workflow.md
@@ -24,7 +24,7 @@ The local Orca plus remote SSH checklist below is one possible path; it is not a
 If you choose the local-Orca-plus-remote-SSH setup, work through these points:
 
 1. **Remote VM reachable.** Confirm you can SSH into the remote VM from your local machine.
-2. **Build and dev tools.** Install common tooling on the remote VM: `git`, `nodejs` and `npm`, `python3`, `make`, `g++`, `curl`, and `clangd`. These are typically available through the system package manager.
+2. **Build and dev tools.** Install common tooling on the remote VM: `git`, `nodejs` and `npm`, `python3`, `make`, `g++`, `curl`, `clangd`, and `rsync`. These are typically available through the system package manager.
 3. **OpenCode on the remote VM.** Install OpenCode and make sure it is on `PATH` for non-interactive SSH sessions so that Orca can invoke it automatically.
 4. **GitHub SSH access.** Configure SSH key access for GitHub on the remote VM so the agent can push branches and create pull requests. Test with `ssh -T git@github.com`.
 5. **Clone Space on the remote VM.** Clone the repository into a working directory the SSH user can write to.
@@ -63,10 +63,9 @@ checkout's cache.
 - Re-runs `cmake` after rewriting the cache so CMake refreshes generated
   files for the new worktree.
 - Copies build files with fresh mtimes (`rsync --no-times`) so copied
-  artifacts appear newer than checkout files. On a divergent branch this
-  can hide needed rebuilds, which is why the clean-worktree caveat matters.
-  As a safety measure, the script compares source/destination HEAD and
-  touches tracked files that differ.
+  artifacts appear newer than checkout files. This is safe because the
+  script requires identical HEADs; if HEADs differ, it refuses to run
+  rather than hiding rebuilds.
 
 Paste the script below into Orca's per-project or per-worktree setup step.
 Adjust the `SPACE_MAIN_CHECKOUT` and `ORCA_WORKTREE` environment variables
@@ -96,6 +95,15 @@ fi
 
 if [ -n "$(git -C "$worktree" status --porcelain)" ]; then
   echo "Worktree is not clean; run this only before agent edits begin." >&2
+  exit 1
+fi
+
+src_head="$(git -C "$main_checkout" rev-parse HEAD)"
+dst_head="$(git -C "$worktree" rev-parse HEAD)"
+if [ "$src_head" != "$dst_head" ]; then
+  echo "Worktree HEAD ($dst_head) differs from main-checkout HEAD ($src_head)." >&2
+  echo "The warm-start script is only safe when the new worktree starts from the same commit as the main checkout." >&2
+  echo "For a divergent branch, run make build or warm from a checkout at the same commit." >&2
   exit 1
 fi
 
@@ -140,12 +148,6 @@ cmake_args=(-S "$worktree" -B "$dst_build" -DCMAKE_BUILD_TYPE=Release)
 [ -n "$profile" ] && cmake_args+=("-DSPACE_BUILD_PROFILE=$profile")
 [ -n "$cef" ] && cmake_args+=("-DSPACE_ENABLE_CEF=$cef")
 cmake "${cmake_args[@]}"
-
-src_head="$(git -C "$main_checkout" rev-parse HEAD)"
-if git -C "$worktree" cat-file -e "$src_head^{commit}" 2>/dev/null; then
-  git -C "$worktree" diff --name-only -z "$src_head"...HEAD -- \
-    | xargs -0 -r -I{} touch "$worktree/{}"
-fi
 
 cmake --build "$dst_build" --target space -- -j"${BUILD_JOBS:-1}"
 ```


### PR DESCRIPTION
## Summary
- Document an optional Orca/new-worktree warm-start script that copies the main checkout build cache and repaths CMake-generated absolute paths.
- Add safety caveats for fresh clean worktrees, identical HEADs, same toolchain, and normal validation requirements.
- Cross-link the guidance from the build documentation.

## Validation
- rg -n 'Optional: warm new worktrees|SPACE_MAIN_CHECKOUT|ORCA_WORKTREE|CMakeCache.txt|rsync -a --delete --no-times|src_head|dst_head|HEADs differ|make build|rsync' docs/dev/features/opencode-agent-workflow.md docs/dev/building.md
- git diff --check HEAD~2..HEAD
- cd docs && npm run docs:build

## Notes
- VitePress emitted existing fnl syntax-highlight fallback warnings and chunk-size warnings; build completed successfully.