### PR TITLE
Fix graph sidebar intrinsic width

### DIFF
--- a/assets/lua/graph/map-sidebar.fnl
+++ b/assets/lua/graph/map-sidebar.fnl
@@ -30,6 +30,12 @@
 (local map-label-max-length 27)
 (local finder-label-max-length 26)
 
+(fn current-sidebar-width [state]
+    (if state.resolved-sidebar-width state.resolved-sidebar-width sidebar-width))
+
+(fn finder-content-width-provider [state]
+    (fn [] (- (current-sidebar-width state) 0.5)))
+
 (fn record-label [state label]
     (table.insert state.visible-labels label)
     label)
@@ -331,13 +337,15 @@
                   :builder (node-row-builder state)})
      ic))
 
-(fn fixed-width-child [name width child-builder]
+(fn fixed-width-child [name width-provider child-builder]
     (fn [ic]
         (local child (child-builder ic))
         (fn measurer [self]
+            (local width (width-provider))
             (child.layout:measurer)
             (set self.measure (glm.vec3 width child.layout.measure.y child.layout.measure.z)))
         (fn layouter [self]
+            (local width (width-provider))
             (set child.layout.position self.position)
             (set child.layout.size (glm.vec3 width self.size.y self.size.z))
             (set child.layout.rotation self.rotation)
@@ -356,9 +364,9 @@
 (fn build-finder [state]
     (fn [ic]
         ((Padding {:edge-insets [0.15 0.25 0.25 0.25]
-                   :child (fixed-width-child "graph-map-sidebar-finder-width"
-                                             (- sidebar-width 0.5)
-                                             (search-view-builder state))})
+                    :child (fixed-width-child "graph-map-sidebar-finder-width"
+                                              (finder-content-width-provider state)
+                                              (search-view-builder state))})
          ic)))
 
 (set search-view-builder
@@ -430,16 +438,23 @@
 (fn sidebar-measurer [state self]
     (if state.content-entity
         (do
+            (set state.resolved-sidebar-width sidebar-width)
             (state.content-entity.layout:measurer)
-            (set self.measure (glm.vec3 sidebar-width
+            (set state.resolved-sidebar-width
+                 (math.max sidebar-width state.content-entity.layout.measure.x))
+            (state.content-entity.layout:measurer)
+            (set self.measure (glm.vec3 (current-sidebar-width state)
                                         state.content-entity.layout.measure.y
                                         state.content-entity.layout.measure.z)))
-        (set self.measure (glm.vec3 sidebar-width 0 0))))
+        (do
+            (set state.resolved-sidebar-width sidebar-width)
+            (set self.measure (glm.vec3 sidebar-width 0 0)))))
 
 (fn sidebar-layouter [state self]
     (local self-size (if self.size self.size (glm.vec3 0 0 0)))
+    (local resolved-width (current-sidebar-width state))
     (local allocated-size
-        (glm.vec3 sidebar-width
+        (glm.vec3 resolved-width
                   (math.max self.measure.y self-size.y)
                   (math.max self.measure.z self-size.z)))
     (set self.size allocated-size)
@@ -510,6 +525,7 @@
                   :node-open-handler options.node-open-handler
                   :theme (and ctx ctx.theme)
                   :content-entity nil
+                  :resolved-sidebar-width sidebar-width
                   :rebuild-requested? false
                   :maps-changed-handler nil
                   :active-map nil

--- a/assets/lua/tests/test-graph-map-sidebar.fnl
+++ b/assets/lua/tests/test-graph-map-sidebar.fnl
@@ -139,6 +139,14 @@
     (local flex-layout (. stack-layout.children 2))
     (. flex-layout.children (length flex-layout.children)))
 
+(fn content-flex-layout [entity]
+    (local stack-layout (. entity.layout.children 1))
+    (. stack-layout.children 2))
+
+(fn actions-layout [entity]
+    (local flex-layout (content-flex-layout entity))
+    (. flex-layout.children 2))
+
 (local long-sidebar-node-label
        "A graph node label that is deliberately long enough to exceed the sidebar width by many characters")
 
@@ -430,7 +438,29 @@
     (manager:drop)
     (graph:drop))
 
-(fn sidebar-width-stays-fixed-with-long-labels []
+(fn sidebar-width-includes-static-action-controls []
+    (local graph (Graph {:with-start false}))
+    (local manager (GraphMapManager.GraphMapManager {:graph graph}))
+    (local ctx (BuildContext {:clickables (assert app.clickables "test requires app.clickables")
+                              :hoverables (make-hoverables-stub)}))
+    (local entity ((GraphMapSidebar.GraphMapSidebar {:manager manager}) ctx))
+    (entity:update)
+    (entity.layout:measurer)
+    (local action-row (actions-layout entity))
+    (assert (>= entity.layout.measure.x action-row.measure.x)
+            (.. "Sidebar measure width " (tostring entity.layout.measure.x)
+                " should include static action-row intrinsic width "
+                (tostring action-row.measure.x)))
+    (layout-sidebar! entity entity.layout.measure.x 24.0)
+    (assert (>= entity.layout.size.x action-row.size.x)
+            (.. "Sidebar layout width " (tostring entity.layout.size.x)
+                " should include static action-row layout width "
+                (tostring action-row.size.x)))
+    (entity:drop)
+    (manager:drop)
+    (graph:drop))
+
+(fn sidebar-width-stays-bounded-with-long-labels []
     (local graph (Graph {:with-start false}))
     (graph:register-key-loader "test" long-sidebar-node-loader)
     (local manager (GraphMapManager.GraphMapManager {:graph graph}))
@@ -442,11 +472,19 @@
     (local entity ((GraphMapSidebar.GraphMapSidebar {:manager manager}) ctx))
     (entity:update)
     (entity.layout:measurer)
-    (assert (approx entity.layout.measure.x 14.0)
-            (.. "Sidebar measure should be fixed at 14.0, got " (tostring entity.layout.measure.x)))
-    (layout-sidebar! entity 14.0 24.0)
-    (assert (approx entity.layout.size.x 14.0)
-            "Sidebar layout width should stay fixed at 14.0")
+    (local action-row (actions-layout entity))
+    (assert (>= entity.layout.measure.x 14.0)
+            (.. "Sidebar measure should stay at/above preferred width, got " (tostring entity.layout.measure.x)))
+    (assert (>= entity.layout.measure.x action-row.measure.x)
+            "Sidebar measure should still include static action controls")
+    (assert (< entity.layout.measure.x 30.0)
+            (.. "Sidebar measure should remain bounded below raw long-label expansion, got "
+                (tostring entity.layout.measure.x)))
+    (layout-sidebar! entity entity.layout.measure.x 24.0)
+    (assert (>= entity.layout.size.x 14.0)
+            "Sidebar layout width should stay at/above preferred width")
+    (assert (< entity.layout.size.x 30.0)
+            "Sidebar layout width should remain bounded below raw long-label expansion")
     (entity:drop)
     (manager:drop)
     (graph:drop))
@@ -481,17 +519,19 @@
     (manager:drop)
     (graph:drop))
 
-(fn sidebar-empty-finder-fills-fixed-content-width []
+(fn sidebar-empty-finder-fills-resolved-content-width []
     (local graph (Graph {:with-start false}))
     (local manager (GraphMapManager.GraphMapManager {:graph graph}))
     (local ctx (BuildContext {:clickables (assert app.clickables "test requires app.clickables")
                               :hoverables (make-hoverables-stub)}))
     (local entity ((GraphMapSidebar.GraphMapSidebar {:manager manager}) ctx))
     (entity:update)
-    (layout-sidebar! entity 14.0 24.0)
+    (entity.layout:measurer)
+    (layout-sidebar! entity entity.layout.measure.x 24.0)
     (local layout (finder-layout entity))
-    (assert (> layout.size.x 13.0)
-            (.. "Finder area should fill fixed sidebar content width, got " (tostring layout.size.x)))
+    (assert (approx layout.size.x entity.layout.size.x)
+            (.. "Finder area should fill resolved sidebar content width "
+                (tostring entity.layout.size.x) ", got " (tostring layout.size.x)))
     (entity:drop)
     (manager:drop)
     (graph:drop))
@@ -519,12 +559,14 @@
                       :fn sidebar-node-finder-clicks-route_callbacks})
 (table.insert tests {:name "GraphMap sidebar New uses integer map id after restored float"
                      :fn sidebar-new-button-uses-integer-map-id-after-restored-float})
-(table.insert tests {:name "GraphMap sidebar width stays fixed with long labels"
-                     :fn sidebar-width-stays-fixed-with-long-labels})
+(table.insert tests {:name "GraphMap sidebar width includes static action controls"
+                     :fn sidebar-width-includes-static-action-controls})
+(table.insert tests {:name "GraphMap sidebar width stays bounded with long labels"
+                     :fn sidebar-width-stays-bounded-with-long-labels})
 (table.insert tests {:name "GraphMap sidebar truncates display labels and preserves finder data"
                      :fn sidebar-truncates-display-labels-and-preserves-finder-data})
-(table.insert tests {:name "GraphMap sidebar empty finder fills fixed content width"
-                     :fn sidebar-empty-finder-fills-fixed-content-width})
+(table.insert tests {:name "GraphMap sidebar empty finder fills resolved content width"
+                     :fn sidebar-empty-finder-fills-resolved-content-width})
 
 (local main
     (fn []


### PR DESCRIPTION
## Summary
- Make the graph map sidebar resolve to at least its static control intrinsic width instead of hard-clamping to 14.0.
- Keep dynamic map/finder labels locally ellipsized so long labels remain bounded.
- Update sidebar layout tests for intrinsic controls, bounded long labels, and resolved finder width.

## Validation
- make fennel-check
- make constraints
- FENNEL_PATH="/home/ubuntu/orca/workspaces/space/wolfeel/assets/lua/?.fnl;/home/ubuntu/orca/workspaces/space/wolfeel/assets/lua/?/init.fnl" FENNEL_MACRO_PATH="/home/ubuntu/orca/workspaces/space/wolfeel/assets/lua/?.fnl;/home/ubuntu/orca/workspaces/space/wolfeel/assets/lua/?/init.fnl" SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="/home/ubuntu/orca/workspaces/space/wolfeel/assets" ./build/space -m tests.test-graph-map-sidebar:main
- SKIP_KEYRING_TESTS=1 XDG_DATA_HOME=/tmp/space/tests/xdg-data SPACE_DISABLE_AUDIO=1 SPACE_ASSETS_PATH="/home/ubuntu/orca/workspaces/space/wolfeel/assets" make test